### PR TITLE
chore(release): v1.3.1

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -3,14 +3,14 @@
   "owner": { "name": "Wei18" },
   "metadata": {
     "description": "A curated catalog of skills for AI coding agents — first-party Apple/Swift and agent-collaboration skills, plus aggregated best-of-breed external plugins (credited to their authors)",
-    "version": "1.3.0"
+    "version": "1.3.1"
   },
   "plugins": [
     {
       "name": "apple-dev-skills",
       "source": "./apple-dev-skills",
       "description": "20 first-party Apple/Swift skills. Namespaced apple-dev-skills:<skill>.",
-      "version": "1.1.0",
+      "version": "1.1.1",
       "author": { "name": "Wei18" },
       "keywords": ["swift", "ios", "macos", "apple-platform", "claude-code", "agent-skills"],
       "category": "workflow"
@@ -19,7 +19,7 @@
       "name": "collaboration-skills",
       "source": "./collaboration-skills",
       "description": "12 first-party AI-agent collaboration & process skills. Namespaced collaboration-skills:<skill>.",
-      "version": "1.3.0",
+      "version": "1.3.1",
       "author": { "name": "Wei18" },
       "keywords": ["claude-code", "agent-skills", "ai-agents", "workflow", "collaboration"],
       "category": "workflow"

--- a/apple-dev-skills/.claude-plugin/plugin.json
+++ b/apple-dev-skills/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "apple-dev-skills",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "20 first-party Apple/Swift skills for AI-agent development — Swift 6 / SwiftPM / testing / CI / L10n / telemetry defaults, security & secrets, monetization, App Review, SwiftUI footguns, plus accessibility, dependency injection, and performance engineering. Distilled from a real shipping project and public Apple/standards docs.",
   "author": { "name": "Wei18" },
   "homepage": "https://github.com/wei18/apple-dev-skills",

--- a/collaboration-skills/.claude-plugin/plugin.json
+++ b/collaboration-skills/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "collaboration-skills",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "description": "12 first-party AI-agent collaboration & process skills — spec-phase orchestration, Leader/Developer handoff contract, subagent review cycles & conflict detection, impl-notes & meeting logs, methodology extraction, backlog routing, PR-diff verification, Claude Code skill-plugin packaging, skill-authoring patterns, and GitHub contribution workflow. Tool-agnostic agent process, not Apple-specific.",
   "author": { "name": "Wei18" },
   "homepage": "https://github.com/wei18/apple-dev-skills",


### PR DESCRIPTION
Patch release bundling the non-review-lens audit fixes (#10, PRs #11–#15) — all doc/description refinements, no skill added or removed:

- router-boundary disambiguation (secret skills), project-diary trims, description compression, de-brittled dated claims, compose-with-externals pointers, positioning moat in README.

Versions: apple-dev-skills `1.1.0 → 1.1.1`, collaboration-skills `1.3.0 → 1.3.1`, marketplace `1.3.0 → 1.3.1`. Counts unchanged (20/12). `mise run check` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)