### PR TITLE
feat(skills): add skill-authoring-patterns → v1.2.0

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -3,7 +3,7 @@
   "owner": { "name": "Wei18" },
   "metadata": {
     "description": "A curated catalog of skills for AI coding agents — first-party Apple/Swift and agent-collaboration skills, plus aggregated best-of-breed external plugins (credited to their authors)",
-    "version": "1.1.0"
+    "version": "1.2.0"
   },
   "plugins": [
     {
@@ -18,8 +18,8 @@
     {
       "name": "collaboration-skills",
       "source": "./collaboration-skills",
-      "description": "10 first-party AI-agent collaboration & process skills. Namespaced collaboration-skills:<skill>.",
-      "version": "1.1.0",
+      "description": "11 first-party AI-agent collaboration & process skills. Namespaced collaboration-skills:<skill>.",
+      "version": "1.2.0",
       "author": { "name": "Wei18" },
       "keywords": ["claude-code", "agent-skills", "ai-agents", "workflow", "collaboration"],
       "category": "workflow"

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ plugins load from the pinned submodule (collaborators are prompted to trust the 
 
 ```bash
 git submodule add https://github.com/wei18/apple-dev-skills.git .claude/skills/apple-dev-skills
-cd .claude/skills/apple-dev-skills && git checkout v1.0.0 && cd -
+cd .claude/skills/apple-dev-skills && git checkout v1.2.0 && cd -
 ```
 
 `.claude/settings.json` (committed):
@@ -84,7 +84,7 @@ npx skills add wei18/apple-dev-skills --skill swift6-concurrency
 | `app-icon-rasterize` | Rasterize a 1024 SVG icon to asset-catalog PNG via `qlmanage` — no Homebrew |
 | `ios-design-mockup` | Single-file HTML iOS design mockup from a spec — iPhone frames + tokens |
 
-### collaboration-skills (10) — AI-agent process
+### collaboration-skills (11) — AI-agent process
 
 | Skill | One-liner |
 |---|---|
@@ -98,6 +98,7 @@ npx skills add wei18/apple-dev-skills --skill swift6-concurrency
 | `pr-diff-verification` | Before push/PR, verify `git show --stat HEAD` matches the commit's claims |
 | `backlog-routing-by-topic` | Route stray ideas by topic to the matching spec file's §Backlog |
 | `claude-skill-plugin-packaging` | Distribute/install Claude Code skills — depth-1 rule, plugin + marketplace, aggregation |
+| `skill-authoring-patterns` | Apple/Swift catalog layer over `superpowers:writing-skills` — router descriptions, bookend sections, two-tier references, evidence-based CR |
 
 ### Aggregated external (5) — by reference, credited
 

--- a/README.zh-Hant.md
+++ b/README.zh-Hant.md
@@ -1,20 +1,20 @@
 # apple-dev-skills
 
-> 一份**為 AI 編碼代理打造的精選技能目錄**（[Claude Code](https://code.claude.com)）——
-> 由一位開發者親身的實戰出貨經驗建構與蒐集而成。涵蓋第一方的 **Apple/Swift**
-> 與 **AI 代理協作**技能，再加上以**引用方式**聚合的同類最佳**外部**技能 plugin
+> 一份**為 AI 編程代理（[Claude Code](https://code.claude.com)）整理的技能目錄** —
+> 由一位開發者根據自身的實際出貨經驗打造與蒐集。第一方的 **Apple/Swift**
+> 與 **AI 代理協作**技能，外加以**引用方式**彙整的同類最佳**外部**技能外掛
 > （完整標註原作者，絕不複製）。
 >
-> English：[`README.md`](README.md)
+> 繁體中文：[`README.zh-Hant.md`](README.zh-Hant.md)
 
-本 repo 是單一 **marketplace**，託管兩個第一方 plugin 與數個聚合的外部 plugin。
+本倉庫是一個**市集（marketplace）**，托管兩個第一方外掛與數個彙整的外部外掛。
 
 ## 安裝
 
-> Claude Code 透過 **plugin** 系統來發現共享技能。本 repo 既是一個
-> marketplace，也是兩個第一方 plugin 的所在地。
+> Claude Code 透過**外掛**系統來發現共享技能。本倉庫既是市集，
+> 也是兩個第一方外掛的所在地。
 
-### A — marketplace（最簡單）
+### A — 市集（最簡單）
 
 ```
 /plugin marketplace add wei18/apple-dev-skills
@@ -22,19 +22,19 @@
 /plugin install collaboration-skills@apple-dev-skills      # 10 agent-collaboration skills
 ```
 
-任選其一或兩者皆裝。外部 plugin 的安裝方式相同，例如 `/plugin install swiftui-expert@apple-dev-skills`。
+任選其一或兩者皆裝。外部外掛的安裝方式相同，例如 `/plugin install swiftui-expert@apple-dev-skills`。
 
-### B — repo 層級（vendored submodule，釘選版本）
+### B — 倉庫層級（vendored submodule，已釘選版本）
 
-將其 vendor 並釘選進單一 repo，接著註冊一個 project-scope 的本機路徑 marketplace，
-讓 plugin 從釘選的 submodule 載入（協作者會被提示信任此 workspace）：
+將其 vendor 並釘選到單一倉庫中，接著註冊一個專案範圍的本機路徑市集，使
+外掛從釘選的 submodule 載入（協作者會被提示信任此工作區）：
 
 ```bash
 git submodule add https://github.com/wei18/apple-dev-skills.git .claude/skills/apple-dev-skills
-cd .claude/skills/apple-dev-skills && git checkout v1.0.0 && cd -
+cd .claude/skills/apple-dev-skills && git checkout v1.2.0 && cd -
 ```
 
-`.claude/settings.json`（已提交版控）：
+`.claude/settings.json`（已提交）：
 
 ```json
 {
@@ -48,9 +48,9 @@ cd .claude/skills/apple-dev-skills && git checkout v1.0.0 && cd -
 }
 ```
 
-單純一個 submodule **不會**被發現——真正載入技能的是 marketplace 註冊。
+光有裸 submodule **無法**被發現 — 是市集註冊在載入這些技能。
 
-### C — `npx skills`（扁平，無 plugin）
+### C — `npx skills`（扁平、無外掛）
 
 ```bash
 npx skills add wei18/apple-dev-skills --list
@@ -63,61 +63,62 @@ npx skills add wei18/apple-dev-skills --skill swift6-concurrency
 
 | Skill | 一句話說明 |
 |---|---|
-| `swift6-concurrency` | Swift 6 語言模式 + 完整並行檢查；Sendable 為預設 |
-| `apple-platform-targets` | 預設 iOS 18 / macOS 15、Xcode 16+；僅在需要最新 OS 專屬 API 時才升到 26 |
-| `swiftpm-modularization` | 單一 Package、多 target、薄 App、DI composition root、測試一對一 |
-| `swift-testing-baseline` | swift-testing + pointfreeco snapshot；protocol fake；嚴格/寬容的 snapshot gate |
-| `xcode-cloud-single-track-ci` | 單軌 Xcode Cloud；PR / Main / Release / Periodic；merge 前的 PR CI |
-| `mise-tool-management` | mise 管理二進位 CLI 工具；dev 與 CI 共用 `.mise.toml`；macOS-only 的 `os` 守門 |
-| `oslog-logger-defaults` | `os.Logger`（不用第三方）；subsystem = bundle ID；`.private` 為預設 |
-| `apple-three-piece-analytics` | ASC Analytics + MetricKit + Game Center；不用第三方追蹤；PrivacyInfo 為必備 |
-| `telemetry-facade-pattern` | 單一 `Telemetry` target、fan-out facade；OSLog / NoOp / MetricKit / GameCenter sink |
-| `ai-translated-localization` | 預設 7 個語系；AI 翻譯流程；`Localizable.xcstrings`；完整性 gate |
-| `ios-accessibility-engineering` | SwiftUI 與 UIKit 的 VoiceOver / Dynamic Type / 觸控目標 / Reduce Motion；WCAG 2.2 |
-| `swift-dependency-injection` | Protocol 注入 + composition root；environment vs constructor；`@TaskLocal`；Sendable |
+| `swift6-concurrency` | Swift 6 語言模式 + 完整並行檢查；預設 Sendable |
+| `apple-platform-targets` | 預設 iOS 18 / macOS 15、Xcode 16+；僅在使用最新版 OS 專屬 API 時才升至 26 |
+| `swiftpm-modularization` | 單一 Package、多 target、薄 App、DI 組裝根（composition root）、測試一對一 |
+| `swift-testing-baseline` | swift-testing + pointfreeco 快照；協定 fake；嚴格／寬鬆快照閘門 |
+| `xcode-cloud-single-track-ci` | 單軌 Xcode Cloud；PR / Main / Release / Periodic；合併前 PR CI |
+| `mise-tool-management` | mise 管理二進位 CLI 工具；開發與 CI 共用 `.mise.toml`；macOS-only `os` 守衛 |
+| `oslog-logger-defaults` | `os.Logger`（不用第三方）；subsystem = bundle ID；預設 `.private` |
+| `apple-three-piece-analytics` | ASC Analytics + MetricKit + Game Center；不用第三方追蹤；PrivacyInfo 為必要項 |
+| `telemetry-facade-pattern` | 單一 `Telemetry` target、扇出 facade；OSLog / NoOp / MetricKit / GameCenter sink |
+| `ai-translated-localization` | 預設 7 種語系；AI 翻譯流程；`Localizable.xcstrings`；完整度閘門 |
+| `ios-accessibility-engineering` | 為 SwiftUI 與 UIKit 提供 VoiceOver / Dynamic Type / 觸控目標 / Reduce Motion；WCAG 2.2 |
+| `swift-dependency-injection` | 協定注入 + 組裝根；environment 對比建構子；`@TaskLocal`；Sendable |
 | `ios-performance-engineering` | Instruments / xctrace / hang-hitch 預算 / 啟動 / 記憶體 / 二進位大小 / MetricKit |
-| `apple-public-repo-security` | 公開 iOS/macOS repo 的三道防線 + 先輪替的洩漏 SOP |
-| `build-time-secret-injection` | xcconfig + Info.plist `$()` + `Bundle.main`，把 ID 出貨進二進位但留在 diff 之外 |
-| `monetization-sdk-integration` | 新增/升級/稽核變現 SDK；把 `import` 隔離在單一橋接檔 |
-| `app-store-review-rejections` | 針對 free + ads + IAP + CloudKit + GC 診斷並預先化解 App Review 退件類型 |
-| `swiftui-interaction-footguns` | 純程式碼審查會漏掉的已知 SwiftUI 互動 bug |
-| `app-icon-rasterize` | 透過 `qlmanage` 把 1024 的 SVG icon 點陣化成 asset catalog PNG——不用 Homebrew |
-| `ios-design-mockup` | 由規格產生單檔 HTML 的 iOS 設計 mockup——iPhone 框架 + tokens |
+| `apple-public-repo-security` | 公開 iOS/macOS 倉庫的三道防線 + 洩漏優先輪替 SOP |
+| `build-time-secret-injection` | xcconfig + Info.plist `$()` + `Bundle.main`，用於隨二進位出貨但不進 diff 的 ID |
+| `monetization-sdk-integration` | 新增／升級／稽核變現 SDK；將 `import` 隔離到單一橋接檔 |
+| `app-store-review-rejections` | 診斷並預先化解免費 + 廣告 + IAP + CloudKit + GC 的 App 審查駁回類型 |
+| `swiftui-interaction-footguns` | 會躲過純程式碼審查的已知 SwiftUI 互動 bug |
+| `app-icon-rasterize` | 透過 `qlmanage` 將 1024 SVG 圖示點陣化為 asset-catalog PNG — 不用 Homebrew |
+| `ios-design-mockup` | 從規格產生單檔 HTML iOS 設計樣稿 — iPhone 外框 + tokens |
 
-### collaboration-skills (10) — AI 代理流程
+### collaboration-skills (11) — AI 代理流程
 
 | Skill | 一句話說明 |
 |---|---|
-| `spec-phase-orchestration` | 實作前的文件流水線；逐節核准 |
-| `subagent-review-cycles` | Leader / Developer / Code-Reviewer 三人組；第一輪外觀問題就地處理；limit(N) |
-| `leader-developer-handoff-contract` | 派發 sub-agent 時的 5 個必備要素 |
-| `agent-impl-notes-log` | sub-agent 任務進行中的 impl-notes——決策、偏離、待解問題 |
-| `subagent-conflict-detection` | 檢查新 sub-agent 的目標不會與進行中的 worktree 重疊 |
+| `spec-phase-orchestration` | 實作前的文件流水線；逐節核可 |
+| `subagent-review-cycles` | Leader / Developer / Code-Reviewer 三方；第一輪外觀問題以 inline 處理；limit(N) |
+| `leader-developer-handoff-contract` | 派遣 sub-agent 時的 5 項必備要素 |
+| `agent-impl-notes-log` | sub-agent 任務進行中的即時 impl-notes — 決策、偏離、待解問題 |
+| `subagent-conflict-detection` | 檢查新 sub-agent 的目標不與進行中的 worktree 重疊 |
 | `methodology-pattern-extractor` | 從會議記錄中萃取重複出現 ≥3 次的模式 |
 | `session-to-meeting-log` | 將一次 Claude Code session 整理成會議記錄；摘要而非逐字 |
-| `pr-diff-verification` | push/PR 前，驗證 `git show --stat HEAD` 與 commit 宣稱相符 |
-| `backlog-routing-by-topic` | 依主題把零散想法路由到對應 spec 檔的 §Backlog |
-| `claude-skill-plugin-packaging` | 散布/安裝 Claude Code 技能——depth-1 規則、plugin + marketplace、聚合 |
+| `pr-diff-verification` | 在 push/PR 前，驗證 `git show --stat HEAD` 與該 commit 的宣稱相符 |
+| `backlog-routing-by-topic` | 依主題將零散想法路由到對應規格檔的 §Backlog |
+| `claude-skill-plugin-packaging` | 散布／安裝 Claude Code 技能 — depth-1 規則、外掛 + 市集、彙整 |
+| `skill-authoring-patterns` | 在 `superpowers:writing-skills` 之上的 Apple/Swift 目錄層 — 路由式描述、首尾呼應段落、兩層式 references、以證據為本的 CR |
 
-### 聚合的外部技能 (5) — 以引用方式，標註原作者
+### 彙整的外部外掛 (5) — 以引用方式，標註出處
 
-此處列出但**並非在此撰寫**；它們從原作者自己的 repo 安裝（你拿到的是
-他們的最新版），並完整標註。**聚合，而非佔用**：只列出與 MIT 相容、
-非重複的 plugin——第一方技能僅針對真正的缺口才撰寫。
+此處僅列出但**非於此處撰寫**；它們從各自作者的倉庫安裝（你取得的是
+其最新版本），並完整標註出處。**彙整，而非佔為己有**：僅列出 MIT 相容、
+非重複的外掛 — 第一方技能只為真正的缺口而寫。
 
 | Plugin | 作者 | 涵蓋範圍 |
 |---|---|---|
-| [`apple-skills`](https://github.com/vabole/apple-skills) | vabole (MIT) | 廣泛的 Apple 框架——SwiftUI、SwiftData、App Intents、WidgetKit、StoreKit、HealthKit … |
+| [`apple-skills`](https://github.com/vabole/apple-skills) | vabole (MIT) | 廣泛的 Apple 框架 — SwiftUI、SwiftData、App Intents、WidgetKit、StoreKit、HealthKit … |
 | [`swiftui-expert`](https://github.com/AvdLee/SwiftUI-Agent-Skill) | Antoine van der Lee (MIT) | SwiftUI 模式、Swift Charts、Liquid Glass、Instruments 工具鏈 |
-| [`swiftui-pro`](https://github.com/twostraws/SwiftUI-Agent-Skill) | Paul Hudson (MIT) | SwiftUI 陷阱、已棄用 API 觀察清單、iOS 26 / Liquid Glass |
-| [`caveman`](https://github.com/JuliusBrussee/caveman) | JuliusBrussee (MIT) | 超壓縮溝通模式——削減約 75% 的 token（通用 agent 行為） |
-| [`ponytail`](https://github.com/DietrichGebert/ponytail) | DietrichGebert (MIT) | 「懶散資深開發者」模式——強制採用最簡、最短的解法（通用 agent 行為） |
+| [`swiftui-pro`](https://github.com/twostraws/SwiftUI-Agent-Skill) | Paul Hudson (MIT) | SwiftUI 陷阱、棄用 API 觀察清單、iOS 26 / Liquid Glass |
+| [`caveman`](https://github.com/JuliusBrussee/caveman) | JuliusBrussee (MIT) | 超壓縮溝通模式 — 削減約 75% 的 token（通用代理行為） |
+| [`ponytail`](https://github.com/DietrichGebert/ponytail) | DietrichGebert (MIT) | 「懶散資深開發者」模式 — 強制採用最簡單、最短的解法（通用代理行為） |
 
-## 來源出處
+## 出處
 
 第一方技能是從 [`wei18/Sudoku`](https://github.com/wei18/Sudoku) 的
-`.claude/skills/` 提煉並通用化而來——一個 spec-first、由 AI-Leader/Developer 建構、
-出貨中的 Apple 平台遊戲作品集——再加上對公開的 Apple / WCAG / Swift 標準的原創撰寫。
-聚合的外部技能仍屬其作者的作品，僅以引用方式呈現。MIT——見 [LICENSE](LICENSE)。
+`.claude/skills/` 中提煉並通用化而來 — 那是一個規格優先、由 AI-Leader/Developer
+打造的出貨級 Apple 平台遊戲作品集 — 外加對公開 Apple / WCAG / Swift 標準的原創整理。
+彙整的外部外掛仍屬其作者的作品，僅以引用方式呈現。MIT — 見 [LICENSE](LICENSE)。
 
-<!-- src-sha: 010c540106cd90092baa4873f0bd0a14905dbc67 -->
+<!-- src-sha: 52a8e48e14caa462bce61b83e70c200d5cc9a1d5 -->

--- a/collaboration-skills/.claude-plugin/plugin.json
+++ b/collaboration-skills/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "collaboration-skills",
-  "version": "1.1.0",
-  "description": "10 first-party AI-agent collaboration & process skills — spec-phase orchestration, Leader/Developer handoff contract, subagent review cycles & conflict detection, impl-notes & meeting logs, methodology extraction, backlog routing, PR-diff verification, and Claude Code skill-plugin packaging. Tool-agnostic agent process, not Apple-specific.",
+  "version": "1.2.0",
+  "description": "11 first-party AI-agent collaboration & process skills — spec-phase orchestration, Leader/Developer handoff contract, subagent review cycles & conflict detection, impl-notes & meeting logs, methodology extraction, backlog routing, PR-diff verification, Claude Code skill-plugin packaging, and skill-authoring patterns. Tool-agnostic agent process, not Apple-specific.",
   "author": { "name": "Wei18" },
   "homepage": "https://github.com/wei18/apple-dev-skills",
   "license": "MIT"

--- a/collaboration-skills/skills/skill-authoring-patterns/SKILL.md
+++ b/collaboration-skills/skills/skill-authoring-patterns/SKILL.md
@@ -1,0 +1,129 @@
+---
+name: skill-authoring-patterns
+description: The Apple/Swift-and-this-catalog layer for authoring or reviewing a SKILL.md, on top of superpowers:writing-skills. Use when writing a new skill for this repo, CR-ing one, wording a skill's description so it routes precisely, splitting a skill that grew unwieldy into references/, or choosing skill granularity and naming. Adds: precision-router descriptions with framework API names, the Common-Mistakes + Review-Checklist bookends, two-tier references/, the Rationale/Deviation convention, and the evidence-based multi-reviewer CR doctrine. Does NOT cover general skill discipline (TDD-for-skills, when-not-to-create, token budgets) — that lives in superpowers:writing-skills.
+---
+
+# Skill Authoring Patterns (Apple/Swift catalog layer)
+
+This is a thin complement, not a replacement. **For the general discipline of writing a skill — whether a skill should exist at all, the test-first / RED-GREEN loop, matching the guidance form to the failure mode, and word-count budgets — use `superpowers:writing-skills` first.** This skill adds only what is specific to *this catalog* and to *Apple/Swift framework skills*: how to word descriptions so an agent routes to the right framework skill, the section conventions we standardize on, and how we review skills.
+
+## When to invoke
+
+- Writing a new `SKILL.md` for this repo (especially an Apple/Swift framework skill).
+- Reviewing / CR-ing a skill for invocation precision and execution quality.
+- A skill's `description` routes wrong (or over-fires); you're rewording it.
+- A skill grew long and you're deciding what to move into `references/`.
+- Choosing a new skill's name and granularity.
+
+## Scope
+
+This skill owns the *catalog-specific* and *Apple/Swift-specific* authoring conventions below. It does **not** own: the decision to create a skill, test-first skill development, or general prose-economy rules — route those to `superpowers:writing-skills`. Distribution/packaging (plugin vs marketplace, discovery) → `claude-skill-plugin-packaging`.
+
+## Description as a precision router
+
+The `description` is the only part of a skill that stays in the model's context by default (the body loads when the skill is invoked, and the description is length-capped). So spend its words on *routing*, not summary.
+
+- **Verb-anchored to observable intent:** "Resolve Swift 6 concurrency errors…", "Audit SwiftUI runtime performance…".
+- **Embed the framework symbols / APIs that should trigger it** — `Sendable`, `@MainActor`, `MetricKit`, `AccessibilityFocusState`. This is the highest-leverage delta for *framework* skills: an agent routing on "I'm getting a Sendable error" only lands here if `Sendable` is in the description.
+- **Chain trigger scenarios** as a short list ("Use when … ; when … ; when …").
+- **Add a negative boundary when over-firing is a real risk** (e.g. "discussing screens" vs "generate a mockup") — name when NOT to fire.
+- Routing is the model's judgment, not literal string matching — write for a reader deciding "is this my situation?", not for a regex.
+
+```
+BAD:  description: Helps with accessibility.
+GOOD: description: VoiceOver / Dynamic Type / touch-target implementation for SwiftUI & UIKit.
+      Use when adding or auditing user-facing UI; when asked "make this accessible" / "VoiceOver
+      doesn't read this" / "does this pass WCAG"; before an App Review a11y pass. Covers
+      accessibilityLabel/value/hint/traits, Dynamic Type + minimumScaleFactor, 44pt targets.
+      Does NOT cover deep Rotor/Focus APIs — see <sibling>.
+```
+
+## Section conventions we standardize
+
+Order the middle by the topic's pedagogy, but keep these conventions:
+
+- **`## Rationale`** — *why* this default was chosen. Unique to this catalog; keep it.
+- **`## Deviation`** — *when to override* the default, and the cost. Also ours; keep it. (Example: "Drop to iOS 17 when targeting education devices — you lose full Observation behaviour.")
+- **`## Common Mistakes`** — concrete, anti-pattern-named items ("Using `DateFormatter()` in `body`"), as many as are real — do not pad to a number.
+- **`## Review Checklist`** — a `- [ ]` list at the **end**, runnable top-to-bottom.
+- **`## Related skills`** — siblings by name.
+
+Use a **scope-boundary** line in the body wherever a sibling is close ("owns X; does NOT own Y → route to `<sibling>`") — this is what stops two framework skills both claiming the same request.
+
+### Skeleton (assembled)
+
+```markdown
+---
+name: <kebab-matches-folder>
+description: <precision router — see above>
+---
+# <Title>
+<1-paragraph scope: what it implements/reviews + target version>
+## When to invoke
+## Scope            ← what it does NOT own → sibling
+## <body: triage/workflow → decision table → rules → code>
+## Rationale
+## Deviation
+## Common Mistakes
+## Review Checklist
+## References        ← only if it has references/
+## Related skills
+```
+
+## Structure aids (use where they fit — not universal)
+
+- **Lead with a triage/workflow** ("Step 1 capture context → 2 smallest fix → 3 verify") for *procedural* skills. Skip it for pure reference/glossary skills — don't manufacture a procedure.
+- **Front-load a decision table** (situation→fix, or option/best-for/complexity) wherever the agent must choose a path before implementing.
+- **Add a `## Contents` TOC only for genuinely long skills** that a reader jumps around in — not by default; for a short linear skill it just costs tokens.
+
+## Two-tier depth (references/)
+
+Keep `SKILL.md` scannable: decision logic, short paired WRONG/RIGHT snippets (one point each), quick tables. Move long migrations, full API references, and big samples into `references/*.md` and **point to them from `SKILL.md` with a plain instruction** ("for the full lock-vs-actor guide, read `references/synchronization.md`"). This is a documentation convention — the agent reads those files via normal file reads when your `SKILL.md` tells it to; there is no automatic lazy-load. It keeps the always-in-context cost low while letting depth exist.
+
+## Naming & granularity
+
+- `name` is kebab-case; **our consistency gate requires `name` to equal the directory** (run `mise run check`) for clean cross-references and tooling. (Note: that's *our* rule — Claude Code itself derives the command from the directory and treats `name` as a label.)
+- **One surface area per skill.** Where Apple ships a Kit, take the Kit name (`widgetkit`, `storekit`). For cross-cutting topics use a descriptive compound at the right altitude — `swift-concurrency`, not the too-broad `swiftui` nor the too-narrow `swiftui-observable`.
+
+## Reviewing a skill (CR)
+
+When you CR a skill or a batch, apply the evidence-based, multi-lens doctrine (it caught real errors in this catalog):
+
+- **Diverse lenses, not one reviewer** — for a batch, dispatch reviewers with distinct expertise (correctness, a11y, security, performance, skill-authoring). Different lenses catch what redundancy can't.
+- **Evidence for every falsifiable claim** — a reviewer flagging "this API/version is wrong" cites the source (Apple docs / Swift Evolution / WCAG), not "looks off"; each lists "what I did NOT verify + confidence".
+- **Reviewers can be wrong → the Leader adjudicates** — don't take the union on faith. Verify disputed falsifiable claims yourself before accepting or overruling (real cases: a reviewer "corrected" an iPhone-14-Pro size that was already right; another pushed a deprecated CLI form).
+
+## Common Mistakes
+
+1. **Vague one-line `description`** — the agent can't route to it. Use the precision-router form with API names.
+2. **No negative boundary** on a skill that can over-fire — it produces unwanted artifacts.
+3. **Description as summary, not router** — it restates the body instead of naming trigger conditions.
+4. **No scope-boundary line** — two adjacent framework skills both claim the same request.
+5. **Decisions buried in prose** instead of a table/triage when the agent must choose a path.
+6. **Deep reference material inlined** into `SKILL.md`, bloating always-in-context cost — move to `references/`.
+7. **Generic Common-Mistakes** ("write good code") instead of concrete, anti-pattern-named items.
+8. **Project-specific workaround presented as general guidance** (e.g. "avoid `.task`, our build has bug #361") — ships wrong advice to every consumer.
+9. **Stale/unverified API or version claim** — cite the source; a wrong version gate emits needless `#available` guards or won't compile.
+
+## Review Checklist
+
+- [ ] (General skill discipline checked against `superpowers:writing-skills` first.)
+- [ ] `name` equals the directory; `mise run check` passes.
+- [ ] `description` is router form: verb-anchored, embeds the triggering framework APIs, lists trigger scenarios; a negative boundary if it could over-fire.
+- [ ] A scope-boundary line names what the skill does NOT own and routes to the sibling.
+- [ ] Choices the agent must make are in a table/triage, not prose.
+- [ ] Deep material is in `references/*.md` with an in-body pointer; `SKILL.md` stays scannable.
+- [ ] `Rationale` + `Deviation` present; code uses current APIs with version gates marked inline.
+- [ ] `Common Mistakes` are concrete and anti-pattern-named; no padding.
+- [ ] No project-specific workaround dressed up as general guidance.
+- [ ] Every falsifiable API/version claim spot-checked against an authoritative source (cite it).
+
+## Related skills
+
+- `superpowers:writing-skills` — **read first** for the general discipline this skill deliberately does not repeat.
+- `claude-skill-plugin-packaging` — packaging/distribution/discovery of the authored skill.
+- `subagent-review-cycles` — the round structure the evidence-based CR plugs into.
+
+## Provenance
+
+The structural patterns (router descriptions, bookend sections, two-tier references, naming) were distilled by **studying** high-quality public Swift/Apple skill collections — methodology only, no content copied — and combined with this catalog's own `Rationale`/`Deviation` convention and an evidence-based multi-reviewer CR doctrine. General skill-authoring doctrine is intentionally delegated to `superpowers:writing-skills`.

--- a/scripts/check-consistency.py
+++ b/scripts/check-consistency.py
@@ -16,7 +16,7 @@ import json, re, subprocess, sys
 from pathlib import Path
 
 ROOT = Path(__file__).resolve().parent.parent
-PLUGINS = {"apple-dev-skills": 20, "collaboration-skills": 10}
+PLUGINS = {"apple-dev-skills": 20, "collaboration-skills": 11}
 EXTERNALS = {"apple-skills", "swiftui-expert", "swiftui-pro", "caveman", "ponytail"}
 errors: list[str] = []
 def fail(m): errors.append(m)
@@ -62,9 +62,9 @@ else:
     missing = (all_skills | EXTERNALS) - tokens
     if missing: fail(f"[readme] Catalog missing: {sorted(missing)}")
     g = [int(x) for x in re.findall(r"\((\d+)\)", sec)]
-    for required in (20, 10, len(EXTERNALS)):
+    for required in (*PLUGINS.values(), len(EXTERNALS)):
         if required not in g:
-            fail(f"[readme] Catalog counts {sorted(g)} must include 20, 10, {len(EXTERNALS)}")
+            fail(f"[readme] Catalog counts {sorted(g)} must include {sorted((*PLUGINS.values(), len(EXTERNALS)))}")
             break
 
 # plugin.json counts


### PR DESCRIPTION
Adds a new `collaboration-skills` skill: an **Apple/Swift catalog authoring layer** that complements `superpowers:writing-skills` (defers general doctrine to it) and adds the catalog-specific deltas — precision-router descriptions with framework API names, Common-Mistakes/Review-Checklist bookends, two-tier `references/`, the Rationale/Deviation convention, and the evidence-based multi-reviewer CR doctrine.

Authored via a **5-reviewer CR** (one a skill-authoring expert loading `superpowers:writing-skills`); re-scoped from standalone → complement and fixed Claude-Code-mechanics overstatements.

Ripple: collaboration-skills **10 → 11**; manifests/README/gate/zh-Hant updated; collaboration-skills + marketplace → **v1.2.0** (apple-dev-skills stays 1.1.0). Gate green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)