### PR TITLE
feat(skills): add github-contribution-workflow (collaboration 12)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -3,7 +3,7 @@
   "owner": { "name": "Wei18" },
   "metadata": {
     "description": "A curated catalog of skills for AI coding agents — first-party Apple/Swift and agent-collaboration skills, plus aggregated best-of-breed external plugins (credited to their authors)",
-    "version": "1.2.0"
+    "version": "1.3.0"
   },
   "plugins": [
     {
@@ -18,8 +18,8 @@
     {
       "name": "collaboration-skills",
       "source": "./collaboration-skills",
-      "description": "11 first-party AI-agent collaboration & process skills. Namespaced collaboration-skills:<skill>.",
-      "version": "1.2.0",
+      "description": "12 first-party AI-agent collaboration & process skills. Namespaced collaboration-skills:<skill>.",
+      "version": "1.3.0",
       "author": { "name": "Wei18" },
       "keywords": ["claude-code", "agent-skills", "ai-agents", "workflow", "collaboration"],
       "category": "workflow"

--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ npx skills add wei18/apple-dev-skills --skill swift6-concurrency
 | `app-icon-rasterize` | Rasterize a 1024 SVG icon to asset-catalog PNG via `qlmanage` — no Homebrew |
 | `ios-design-mockup` | Single-file HTML iOS design mockup from a spec — iPhone frames + tokens |
 
-### collaboration-skills (11) — AI-agent process
+### collaboration-skills (12) — AI-agent process
 
 | Skill | One-liner |
 |---|---|
@@ -99,6 +99,7 @@ npx skills add wei18/apple-dev-skills --skill swift6-concurrency
 | `backlog-routing-by-topic` | Route stray ideas by topic to the matching spec file's §Backlog |
 | `claude-skill-plugin-packaging` | Distribute/install Claude Code skills — depth-1 rule, plugin + marketplace, aggregation |
 | `skill-authoring-patterns` | Apple/Swift catalog layer over `superpowers:writing-skills` — router descriptions, bookend sections, two-tier references, evidence-based CR |
+| `github-contribution-workflow` | gh-CLI contribution loop — PRs, issues, GitHub file ops, secrets, contribution-flow repo settings; conventions + CLEAN-before-merge |
 
 ### Aggregated external (5) — by reference, credited
 

--- a/README.zh-Hant.md
+++ b/README.zh-Hant.md
@@ -1,17 +1,17 @@
 # apple-dev-skills
 
-> 一份**為 AI 編程代理（[Claude Code](https://code.claude.com)）整理的技能目錄** —
-> 由一位開發者根據自身的實際出貨經驗打造與蒐集。第一方的 **Apple/Swift**
-> 與 **AI 代理協作**技能，外加以**引用方式**彙整的同類最佳**外部**技能外掛
-> （完整標註原作者，絕不複製）。
+> 一份**為 AI 編程代理打造的精選技能目錄**（[Claude Code](https://code.claude.com)）——
+> 源自一位開發者自身的實戰出貨經驗，建構並彙整而成。涵蓋第一方的 **Apple/Swift**
+> 與 **AI-代理協作**技能，再加上**以引用方式**彙整的同類最佳**外部**技能外掛
+>（完整標註原作者，絕不複製）。
 >
-> 繁體中文：[`README.zh-Hant.md`](README.zh-Hant.md)
+> English：[`README.md`](README.md)
 
-本倉庫是一個**市集（marketplace）**，托管兩個第一方外掛與數個彙整的外部外掛。
+本 repo 是一個托管兩個第一方外掛與數個彙整外部外掛的**市集（marketplace）**。
 
 ## 安裝
 
-> Claude Code 透過**外掛**系統來發現共享技能。本倉庫既是市集，
+> Claude Code 透過**外掛（plugin）**系統來探索共享技能。本 repo 既是市集，
 > 也是兩個第一方外掛的所在地。
 
 ### A — 市集（最簡單）
@@ -22,19 +22,19 @@
 /plugin install collaboration-skills@apple-dev-skills      # 10 agent-collaboration skills
 ```
 
-任選其一或兩者皆裝。外部外掛的安裝方式相同，例如 `/plugin install swiftui-expert@apple-dev-skills`。
+可任選其一或兩者皆裝。外部外掛安裝方式相同，例如 `/plugin install swiftui-expert@apple-dev-skills`。
 
-### B — 倉庫層級（vendored submodule，已釘選版本）
+### B — repo 層級（內嵌 submodule，釘選版本）
 
-將其 vendor 並釘選到單一倉庫中，接著註冊一個專案範圍的本機路徑市集，使
-外掛從釘選的 submodule 載入（協作者會被提示信任此工作區）：
+將其內嵌並釘選進單一 repo，接著註冊一個 project-scope 的本機路徑市集，
+讓外掛從釘選的 submodule 載入（協作者會被提示信任此 workspace）：
 
 ```bash
 git submodule add https://github.com/wei18/apple-dev-skills.git .claude/skills/apple-dev-skills
 cd .claude/skills/apple-dev-skills && git checkout v1.2.0 && cd -
 ```
 
-`.claude/settings.json`（已提交）：
+`.claude/settings.json`（納入版控）：
 
 ```json
 {
@@ -48,9 +48,9 @@ cd .claude/skills/apple-dev-skills && git checkout v1.2.0 && cd -
 }
 ```
 
-光有裸 submodule **無法**被發現 — 是市集註冊在載入這些技能。
+單靠一個裸 submodule **不會**被探索到——是市集的註冊動作才載入這些技能。
 
-### C — `npx skills`（扁平、無外掛）
+### C — `npx skills`（扁平化，不走外掛）
 
 ```bash
 npx skills add wei18/apple-dev-skills --list
@@ -59,66 +59,67 @@ npx skills add wei18/apple-dev-skills --skill swift6-concurrency
 
 ## 目錄
 
-### apple-dev-skills (20) — Apple/Swift
+### apple-dev-skills（20）— Apple/Swift
 
 | Skill | 一句話說明 |
 |---|---|
-| `swift6-concurrency` | Swift 6 語言模式 + 完整並行檢查；預設 Sendable |
-| `apple-platform-targets` | 預設 iOS 18 / macOS 15、Xcode 16+；僅在使用最新版 OS 專屬 API 時才升至 26 |
-| `swiftpm-modularization` | 單一 Package、多 target、薄 App、DI 組裝根（composition root）、測試一對一 |
-| `swift-testing-baseline` | swift-testing + pointfreeco 快照；協定 fake；嚴格／寬鬆快照閘門 |
+| `swift6-concurrency` | Swift 6 語言模式 + 完整並行檢查；Sendable 預設啟用 |
+| `apple-platform-targets` | 預設 iOS 18 / macOS 15、Xcode 16+；僅在使用最新 OS 專屬 API 時才升至 26 |
+| `swiftpm-modularization` | 單一 Package、多 target、薄 App、DI composition root、測試一對一 |
+| `swift-testing-baseline` | swift-testing + pointfreeco snapshot；protocol fakes；嚴格/容忍式 snapshot gate |
 | `xcode-cloud-single-track-ci` | 單軌 Xcode Cloud；PR / Main / Release / Periodic；合併前 PR CI |
-| `mise-tool-management` | mise 管理二進位 CLI 工具；開發與 CI 共用 `.mise.toml`；macOS-only `os` 守衛 |
-| `oslog-logger-defaults` | `os.Logger`（不用第三方）；subsystem = bundle ID；預設 `.private` |
-| `apple-three-piece-analytics` | ASC Analytics + MetricKit + Game Center；不用第三方追蹤；PrivacyInfo 為必要項 |
-| `telemetry-facade-pattern` | 單一 `Telemetry` target、扇出 facade；OSLog / NoOp / MetricKit / GameCenter sink |
-| `ai-translated-localization` | 預設 7 種語系；AI 翻譯流程；`Localizable.xcstrings`；完整度閘門 |
+| `mise-tool-management` | 由 mise 管理二進位 CLI 工具；開發與 CI 共用 `.mise.toml`；macOS-only `os` guard |
+| `oslog-logger-defaults` | `os.Logger`（不用第三方）；subsystem = bundle ID；`.private` 預設 |
+| `apple-three-piece-analytics` | ASC Analytics + MetricKit + Game Center；不用第三方追蹤；PrivacyInfo 必備 |
+| `telemetry-facade-pattern` | 單一 `Telemetry` target、fan-out facade；OSLog / NoOp / MetricKit / GameCenter sinks |
+| `ai-translated-localization` | 預設 7 種語系；AI 翻譯流程；`Localizable.xcstrings`；完整性 gate |
 | `ios-accessibility-engineering` | 為 SwiftUI 與 UIKit 提供 VoiceOver / Dynamic Type / 觸控目標 / Reduce Motion；WCAG 2.2 |
-| `swift-dependency-injection` | 協定注入 + 組裝根；environment 對比建構子；`@TaskLocal`；Sendable |
+| `swift-dependency-injection` | Protocol 注入 + composition root；environment 對比 constructor；`@TaskLocal`；Sendable |
 | `ios-performance-engineering` | Instruments / xctrace / hang-hitch 預算 / 啟動 / 記憶體 / 二進位大小 / MetricKit |
-| `apple-public-repo-security` | 公開 iOS/macOS 倉庫的三道防線 + 洩漏優先輪替 SOP |
-| `build-time-secret-injection` | xcconfig + Info.plist `$()` + `Bundle.main`，用於隨二進位出貨但不進 diff 的 ID |
-| `monetization-sdk-integration` | 新增／升級／稽核變現 SDK；將 `import` 隔離到單一橋接檔 |
-| `app-store-review-rejections` | 診斷並預先化解免費 + 廣告 + IAP + CloudKit + GC 的 App 審查駁回類型 |
+| `apple-public-repo-security` | 公開 iOS/macOS repo 的三道防線 + 外洩優先輪替 SOP |
+| `build-time-secret-injection` | xcconfig + Info.plist `$()` + `Bundle.main`，達成隨二進位出貨但不入 diff 的 ID |
+| `monetization-sdk-integration` | 新增/升級/稽核變現 SDK；將 `import` 隔離到單一 bridge 檔 |
+| `app-store-review-rejections` | 為免費 + 廣告 + IAP + CloudKit + GC 診斷並預先化解 App Review 退件類別 |
 | `swiftui-interaction-footguns` | 會躲過純程式碼審查的已知 SwiftUI 互動 bug |
-| `app-icon-rasterize` | 透過 `qlmanage` 將 1024 SVG 圖示點陣化為 asset-catalog PNG — 不用 Homebrew |
-| `ios-design-mockup` | 從規格產生單檔 HTML iOS 設計樣稿 — iPhone 外框 + tokens |
+| `app-icon-rasterize` | 透過 `qlmanage` 將 1024 SVG 圖示點陣化為 asset-catalog PNG——免 Homebrew |
+| `ios-design-mockup` | 由規格產出單檔 HTML iOS 設計 mockup——iPhone 外框 + tokens |
 
-### collaboration-skills (11) — AI 代理流程
+### collaboration-skills（12）— AI 代理流程
 
 | Skill | 一句話說明 |
 |---|---|
-| `spec-phase-orchestration` | 實作前的文件流水線；逐節核可 |
-| `subagent-review-cycles` | Leader / Developer / Code-Reviewer 三方；第一輪外觀問題以 inline 處理；limit(N) |
-| `leader-developer-handoff-contract` | 派遣 sub-agent 時的 5 項必備要素 |
-| `agent-impl-notes-log` | sub-agent 任務進行中的即時 impl-notes — 決策、偏離、待解問題 |
+| `spec-phase-orchestration` | 實作前的文件管線；逐段審核 |
+| `subagent-review-cycles` | Leader / Developer / Code-Reviewer 三角；第 1 輪外觀問題行內處理；limit(N) |
+| `leader-developer-handoff-contract` | 派發 sub-agent 時的 5 個必備要素 |
+| `agent-impl-notes-log` | sub-agent 任務進行中的 impl-notes——決策、偏離、待解問題 |
 | `subagent-conflict-detection` | 檢查新 sub-agent 的目標不與進行中的 worktree 重疊 |
-| `methodology-pattern-extractor` | 從會議記錄中萃取重複出現 ≥3 次的模式 |
-| `session-to-meeting-log` | 將一次 Claude Code session 整理成會議記錄；摘要而非逐字 |
-| `pr-diff-verification` | 在 push/PR 前，驗證 `git show --stat HEAD` 與該 commit 的宣稱相符 |
-| `backlog-routing-by-topic` | 依主題將零散想法路由到對應規格檔的 §Backlog |
-| `claude-skill-plugin-packaging` | 散布／安裝 Claude Code 技能 — depth-1 規則、外掛 + 市集、彙整 |
-| `skill-authoring-patterns` | 在 `superpowers:writing-skills` 之上的 Apple/Swift 目錄層 — 路由式描述、首尾呼應段落、兩層式 references、以證據為本的 CR |
+| `methodology-pattern-extractor` | 從會議紀錄中萃取重複出現 ≥3 次的模式 |
+| `session-to-meeting-log` | 將一段 Claude Code session 整併為會議紀錄；摘要而非逐字 |
+| `pr-diff-verification` | 在 push/PR 前，驗證 `git show --stat HEAD` 與 commit 宣稱相符 |
+| `backlog-routing-by-topic` | 依主題將零散點子導向對應 spec 檔的 §Backlog |
+| `claude-skill-plugin-packaging` | 散布/安裝 Claude Code 技能——depth-1 規則、外掛 + 市集、彙整 |
+| `skill-authoring-patterns` | 在 `superpowers:writing-skills` 之上的 Apple/Swift 目錄層——router 描述、bookend 區段、兩層 references、以證據為本的 CR |
+| `github-contribution-workflow` | gh-CLI 貢獻迴圈——PR、issue、GitHub 檔案操作、secrets、contribution-flow repo 設定；慣例 + 合併前 CLEAN |
 
-### 彙整的外部外掛 (5) — 以引用方式，標註出處
+### 彙整外部（5）— 以引用方式列出，已標註原作者
 
-此處僅列出但**非於此處撰寫**；它們從各自作者的倉庫安裝（你取得的是
-其最新版本），並完整標註出處。**彙整，而非佔為己有**：僅列出 MIT 相容、
-非重複的外掛 — 第一方技能只為真正的缺口而寫。
+此處列出但**非於此撰寫**；它們從各原作者自己的 repo 安裝（你會取得
+其最新版），並完整標註出處。**彙整，而非占用**：僅列出與 MIT 相容、
+無重複的外掛——第一方技能只為真正的空缺而撰寫。
 
 | Plugin | 作者 | 涵蓋範圍 |
 |---|---|---|
-| [`apple-skills`](https://github.com/vabole/apple-skills) | vabole (MIT) | 廣泛的 Apple 框架 — SwiftUI、SwiftData、App Intents、WidgetKit、StoreKit、HealthKit … |
+| [`apple-skills`](https://github.com/vabole/apple-skills) | vabole (MIT) | 廣泛的 Apple 框架——SwiftUI、SwiftData、App Intents、WidgetKit、StoreKit、HealthKit … |
 | [`swiftui-expert`](https://github.com/AvdLee/SwiftUI-Agent-Skill) | Antoine van der Lee (MIT) | SwiftUI 模式、Swift Charts、Liquid Glass、Instruments 工具鏈 |
-| [`swiftui-pro`](https://github.com/twostraws/SwiftUI-Agent-Skill) | Paul Hudson (MIT) | SwiftUI 陷阱、棄用 API 觀察清單、iOS 26 / Liquid Glass |
-| [`caveman`](https://github.com/JuliusBrussee/caveman) | JuliusBrussee (MIT) | 超壓縮溝通模式 — 削減約 75% 的 token（通用代理行為） |
-| [`ponytail`](https://github.com/DietrichGebert/ponytail) | DietrichGebert (MIT) | 「懶散資深開發者」模式 — 強制採用最簡單、最短的解法（通用代理行為） |
+| [`swiftui-pro`](https://github.com/twostraws/SwiftUI-Agent-Skill) | Paul Hudson (MIT) | SwiftUI 陷阱、已棄用 API 觀察清單、iOS 26 / Liquid Glass |
+| [`caveman`](https://github.com/JuliusBrussee/caveman) | JuliusBrussee (MIT) | 超壓縮溝通模式——削減約 75% token（通用代理行為） |
+| [`ponytail`](https://github.com/DietrichGebert/ponytail) | DietrichGebert (MIT) | 「懶惰資深開發者」模式——強制採用最簡、最短的解法（通用代理行為） |
 
 ## 出處
 
 第一方技能是從 [`wei18/Sudoku`](https://github.com/wei18/Sudoku) 的
-`.claude/skills/` 中提煉並通用化而來 — 那是一個規格優先、由 AI-Leader/Developer
-打造的出貨級 Apple 平台遊戲作品集 — 外加對公開 Apple / WCAG / Swift 標準的原創整理。
-彙整的外部外掛仍屬其作者的作品，僅以引用方式呈現。MIT — 見 [LICENSE](LICENSE)。
+`.claude/skills/` 中提煉並泛化而來——一個 spec-first、由 AI-Leader/Developer 建構的
+出貨型 Apple 平台遊戲作品集——再加上對公開 Apple / WCAG / Swift 標準的原創整理。
+彙整的外部外掛仍屬其各自作者的作品，僅以引用方式呈現。MIT——詳見 [LICENSE](LICENSE)。
 
-<!-- src-sha: 52a8e48e14caa462bce61b83e70c200d5cc9a1d5 -->
+<!-- src-sha: 0a79ccfebb996986a982f1087becf65f996f157e -->

--- a/collaboration-skills/.claude-plugin/plugin.json
+++ b/collaboration-skills/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "collaboration-skills",
-  "version": "1.2.0",
-  "description": "11 first-party AI-agent collaboration & process skills — spec-phase orchestration, Leader/Developer handoff contract, subagent review cycles & conflict detection, impl-notes & meeting logs, methodology extraction, backlog routing, PR-diff verification, Claude Code skill-plugin packaging, and skill-authoring patterns. Tool-agnostic agent process, not Apple-specific.",
+  "version": "1.3.0",
+  "description": "12 first-party AI-agent collaboration & process skills — spec-phase orchestration, Leader/Developer handoff contract, subagent review cycles & conflict detection, impl-notes & meeting logs, methodology extraction, backlog routing, PR-diff verification, Claude Code skill-plugin packaging, skill-authoring patterns, and GitHub contribution workflow. Tool-agnostic agent process, not Apple-specific.",
   "author": { "name": "Wei18" },
   "homepage": "https://github.com/wei18/apple-dev-skills",
   "license": "MIT"

--- a/collaboration-skills/skills/github-contribution-workflow/SKILL.md
+++ b/collaboration-skills/skills/github-contribution-workflow/SKILL.md
@@ -1,0 +1,89 @@
+---
+name: github-contribution-workflow
+description: Author GitHub contributions with the gh CLI — open/merge PRs, open issues, create or edit files on GitHub, set repo secrets, and configure contribution-flow repo settings. Use when running `gh pr create` / `gh pr merge` / `gh pr checks` / `gh issue create` / `gh secret set` / `gh api`, checking CI before merging, or bumping a submodule pin. Covers branch + Conventional-Commits PR-title conventions, the Co-Authored-By trailer + 🤖 footer, squash+delete merge, CLEAN-before-merge, `gh secret set` without --body, submodule bumps via `git update-index`, and the --no-verify rule. Does NOT cover pure local git, diff-vs-commit verification (→ pr-diff-verification), security repo settings (→ apple-public-repo-security), worktree conflict detection (→ subagent-conflict-detection), or plugin distribution (→ claude-skill-plugin-packaging).
+---
+
+# GitHub Contribution Workflow
+
+The `gh`-CLI contribution loop for an agent acting on a GitHub repo: branch →
+commit → PR → CI → merge, plus issues, GitHub-side file ops, repo secrets, and
+contribution-flow repo settings. Encodes conventions that keep an agent's
+contributions reviewable and consistent. Tool-agnostic in spirit; concrete
+commands are `gh` + `git`.
+
+## When to invoke
+
+- Opening or merging a PR; opening or commenting on an issue.
+- Creating or editing a file *through GitHub* (API / web flow) rather than a local clone.
+- Setting a repo secret or configuring contribution-flow repo settings.
+- Checking CI status before a merge; bumping a submodule pin.
+- User says "open a PR / issue", "merge this", "set the secret", "configure the repo".
+
+## Scope — what this does NOT own (route to sibling)
+
+- **Verifying the diff matches the commit's claims** before push/PR → `pr-diff-verification`.
+- **Security repo settings** (Secret Scanning, push protection, gitleaks, `.gitignore` baseline) → `apple-public-repo-security`.
+- **Parallel-session / submodule worktree conflicts** → `subagent-conflict-detection`.
+- **Distributing or installing skill plugins** (marketplace, depth-1 rule) → `claude-skill-plugin-packaging`.
+- **Pure local git** with no GitHub surface → out of scope.
+
+## Intent → command
+
+| Intent | Command |
+|---|---|
+| Open a PR | `gh pr create --title "<conventional title>" --body "<body + 🤖 footer>"` |
+| Check CI before merge | `gh pr checks <n> --repo <o/r>` ; `gh pr view <n> --json mergeStateStatus` |
+| Merge a PR | `gh pr merge <n> --squash --delete-branch` (only when status is `CLEAN`) |
+| Open an issue | `gh issue create --title "<title>" --body "<body>"` |
+| Comment on an issue | `gh issue comment <n> --body "<text>"` |
+| Create/edit a file via GitHub | `gh api -X PUT repos/<o/r>/contents/<path> -f message=… -f content=$(base64) …` (no local clone needed) |
+| Set a repo secret | `gh secret set <NAME> --repo <o/r>` (interactive paste; see Conventions) |
+| List secrets | `gh secret list --repo <o/r>` (names only; values are write-only) |
+| Configure merge / branch protection | `gh api -X PATCH repos/<o/r> -F allow_squash_merge=true -F delete_branch_on_merge=true` ; `gh api -X PUT repos/<o/r>/branches/<b>/protection …` |
+
+## Conventions
+
+- **Branch names** use Conventional prefixes: `feat/ fix/ chore/ docs/ ci/ refactor/ test/`.
+- **PR titles** follow Conventional Commits (some repos enforce this with a CI gate — e.g. a "Validate PR title" check; a non-conforming title fails the PR).
+- **Commit trailer**: end commit messages with the agreed `Co-Authored-By:` trailer. **PR body**: end with the 🤖 footer.
+- **Merge**: `--squash --delete-branch`. **Never merge unless `gh pr checks` / `mergeStateStatus` is `CLEAN`.** `BLOCKED` is usually just *pending required checks*, not a failure — poll until they finish, don't force-merge.
+- **Secrets**: `gh secret set <NAME>` **without `--body`** — the interactive prompt keeps the value out of shell history. Never `gh secret set X --body "$TOKEN"`. Verify presence (not value) with `gh secret list`.
+- **Submodule pin bump**: set the gitlink surgically with
+  `git update-index --cacheinfo 160000,<commit-sha>,<submodule-path>` — no submodule checkout needed (works in a fresh worktree). Confirm the target SHA is pushed/tag-reachable on the submodule's remote first (`git ls-remote --tags <url> <tag>`).
+- **`--no-verify`**: allowed ONLY for a commit with **no code and no secrets** (a submodule-pin bump, a `.gitmodules`/config-only change) when the repo's pre-commit gate is heavy and times out. Never for code or content commits — those must pass the hooks.
+- **Shared repo / submodule**: edit via an isolated worktree branched from `origin/main` + PR, never in place — see `subagent-conflict-detection`.
+
+## Repo settings (contribution-flow only)
+
+This skill owns the *contribution-flow* repo config: merge-button policy
+(`allow_squash_merge`, `delete_branch_on_merge`), branch protection requiring CI,
+required status checks, and labels. **Security settings (Secret Scanning, push
+protection) are owned by `apple-public-repo-security`** — set them there, not here.
+
+## Common Mistakes
+
+1. **Merging on a non-CLEAN status** — treating `BLOCKED` (pending checks) as a failure, or force-merging past a real red check. Poll; merge only on `CLEAN`.
+2. **`gh secret set --body "$TOKEN"`** — leaks the token into shell history. Use the interactive prompt.
+3. **Non-Conventional PR title** — fails a repo's title-lint gate; the PR can't merge.
+4. **Editing a shared repo / submodule in place** — two writers clobber each other; use a worktree + PR.
+5. **`--no-verify` on a code/content commit** — bypasses the gate that protects the repo. Reserve it for no-code/no-secret commits only.
+6. **Hand-editing a submodule's checked-out files from the parent repo** — bump the pin instead (`git update-index --cacheinfo`), and land the submodule's own change via its own PR.
+7. **Duplicating a sibling's job** — re-doing diff verification, security settings, or worktree conflict checks here instead of routing to the owning skill.
+
+## Review Checklist
+
+- [ ] Branch name uses a Conventional prefix; PR title is Conventional Commits.
+- [ ] Commit carries the `Co-Authored-By:` trailer; PR body ends with the 🤖 footer.
+- [ ] `gh pr checks` is `CLEAN` before merge; merged with `--squash --delete-branch`.
+- [ ] Any secret was set via interactive `gh secret set` (no `--body`); verified with `gh secret list`.
+- [ ] A submodule bump used `git update-index --cacheinfo` against a remote-reachable SHA.
+- [ ] `--no-verify` used only on a no-code/no-secret commit, with the reason stated.
+- [ ] Shared-repo/submodule edits went through a worktree + PR.
+- [ ] Nothing here duplicates a sibling skill's scope.
+
+## Related skills
+
+- `pr-diff-verification` — verify `git show --stat HEAD` matches the commit's claims before push/PR.
+- `apple-public-repo-security` — security repo settings + secret-leak prevention.
+- `subagent-conflict-detection` — worktree + PR flow for parallel sessions / submodules.
+- `claude-skill-plugin-packaging` — distributing/installing skill plugins.

--- a/docs/superpowers/plans/2026-06-25-github-contribution-workflow.md
+++ b/docs/superpowers/plans/2026-06-25-github-contribution-workflow.md
@@ -1,0 +1,238 @@
+# github-contribution-workflow Skill — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add the first-party `github-contribution-workflow` skill (12th collaboration skill) and wire it through the SSOT/consistency gate.
+
+**Architecture:** Author one `SKILL.md` under `collaboration-skills/skills/`, then update the four SSOT surfaces (README Catalog, the plugin's `plugin.json`, the root `marketplace.json`, the regenerated zh-Hant mirror). The consistency gate (`mise run check`) is the test harness — it must end green; the `skill-authoring-patterns` Review Checklist is the qualitative gate.
+
+**Tech Stack:** Markdown SKILL.md; JSON manifests; `mise run check` (Python gate); `mise run readme-zh` (`claude`-backed zh-Hant generator).
+
+## Global Constraints
+
+- Skill lives in `collaboration-skills/` (tool-agnostic process), NOT `apple-dev-skills/`.
+- `name` frontmatter MUST equal the directory `github-contribution-workflow` (gate-enforced).
+- Single skill — no split (user-confirmed).
+- Compose, don't duplicate: a scope-boundary routes to `pr-diff-verification`, `apple-public-repo-security`, `subagent-conflict-detection`, `claude-skill-plugin-packaging`.
+- Count goes 11 → 12; collaboration-skills + marketplace version `1.2.0 → 1.3.0`.
+- README.md is SSOT; zh-Hant is regenerated, never hand-edited; `mise run check` must pass.
+
+---
+
+### Task 1: Author the SKILL.md
+
+**Files:**
+- Create: `collaboration-skills/skills/github-contribution-workflow/SKILL.md`
+
+**Interfaces:**
+- Produces: a depth-1 skill `collaboration-skills/skills/github-contribution-workflow/SKILL.md` whose frontmatter `name: github-contribution-workflow`.
+
+- [ ] **Step 1: Write the file** with exactly this content:
+
+````markdown
+---
+name: github-contribution-workflow
+description: Author GitHub contributions with the gh CLI — open/merge PRs, open issues, create or edit files on GitHub, set repo secrets, and configure contribution-flow repo settings. Use when running `gh pr create` / `gh pr merge` / `gh pr checks` / `gh issue create` / `gh secret set` / `gh api`, checking CI before merging, or bumping a submodule pin. Covers branch + Conventional-Commits PR-title conventions, the Co-Authored-By trailer + 🤖 footer, squash+delete merge, CLEAN-before-merge, `gh secret set` without --body, submodule bumps via `git update-index`, and the --no-verify rule. Does NOT cover pure local git, diff-vs-commit verification (→ pr-diff-verification), security repo settings (→ apple-public-repo-security), worktree conflict detection (→ subagent-conflict-detection), or plugin distribution (→ claude-skill-plugin-packaging).
+---
+
+# GitHub Contribution Workflow
+
+The `gh`-CLI contribution loop for an agent acting on a GitHub repo: branch →
+commit → PR → CI → merge, plus issues, GitHub-side file ops, repo secrets, and
+contribution-flow repo settings. Encodes conventions that keep an agent's
+contributions reviewable and consistent. Tool-agnostic in spirit; concrete
+commands are `gh` + `git`.
+
+## When to invoke
+
+- Opening or merging a PR; opening or commenting on an issue.
+- Creating or editing a file *through GitHub* (API / web flow) rather than a local clone.
+- Setting a repo secret or configuring contribution-flow repo settings.
+- Checking CI status before a merge; bumping a submodule pin.
+- User says "open a PR / issue", "merge this", "set the secret", "configure the repo".
+
+## Scope — what this does NOT own (route to sibling)
+
+- **Verifying the diff matches the commit's claims** before push/PR → `pr-diff-verification`.
+- **Security repo settings** (Secret Scanning, push protection, gitleaks, `.gitignore` baseline) → `apple-public-repo-security`.
+- **Parallel-session / submodule worktree conflicts** → `subagent-conflict-detection`.
+- **Distributing or installing skill plugins** (marketplace, depth-1 rule) → `claude-skill-plugin-packaging`.
+- **Pure local git** with no GitHub surface → out of scope.
+
+## Intent → command
+
+| Intent | Command |
+|---|---|
+| Open a PR | `gh pr create --title "<conventional title>" --body "<body + 🤖 footer>"` |
+| Check CI before merge | `gh pr checks <n> --repo <o/r>` ; `gh pr view <n> --json mergeStateStatus` |
+| Merge a PR | `gh pr merge <n> --squash --delete-branch` (only when status is `CLEAN`) |
+| Open an issue | `gh issue create --title "<title>" --body "<body>"` |
+| Comment on an issue | `gh issue comment <n> --body "<text>"` |
+| Create/edit a file via GitHub | `gh api -X PUT repos/<o/r>/contents/<path> -f message=… -f content=$(base64) …` (no local clone needed) |
+| Set a repo secret | `gh secret set <NAME> --repo <o/r>` (interactive paste; see Conventions) |
+| List secrets | `gh secret list --repo <o/r>` (names only; values are write-only) |
+| Configure merge / branch protection | `gh api -X PATCH repos/<o/r> -F allow_squash_merge=true -F delete_branch_on_merge=true` ; `gh api -X PUT repos/<o/r>/branches/<b>/protection …` |
+
+## Conventions
+
+- **Branch names** use Conventional prefixes: `feat/ fix/ chore/ docs/ ci/ refactor/ test/`.
+- **PR titles** follow Conventional Commits (some repos enforce this with a CI gate — e.g. a "Validate PR title" check; a non-conforming title fails the PR).
+- **Commit trailer**: end commit messages with the agreed `Co-Authored-By:` trailer. **PR body**: end with the 🤖 footer.
+- **Merge**: `--squash --delete-branch`. **Never merge unless `gh pr checks` / `mergeStateStatus` is `CLEAN`.** `BLOCKED` is usually just *pending required checks*, not a failure — poll until they finish, don't force-merge.
+- **Secrets**: `gh secret set <NAME>` **without `--body`** — the interactive prompt keeps the value out of shell history. Never `gh secret set X --body "$TOKEN"`. Verify presence (not value) with `gh secret list`.
+- **Submodule pin bump**: set the gitlink surgically with
+  `git update-index --cacheinfo 160000,<commit-sha>,<submodule-path>` — no submodule checkout needed (works in a fresh worktree). Confirm the target SHA is pushed/tag-reachable on the submodule's remote first (`git ls-remote --tags <url> <tag>`).
+- **`--no-verify`**: allowed ONLY for a commit with **no code and no secrets** (a submodule-pin bump, a `.gitmodules`/config-only change) when the repo's pre-commit gate is heavy and times out. Never for code or content commits — those must pass the hooks.
+- **Shared repo / submodule**: edit via an isolated worktree branched from `origin/main` + PR, never in place — see `subagent-conflict-detection`.
+
+## Repo settings (contribution-flow only)
+
+This skill owns the *contribution-flow* repo config: merge-button policy
+(`allow_squash_merge`, `delete_branch_on_merge`), branch protection requiring CI,
+required status checks, and labels. **Security settings (Secret Scanning, push
+protection) are owned by `apple-public-repo-security`** — set them there, not here.
+
+## Common Mistakes
+
+1. **Merging on a non-CLEAN status** — treating `BLOCKED` (pending checks) as a failure, or force-merging past a real red check. Poll; merge only on `CLEAN`.
+2. **`gh secret set --body "$TOKEN"`** — leaks the token into shell history. Use the interactive prompt.
+3. **Non-Conventional PR title** — fails a repo's title-lint gate; the PR can't merge.
+4. **Editing a shared repo / submodule in place** — two writers clobber each other; use a worktree + PR.
+5. **`--no-verify` on a code/content commit** — bypasses the gate that protects the repo. Reserve it for no-code/no-secret commits only.
+6. **Hand-editing a submodule's checked-out files from the parent repo** — bump the pin instead (`git update-index --cacheinfo`), and land the submodule's own change via its own PR.
+7. **Duplicating a sibling's job** — re-doing diff verification, security settings, or worktree conflict checks here instead of routing to the owning skill.
+
+## Review Checklist
+
+- [ ] Branch name uses a Conventional prefix; PR title is Conventional Commits.
+- [ ] Commit carries the `Co-Authored-By:` trailer; PR body ends with the 🤖 footer.
+- [ ] `gh pr checks` is `CLEAN` before merge; merged with `--squash --delete-branch`.
+- [ ] Any secret was set via interactive `gh secret set` (no `--body`); verified with `gh secret list`.
+- [ ] A submodule bump used `git update-index --cacheinfo` against a remote-reachable SHA.
+- [ ] `--no-verify` used only on a no-code/no-secret commit, with the reason stated.
+- [ ] Shared-repo/submodule edits went through a worktree + PR.
+- [ ] Nothing here duplicates a sibling skill's scope.
+
+## Related skills
+
+- `pr-diff-verification` — verify `git show --stat HEAD` matches the commit's claims before push/PR.
+- `apple-public-repo-security` — security repo settings + secret-leak prevention.
+- `subagent-conflict-detection` — worktree + PR flow for parallel sessions / submodules.
+- `claude-skill-plugin-packaging` — distributing/installing skill plugins.
+````
+
+- [ ] **Step 2: Verify name == dir**
+
+Run: `grep '^name:' collaboration-skills/skills/github-contribution-workflow/SKILL.md`
+Expected: `name: github-contribution-workflow`
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add collaboration-skills/skills/github-contribution-workflow/SKILL.md
+git commit -m "feat(skills): add github-contribution-workflow (collaboration 12)
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 2: Wire SSOT — README + manifests (counts/versions)
+
+**Files:**
+- Modify: `README.md` (Catalog: add row, `(11)` → `(12)`)
+- Modify: `collaboration-skills/.claude-plugin/plugin.json` (description "11" → "12"; version `1.2.0` → `1.3.0`)
+- Modify: `.claude-plugin/marketplace.json` (collaboration-skills description "11" → "12", version `1.2.0` → `1.3.0`; `metadata.version` `1.2.0` → `1.3.0`)
+
+**Interfaces:**
+- Consumes: the skill dir from Task 1.
+- Produces: README Catalog + counts + manifests consistent for the gate.
+
+- [ ] **Step 1: Add the README Catalog row** under the collaboration-skills table (after `claude-skill-plugin-packaging`), and change the header `### collaboration-skills (11)` → `(12)`:
+
+```markdown
+| `github-contribution-workflow` | gh-CLI contribution loop — PRs, issues, GitHub file ops, secrets, contribution-flow repo settings; conventions + CLEAN-before-merge |
+```
+
+- [ ] **Step 2: Edit `collaboration-skills/.claude-plugin/plugin.json`** — change `"version": "1.2.0"` → `"1.3.0"`; in `description`, `"11 first-party"` → `"12 first-party"` and append `, and GitHub contribution workflow` to the skill list before the closing sentence.
+
+- [ ] **Step 3: Edit `.claude-plugin/marketplace.json`** — `metadata.version` `1.2.0` → `1.3.0`; the `collaboration-skills` plugin entry `version` `1.2.0` → `1.3.0` and its `description` `"11 first-party"` → `"12 first-party"`.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add README.md collaboration-skills/.claude-plugin/plugin.json .claude-plugin/marketplace.json
+git commit -m "docs: wire github-contribution-workflow into Catalog + bump collaboration-skills 1.3.0
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 3: Regenerate zh-Hant + green gate + skill review
+
+**Files:**
+- Modify (generated): `README.zh-Hant.md`
+
+**Interfaces:**
+- Consumes: README.md from Task 2.
+- Produces: fresh zh-Hant `src-sha`; `mise run check` exit 0.
+
+- [ ] **Step 1: Regenerate zh-Hant**
+
+Run: `mise run readme-zh`
+Expected: `README.zh-Hant.md` rewritten with a new trailing `<!-- src-sha: … -->`. (If `claude` is unavailable, translate the new Catalog row + count by hand and re-stamp with `printf '\n<!-- src-sha: %s -->\n' "$(git hash-object README.md)" >> README.zh-Hant.md`.)
+
+- [ ] **Step 2: Run the gate**
+
+Run: `mise run check; echo "exit=$?"`
+Expected: `OK — 2 plugins (20/12), catalog + counts + zh-Hant consistent.` and `exit=0`.
+
+> Note: the gate's `PLUGINS` map hardcodes `{"collaboration-skills": 11}`. Update it to `12` in `scripts/check-consistency.py` (line ~19) as part of this step — it is the gate's own count expectation, not a derived value. Commit it with this task.
+
+- [ ] **Step 3: Self-review against `skill-authoring-patterns` Review Checklist** — confirm: router description with embedded `gh` commands + negative boundary ✓; scope-boundary routes to all four siblings ✓; decisions in a table ✓; Common Mistakes concrete + anti-pattern-named ✓; no project-specific workaround dressed as general guidance ✓.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add README.zh-Hant.md scripts/check-consistency.py
+git commit -m "chore: regenerate zh-Hant + gate count 12 for github-contribution-workflow
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 4: PR linking the issue
+
+**Files:** none (release).
+
+- [ ] **Step 1: Push + PR (closes the tracking issue)**
+
+```bash
+git push -u origin feat/github-contribution-workflow-skill
+gh pr create --repo wei18/apple-dev-skills \
+  --title "feat(skills): add github-contribution-workflow (collaboration 12)" \
+  --body "Adds the 12th collaboration skill — the gh-CLI contribution loop (PRs, issues, GitHub file ops, secrets, contribution-flow repo settings) with this catalog's conventions. Composes with pr-diff-verification / apple-public-repo-security / subagent-conflict-detection / claude-skill-plugin-packaging via a scope boundary. Bumps collaboration-skills to 1.3.0.
+
+Spec: docs/superpowers/specs/2026-06-25-github-contribution-workflow-design.md
+Plan: docs/superpowers/plans/2026-06-25-github-contribution-workflow.md
+
+Closes #8
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)"
+```
+
+- [ ] **Step 2: Verify CI CLEAN, then merge**
+
+Run: poll `gh pr checks <n> --repo wei18/apple-dev-skills` until no `pending`; confirm `mergeStateStatus` `CLEAN`; then `gh pr merge <n> --squash --delete-branch`.
+
+---
+
+## Self-Review
+
+**1. Spec coverage:** single skill in collaboration-skills ✓ (T1); router description + conventions + repo-settings-contribution-only ✓ (T1); scope boundary to 4 siblings ✓ (T1); gate impact README/plugin.json/marketplace/zh-Hant/count ✓ (T2–T3); issue/PR tracking ✓ (T4, Closes #8). No gaps.
+
+**2. Placeholder scan:** none — full SKILL.md content is in T1 Step 1; manifest edits name exact fields/values.
+
+**3. Type/name consistency:** `github-contribution-workflow` identical across SKILL.md `name`, dir, README row, and (implicitly) the gate's skill-set discovery. Count `12` consistent across README header, both manifests, and the gate's `PLUGINS` map (T3 Step 2). Version `1.3.0` consistent across plugin.json + marketplace plugin entry + marketplace metadata.

--- a/docs/superpowers/specs/2026-06-25-github-contribution-workflow-design.md
+++ b/docs/superpowers/specs/2026-06-25-github-contribution-workflow-design.md
@@ -1,0 +1,117 @@
+# github-contribution-workflow — first-party skill (design spec)
+
+Date: 2026-06-25
+Status: APPROVED (design approved by user; spec for review)
+
+## Context
+
+The catalog has process discipline *around* git/PR (`pr-diff-verification`,
+`subagent-conflict-detection`) and the security slice of repo config
+(`apple-public-repo-security`), but **no skill for the GitHub contribution loop
+itself** — opening PRs and issues, creating/editing files via GitHub, setting
+repo secrets, configuring contribution-flow repo settings, and merging. An
+externals survey (2026-06-25) found the only well-licensed, maintained options
+(`anthropics/claude-plugins-official` `github` via MCP; `ccplugins/awesome-claude-code-plugins`
+via `gh` CLI, Apache-2.0, ~8 mo stale) but the user chose to write a focused
+first-party skill that encodes *this owner's* conventions and composes with the
+existing siblings rather than duplicating them.
+
+This skill is **tool-agnostic agent process**, so it lives in
+`collaboration-skills/` (not `apple-dev-skills/`). It is the catalog's 12th
+collaboration skill.
+
+## Goals
+
+- A single skill (`github-contribution-workflow`) covering the `gh`-CLI
+  contribution loop: PRs, issues, GitHub file ops, repo secrets, contribution-flow
+  repo settings, and merge hygiene.
+- Encode the owner's observed conventions (branch naming, Conventional-Commits PR
+  titles, `Co-Authored-By` trailer, 🤖 PR footer, squash+delete merge,
+  CLEAN-before-merge, `gh secret set` without `--body`, submodule-pin bump via
+  `git update-index --cacheinfo`, `--no-verify` only for no-code/no-secret commits,
+  worktree+PR for shared repos).
+- Route, not duplicate: a scope-boundary that hands off to the four siblings.
+
+## Non-goals / scope boundaries (route to sibling, do NOT re-cover)
+
+- push/PR diff-vs-commit-claim integrity → `pr-diff-verification`
+- security repo settings (Secret Scanning, push protection, gitleaks, `.gitignore`
+  baseline) → `apple-public-repo-security`
+- parallel-session / submodule worktree conflicts → `subagent-conflict-detection`
+- distributing/installing skill plugins (marketplace, depth-1) → `claude-skill-plugin-packaging`
+- pure local git operations with no GitHub surface → out of scope entirely
+
+## Granularity decision
+
+**One skill**, not split into PR / issue / repo-settings. Rationale: the three
+share one toolchain (`gh` + git) and one set of conventions; splitting would force
+heavy cross-references and violate the catalog's "one surface area, don't
+over-split" rule. (User-confirmed.)
+
+## Skill design
+
+**`name`**: `github-contribution-workflow` (kebab == dir; gate-enforced).
+
+**`description`** (precision router): verb-anchored to the GitHub contribution
+loop; embeds the triggering commands so an agent routes here on intent —
+`gh pr create` / `gh pr merge` / `gh pr checks` / `gh issue create` / `gh secret set` /
+`gh api` / `git submodule` bump; chains trigger scenarios (open a PR, open an
+issue, create/edit a file on GitHub, set a repo secret, configure repo settings,
+check CI before merge); negative boundary (pure local git → not here; diff
+verification → `pr-diff-verification`).
+
+**Body structure** (scannable; decisions in tables):
+
+1. **When to invoke / Scope** — trigger list + the scope-boundary block routing to
+   the four siblings above.
+2. **Decision table: intent → `gh` command** — rows for open PR / open issue /
+   create-or-edit file via GitHub / set secret / configure repo settings / merge.
+3. **Conventions** (the core value; sourced from the owner's repos + this session):
+   - Branch naming: Conventional prefixes (`feat/ fix/ chore/ docs/ ci/`).
+   - PR title: Conventional Commits (Sudoku enforces this via a CI gate).
+   - Commit ends with `Co-Authored-By:` trailer; PR body ends with the 🤖 footer.
+   - Merge with `--squash --delete-branch`; **`gh pr checks` must be CLEAN before
+     merge** — never merge on a non-CLEAN / BLOCKED status; BLOCKED is usually
+     just pending required checks → poll, don't force.
+   - Secrets: `gh secret set <NAME>` **without `--body`** (interactive paste keeps
+     the value out of shell history); verify with `gh secret list` (values are
+     write-only).
+   - Submodule pin bump: `git update-index --cacheinfo 160000,<sha>,<path>`
+     (surgical gitlink set; no submodule checkout needed in a worktree).
+   - `--no-verify`: allowed **only** for commits with no code and no secrets (e.g.
+     a submodule-pin bump or config-only change) when a repo's pre-commit gate is
+     heavy/slow; never for code/content commits. State the judgment rule.
+   - Shared repo / submodule: edit via an isolated worktree + PR, never in place
+     (cross-ref `subagent-conflict-detection`).
+4. **Repo settings (contribution-flow only)** — merge-button config (squash-only,
+   auto-delete head branch), branch protection requiring CI, required status
+   checks, labels. Security settings (secret scanning, push protection) are
+   explicitly deferred to `apple-public-repo-security`.
+5. **Common Mistakes** + **Review Checklist** (the catalog's bookend convention).
+6. **Related skills** — the four siblings by name.
+
+## Consistency-gate impact
+
+- `README.md` Catalog: add a `github-contribution-workflow` row under
+  collaboration-skills; bump the group header `(11)` → `(12)`.
+- `collaboration-skills/.claude-plugin/plugin.json`: description "11 first-party" →
+  "12 first-party"; version bump `1.2.0` → `1.3.0`.
+- `.claude-plugin/marketplace.json`: collaboration-skills `description` "11" → "12";
+  version `1.2.0` → `1.3.0`; marketplace `metadata.version` bump.
+- Regenerate `README.zh-Hant.md` (`mise run readme-zh`).
+- `mise run check` green.
+
+## Success criteria
+
+- `mise run check` passes; the new skill's `name` matches its dir.
+- `description` is router-form with the `gh` commands embedded and a negative
+  boundary.
+- A scope-boundary line routes each non-owned concern to the correct sibling; no
+  content duplicates a sibling.
+- README Catalog + counts + plugin.json + zh-Hant all consistent.
+
+## Issue / PR tracking (user-requested workflow)
+
+- This spec is recorded in a GitHub issue on `wei18/apple-dev-skills`.
+- The implementation plan (writing-plans output) is appended to that issue.
+- The implementation PR links and closes the issue.

--- a/scripts/check-consistency.py
+++ b/scripts/check-consistency.py
@@ -16,7 +16,7 @@ import json, re, subprocess, sys
 from pathlib import Path
 
 ROOT = Path(__file__).resolve().parent.parent
-PLUGINS = {"apple-dev-skills": 20, "collaboration-skills": 11}
+PLUGINS = {"apple-dev-skills": 20, "collaboration-skills": 12}
 EXTERNALS = {"apple-skills", "swiftui-expert", "swiftui-pro", "caveman", "ponytail"}
 errors: list[str] = []
 def fail(m): errors.append(m)


### PR DESCRIPTION
Adds the 12th collaboration skill — the **gh-CLI contribution loop** (PRs, issues, GitHub file ops, secrets, contribution-flow repo settings) encoding this catalog's conventions (Conventional branch/PR titles, `Co-Authored-By` + 🤖 footer, squash+delete, **CLEAN-before-merge**, `gh secret set` without `--body`, `git update-index` submodule bumps, the `--no-verify` rule, worktree+PR for shared repos).

Composes with — does not duplicate — `pr-diff-verification`, `apple-public-repo-security`, `subagent-conflict-detection`, `claude-skill-plugin-packaging` via a scope boundary. Bumps `collaboration-skills` + marketplace to **1.3.0**.

Spec: `docs/superpowers/specs/2026-06-25-github-contribution-workflow-design.md`
Plan: `docs/superpowers/plans/2026-06-25-github-contribution-workflow.md`

Closes #8

🤖 Generated with [Claude Code](https://claude.com/claude-code)