### PR TITLE
chore: deferred minors cleanup

### DIFF
--- a/docs/superpowers/plans/2026-06-24-apple-dev-skills-restructure.md
+++ b/docs/superpowers/plans/2026-06-24-apple-dev-skills-restructure.md
@@ -242,8 +242,8 @@ git commit -m "refactor: split into apple-dev-skills (20) + collaboration-skills
 Checks
   1. Each <plugin>/skills/<dir>/ has a SKILL.md whose frontmatter name == <dir>.
   2. README.md Catalog lists exactly the union of both plugins' skills (30) AND the
-     three aggregated external plugin names (set-equality, both directions).
-  3. Counts match: README group headers (20)/(10)/(3) and each plugin.json's "N first-party".
+     five aggregated external plugin names (set-equality, both directions).
+  3. Counts match: README group headers (20)/(10)/(5) and each plugin.json's "N first-party".
   4. README.zh-Hant.md exists and its embedded src-sha == git hash-object README.md.
   5. All plugin/marketplace JSON parse; the two subdir plugin sources resolve to dirs.
 Stdlib only.
@@ -369,7 +369,7 @@ git commit -m "test: consistency gate for two-plugin layout (catalog + counts + 
 - Delete: `ROADMAP.md`, `CURATION.md`
 
 **Interfaces:**
-- Produces: a `## Catalog` section listing all 30 skills (grouped `(20)`/`(10)`) + 3 externals `(3)`, satisfying the gate's check 2/3.
+- Produces: a `## Catalog` section listing all 30 skills (grouped `(20)`/`(10)`) + 5 externals `(5)`, satisfying the gate's check 2/3.
 
 - [ ] **Step 1: Write `README.md`**
 

--- a/scripts/gen-readme-zh.sh
+++ b/scripts/gen-readme-zh.sh
@@ -13,7 +13,7 @@ Output ONLY the translated markdown, nothing else." < README.md > README.zh-Hant
   git add README.zh-Hant.md
   echo "regenerated README.zh-Hant.md (src-sha $SHA)"
 else
-  EMB="$(grep -oE 'src-sha: [0-9a-f]+' README.zh-Hant.md 2>/dev/null | awk '{print $2}' || true)"
+  EMB="$(grep -oE '<!-- src-sha: [0-9a-f]+ -->' README.zh-Hant.md 2>/dev/null | grep -oE '[0-9a-f]{7,}' || true)"
   if [ "$EMB" != "$SHA" ]; then
     echo "README.zh-Hant.md is stale; run 'mise run readme-zh' where 'claude' is on PATH" >&2
     exit 1


### PR DESCRIPTION
Closes out the deferred Minor findings from the final review:
- `scripts/gen-readme-zh.sh`: anchor the freshness `grep` to the `<!-- src-sha: ... -->` comment (avoids matching a stray sha in prose).
- plan doc: fix stale `(3)` → `(5)` externals references.

Skipped (with reason): the lefthook `stage_fixed` suggestion — its `glob` is `README.md`, so it would not re-stage `README.zh-Hant.md`; the generator already `git add`s it explicitly.

Tooling/doc only — no skill content, no version bump. Gate green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)