### PR TITLE
docs(subagent-conflict-detection): worktree base-correctness + cross-session coexistence

### DIFF
--- a/collaboration-skills/skills/subagent-conflict-detection/SKILL.md
+++ b/collaboration-skills/skills/subagent-conflict-detection/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: subagent-conflict-detection
-description: Use before dispatching a new subagent (especially with isolation:"worktree") to avoid worktree-dispatch hazards — file-scope overlap with an in-flight subagent, a stale dispatch base (the worktree branches from current HEAD, so a dispatch right after a merge can hand the agent a pre-merge base), and collisions with ANOTHER live agent/session editing the same checkout or git-submodule path. Invoke when about to call Agent tool with isolation:"worktree", when another subagent is running, right after merging/switching branches, or when a shared repo/submodule path is also being edited by another Claude session.
+description: Use before dispatching a subagent (especially `isolation:"worktree"`) to avoid three dispatch hazards — file-scope overlap with an in-flight subagent, a stale dispatch base, and collisions with another live agent/session editing the same checkout or git-submodule path. Invoke when about to call the Agent tool with `isolation:"worktree"`; when another subagent is running; right after a merge or branch switch (verify the dispatch base first); or when another Claude session is editing a shared repo/submodule path.
 ---
 
 # Subagent Conflict Detection
@@ -57,7 +57,7 @@ git log --oneline -3                     # does it include the commit/PR this wo
 git merge-base --is-ancestor <dep-sha> HEAD && echo "base OK" || echo "STALE BASE"
 ```
 
-If the work depends on a just-merged PR, sync first (`git checkout main && git fetch && git reset --hard origin/main`) THEN dispatch. State the expected base SHA in the dispatch prompt and tell the agent to verify it (`git log --oneline -5`; confirm a key file/symbol exists) before coding.
+If the work depends on a just-merged PR, sync first (`git checkout main && git fetch && git reset --hard origin/main` — `reset --hard` discards uncommitted local changes, so stash them first) THEN dispatch. `<dep-sha>` above is the commit your work depends on (e.g. the merged PR's commit on `main`). State the expected base SHA in the dispatch prompt and tell the agent to verify it (`git log --oneline -5`; confirm a key file/symbol exists) before coding.
 
 > Real incident: a DEBUG test-hook subagent was dispatched right after a fix merged to `main`, but the dispatching HEAD was a pre-merge commit. The worktree branched from the stale base, so the new code referenced an `init` parameter and a file that only existed post-merge → 2 compile errors that the agent's own package build hadn't surfaced. Cost a full cherry-pick-onto-correct-base + rebuild cycle.
 

--- a/collaboration-skills/skills/subagent-conflict-detection/SKILL.md
+++ b/collaboration-skills/skills/subagent-conflict-detection/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: subagent-conflict-detection
-description: Use before dispatching a new subagent to check that its target file set does not overlap with any in-flight subagent's working tree. Prevents the parallel-dispatch race where two subagents edit the same file via different worktrees and one's commit gets force-pushed over the other. Invoke when about to call Agent tool with isolation:"worktree" if any other subagent is currently running.
+description: Use before dispatching a new subagent (especially with isolation:"worktree") to avoid worktree-dispatch hazards — file-scope overlap with an in-flight subagent, a stale dispatch base (the worktree branches from current HEAD, so a dispatch right after a merge can hand the agent a pre-merge base), and collisions with ANOTHER live agent/session editing the same checkout or git-submodule path. Invoke when about to call Agent tool with isolation:"worktree", when another subagent is running, right after merging/switching branches, or when a shared repo/submodule path is also being edited by another Claude session.
 ---
 
 # Subagent Conflict Detection
@@ -42,6 +42,38 @@ For each in-flight subagent's dirty-file set vs the new dispatch's likely scope:
 - **Direct overlap** (same file path): BLOCK dispatch, surface to user. Options: serialize (wait for in-flight to merge) OR carve scopes (rewrite new dispatch's prompt to exclude overlapping files).
 - **Module overlap** (same target directory but different files): WARN but allow with `isolation: "worktree"`. Note in dispatch prompt: "in-flight subagent X is editing target Y; do not touch files Z."
 - **No overlap**: dispatch safely.
+
+## Pre-dispatch base correctness (verify HEAD before you dispatch)
+
+`isolation: "worktree"` branches the subagent's worktree from the **current HEAD of the dispatching checkout at dispatch time**. So WHAT HEAD points at is part of the dispatch contract — get it wrong and the agent silently works against the wrong base.
+
+The classic failure: you merge PR A to `main`, then immediately dispatch a subagent for follow-up work that depends on A. If HEAD is not actually on the post-merge `main` (e.g. a background build left it detached, you forgot to `git checkout main && git reset --hard origin/main`, or the branch you're on predates A), the worktree branches from a **pre-A base**. The agent then can't see A's new symbols/files — it fails to compile against APIs that "should exist", or worse, re-implements against the old shape. Code review may not catch it (the agent's local build can pass on the stale base); it surfaces only when you try to build the integrated result.
+
+**Before dispatching, confirm the base:**
+
+```bash
+git rev-parse --abbrev-ref HEAD          # on the branch you think you are?
+git log --oneline -3                     # does it include the commit/PR this work depends on?
+git merge-base --is-ancestor <dep-sha> HEAD && echo "base OK" || echo "STALE BASE"
+```
+
+If the work depends on a just-merged PR, sync first (`git checkout main && git fetch && git reset --hard origin/main`) THEN dispatch. State the expected base SHA in the dispatch prompt and tell the agent to verify it (`git log --oneline -5`; confirm a key file/symbol exists) before coding.
+
+> Real incident: a DEBUG test-hook subagent was dispatched right after a fix merged to `main`, but the dispatching HEAD was a pre-merge commit. The worktree branched from the stale base, so the new code referenced an `init` parameter and a file that only existed post-merge → 2 compile errors that the agent's own package build hadn't surfaced. Cost a full cherry-pick-onto-correct-base + rebuild cycle.
+
+## Coexisting with another live agent / session on the same repo
+
+When ANOTHER Claude session (or human) is actively editing the same working checkout — or a **git submodule** vendored into your repo (e.g. a shared `.claude/skills/<plugin>` submodule) — do NOT edit that shared checkout in place. Two writers on one working tree clobber each other's uncommitted edits, fight over branch HEAD, and produce confusing diffs.
+
+Instead, collaborate through isolation + PR:
+
+1. Add your own worktree of THAT repo, branched from its `origin/main` (not the shared checkout's possibly-dirty local state):
+   `git -C <shared-repo-or-submodule-path> fetch origin && git -C <…> worktree add /tmp/<name> -b <branch> origin/main`
+2. Make your edits in the isolated worktree.
+3. Commit, push the branch, open a PR on that repo. Let the normal review/merge flow integrate it.
+4. For a submodule: after the upstream PR merges (and is tagged, if the consumer pins tags), bump the submodule pointer in the consuming repo via a SEPARATE PR — never hand-edit the submodule's checked-out files from the parent repo.
+
+This is the cross-session mirror of the within-session conflict check: same goal (no two writers on one tree), different scope (independent sessions / submodules rather than your own in-flight subagents). When unsure whether another agent is on a path, treat it as occupied and use the worktree+PR path — it's cheap insurance.
 
 ## Output format
 


### PR DESCRIPTION
## What
Adds two worktree-dispatch hazards to `subagent-conflict-detection` (beyond the existing file-scope overlap check):

1. **Pre-dispatch base correctness** — `isolation:"worktree"` branches from the dispatching checkout's current HEAD. Dispatching right after a merge, without syncing HEAD to post-merge `main`, hands the subagent a **pre-merge base**: it references symbols/files that only exist post-merge and fails to compile, often invisibly to the agent's own package build. Adds a HEAD/base verification step + the real incident that motivated it.
2. **Coexisting with another live agent/session** — when another Claude session (or a vendored git submodule) is editing the same shared checkout, collaborate via an isolated worktree branched from `origin/main` + PR instead of editing the shared checkout in place; bump submodule pointers in a separate consumer PR.

Frontmatter `description` extended so the skill also triggers right after merges/branch switches and when a shared repo/submodule path is co-edited.

## Why
Both bit a real multi-agent session: a DEBUG test-hook subagent branched from a stale pre-merge base (2 compile errors, cherry-pick-to-fix), and a shared skills submodule was being edited by two sessions at once. Captured as durable skill guidance rather than ephemeral session memory.

## Scope
Single file, content-only (`collaboration-skills/skills/subagent-conflict-detection/SKILL.md`). No new/removed skills, no version/manifest change — defer any version bump to maintainer preference.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
