### PR TITLE
docs(skills): trim project-diary bloat + dedupe Dynamic Type (Lens 2 T1-T3)

### DIFF
--- a/apple-dev-skills/skills/build-time-secret-injection/SKILL.md
+++ b/apple-dev-skills/skills/build-time-secret-injection/SKILL.md
@@ -5,10 +5,6 @@ description: Use when introducing an AdMob production ID (`GADApplicationIdentif
 
 # Build-time Secret Injection (Apple-platform)
 
-## Known testing gap
-
-**This skill shipped without a TDD baseline test** (see `superpowers:writing-skills` Iron Law). The loophole list below is best-effort, captured retroactively from one incident (a production AdMob App ID leaked into an Info.plist comment in a PR) and one Architect review. Treat the rationalizations table as incomplete; revise on next leak incident.
-
 ## When to invoke
 
 Any task that introduces or wires values which are:
@@ -144,17 +140,6 @@ A future PR should add a build-phase script that asserts no `$()` literals survi
 
 8. **Tuist `tuist generate` silently clobbering unmanaged xcconfigs.** If `Tuist/<Domain>.xcconfig` exists but is NOT referenced in `Project.swift`'s `.settings(configurations:)`, Tuist regen drops it from the project. Verify Project.swift wiring before assuming xcconfig is active.
 
-## Rationalizations table
-
-| Rationalization | Counter |
-|---|---|
-| "But this is just a TODO comment, not the actual value" | Including the literal ID anywhere in tracked text IS the leak. Reference memory/secrets files by name, never paste the value. |
-| "But the prod ID ships in the binary anyway" | Two adversary models: (a) pre-launch reconnaissance / ad-fraud preparation against the still-empty unit, (b) leak-through-co-authors. Both warrant pre-launch holdback. |
-| "But our project doesn't use Tuist" | Pattern still applies; replace `Tuist/<Domain>.xcconfig` with `Config/<Domain>.xcconfig` referenced via target Base Configuration. |
-| "But our app is private repo, who cares" | Applies when (a) repo may go public later (see [[apple-public-repo-security]]) or (b) collaborator set is broader than production-credential trust set. |
-| "It's a 1-time integration; the skill is overkill" | No threshold. The FIRST secret is the one that establishes the leak channel. |
-| "`fatalError("REPLACE_IN_...")` is fine for now; I'll migrate later" | fatalError-only is forbidden going forward. xcconfig + transitional fatalError IS the allowed combined state during one release cycle. |
-
 ## Checklist when adding a new secret value
 
 1. Decide layer:
@@ -188,18 +173,6 @@ A future PR should add a build-phase script that asserts no `$()` literals survi
 - **SIBLING**: your ASC submission-ops workflow (who may push what) — ASC API key handling more broadly
 - Project memory file documenting the secret-scrubbing incident — the incident that triggered this skill pattern
 - Project memory files for each credential set — real values held outside repo (cite by memory-file name, never paste inline)
-
-## Migration playbook
-
-**Disclosure**: In a real project, the initial AdMob secret-injection migration compressed the Architect's recommended 7-stage plan into a single PR. The sequence below reflects that compressed landing pattern, NOT the gold-standard staging. An Architect review session produced a 7-PR staged plan; save that detail in your own meeting log.
-
-| PR | Scope | Notes |
-|---|---|---|
-| 1 | Scaffolding + Info.plist substitution + Live.swift Bundle.main + smoke tests + ci_post_clone.sh extension + secrets/.env.example (all in one) | Compressed shape. Architect would split into 3 PRs. |
-| 2 | Build-phase substitution-resolution check (asserts no `$()` literals in built bundle) | Strictly stronger safety net than runtime guard alone. |
-| 3 | gitleaks rule for `ca-app-pub-[0-9]{16}~[0-9]+` excluding Google universal test prefix | Closes the comment-leak class. |
-| 4 | After two successful production releases via XCC env vars, remove transitional `fatalError` gates (if any remain) | Belt-and-suspenders graduation. |
-| 5 | ADR + `docs/foundations.md` update | Locks the decision history. |
 
 ## AdMob env keys pattern
 

--- a/apple-dev-skills/skills/ios-accessibility-engineering/SKILL.md
+++ b/apple-dev-skills/skills/ios-accessibility-engineering/SKILL.md
@@ -66,8 +66,7 @@ In UIKit: `UIAccessibility.post(notification: .announcement, argument: "Level co
 - Use `Font.body`, `.headline`, `.caption` etc. (text styles), or `UIFont.preferredFont(forTextStyle:)` in UIKit. Never hard-code `Font.system(size: 17)` without a text style.
 - SwiftUI text styles scale automatically. If a control must cap scaling (compact digit grids, icon labels), apply `.dynamicTypeSize(...DynamicTypeSize.xLarge)` — this clamps only sizes above `.xLarge`; default `.large` stays byte-identical and snapshot baselines are unaffected.
 - Test at AX5 (`accessibility-extra-extra-extra-large`) in Simulator: `xcrun simctl ui <udid> content_size accessibility-extra-extra-extra-large`.
-- **`minimumScaleFactor` is width-only.** It shrinks glyphs that overflow horizontally; it does nothing for a glyph that overflows vertically. A digit at AX5 can be 50–60pt tall inside a 44pt cell — `minimumScaleFactor` never engages and the cell just clips blank. The fix is a size cap, not a scale factor.
-- In `fullScreenCover` / `sheet` modals, `@Environment(\.dynamicTypeSize)` can return a stale value from the presenting context. Use geometry-driven layout (`ViewThatFits`) rather than an `if dynamicTypeSize.isAccessibilitySize` branch inside a modal.
+- **`minimumScaleFactor` is width-only** — it won't rescue a glyph that overflows *vertically* (a tall digit clips blank in a short cell); cap the size instead. In `fullScreenCover` / `sheet` modals `@Environment(\.dynamicTypeSize)` can read stale — use geometry-driven layout (`ViewThatFits`). See `swiftui-interaction-footguns` for both traps in full.
 - Avoid fixed `frame(height:)` on text containers; prefer `frame(minHeight:)` with unlimited vertical growth.
 
 ## Touch targets

--- a/apple-dev-skills/skills/swiftui-interaction-footguns/SKILL.md
+++ b/apple-dev-skills/skills/swiftui-interaction-footguns/SKILL.md
@@ -92,7 +92,6 @@ A class of bugs that look fine in code but break at runtime. These have shipped 
 - **Tap-target shrink** — A home screen mode card used `Button { } label: { card-with-Spacer }` with `.buttonStyle(.plain)`, shrinking the tap target to drawn content only. Caught by macOS smoke test, **not** by Code Reviewer. Fix: `.contentShape(Rectangle())`.
 - **Inert sidebar Labels** — Mac `NavigationSplitView` sidebar items were bare `Label`s with no `NavigationLink` / `Button`, so clicking did nothing. Same review-blind-spot path.
 - **Blank `fullScreenCover`** — A near-win hook presented a **blank** `fullScreenCover`: `fullScreenCover(isPresented: $bool)` + a separate optional `@State` for content, set back-to-back, raced → content closure's `if let` rendered the empty branch (a11y tree = 1 element vs 99 for a real board). Dual-model CR + unit tests passed; only the idb interactive audit caught it. Fix: `fullScreenCover(item:)` with an `Identifiable` payload.
-- (Future: append as more are caught.)
 
 ## Related skills
 


### PR DESCRIPTION
Accepted trims from the **Lens-2 ponytail audit** (#10) — pure content slimming, no count/version/zh-Hant change, no routing cost.

- **T1** `build-time-secret-injection`: cut the "Known testing gap" confession, the **Migration playbook** (one project's PR history), and the **Rationalizations** table (restated the Anti-patterns). Kept the load-bearing gotchas (shell-env-vs-`$(VAR)`, source-plist-vs-built-bundle false-pass).
- **T2** dedupe the `minimumScaleFactor` / Dynamic Type passage duplicated near-verbatim in `ios-accessibility-engineering` and `swiftui-interaction-footguns` → a11y now points to footguns (already its named owner).
- **T3** `swiftui-interaction-footguns`: drop the `(Future: append…)` TODO marker. Sightings kept — they carry the "caught by X not Y" detection evidence the checklist lacks.

`mise run check` green.

Relates to #10

🤖 Generated with [Claude Code](https://claude.com/claude-code)