### PR TITLE
ci: add upkeep repo-audit workflow

### DIFF
--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -1,0 +1,17 @@
+name: Repo audit (upkeep)
+
+on:
+  schedule:
+    - cron: '0 20 * * *'   # 04:00 Asia/Taipei (UTC+8) daily
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  issues: write
+  id-token: write
+
+jobs:
+  audit:
+    uses: wei18/upkeep/.github/workflows/audit.yml@v1
+    secrets:
+      claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}


### PR DESCRIPTION
Adds \`.github/workflows/audit.yml\` mirroring [wei18/Sudoku](https://github.com/wei18/Sudoku/blob/main/.github/workflows/audit.yml) — a thin caller of the \`wei18/upkeep\` reusable audit workflow (daily cron @ 04:00 Asia/Taipei + \`workflow_dispatch\`).

**Action required:** set the \`CLAUDE_CODE_OAUTH_TOKEN\` repo secret (Settings → Secrets and variables → Actions) or the workflow will fail at runtime.

🤖 Generated with [Claude Code](https://claude.com/claude-code)