### PR TITLE
fix: converge stale collaboration count to 12 + widen consistency gate

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ This repo is one **marketplace** hosting two first-party plugins and several agg
 ```
 /plugin marketplace add wei18/apple-dev-skills
 /plugin install apple-dev-skills@apple-dev-skills          # 20 Apple/Swift skills
-/plugin install collaboration-skills@apple-dev-skills      # 10 agent-collaboration skills
+/plugin install collaboration-skills@apple-dev-skills      # 12 agent-collaboration skills
 ```
 
 Install either or both. Externals install the same way, e.g. `/plugin install swiftui-expert@apple-dev-skills`.
@@ -31,7 +31,7 @@ plugins load from the pinned submodule (collaborators are prompted to trust the 
 
 ```bash
 git submodule add https://github.com/wei18/apple-dev-skills.git .claude/skills/apple-dev-skills
-cd .claude/skills/apple-dev-skills && git checkout v1.2.0 && cd -
+cd .claude/skills/apple-dev-skills && git checkout v1.3.1 && cd -
 ```
 
 `.claude/settings.json` (committed):

--- a/README.zh-Hant.md
+++ b/README.zh-Hant.md
@@ -19,7 +19,7 @@
 ```
 /plugin marketplace add wei18/apple-dev-skills
 /plugin install apple-dev-skills@apple-dev-skills          # 20 Apple/Swift skills
-/plugin install collaboration-skills@apple-dev-skills      # 10 agent-collaboration skills
+/plugin install collaboration-skills@apple-dev-skills      # 12 agent-collaboration skills
 ```
 
 兩者擇一或全裝皆可。外部來源以相同方式安裝，例如 `/plugin install swiftui-expert@apple-dev-skills`。
@@ -31,7 +31,7 @@
 
 ```bash
 git submodule add https://github.com/wei18/apple-dev-skills.git .claude/skills/apple-dev-skills
-cd .claude/skills/apple-dev-skills && git checkout v1.2.0 && cd -
+cd .claude/skills/apple-dev-skills && git checkout v1.3.1 && cd -
 ```
 
 `.claude/settings.json`（已提交）：
@@ -126,4 +126,4 @@ npx skills add wei18/apple-dev-skills --skill swift6-concurrency
 出貨 Apple 平台遊戲作品集——再加上對公開的 Apple / WCAG / Swift 標準的原創撰述。
 彙整的外部來源仍屬其作者所有，僅以引用方式呈現。MIT——見 [LICENSE](LICENSE)。
 
-<!-- src-sha: b0cc7f450d7bf5691a5d64997e9579f9aca8c30a -->
+<!-- src-sha: 4e4537e5aac82af649dccfa8eddf7141fb205def -->

--- a/scripts/check-consistency.py
+++ b/scripts/check-consistency.py
@@ -3,9 +3,10 @@
 
 Checks
   1. Each <plugin>/skills/<dir>/ has a SKILL.md whose frontmatter name == <dir>.
-  2. README.md Catalog lists exactly the union of both plugins' skills (30) AND the
+  2. README.md Catalog lists exactly the union of both plugins' skills (32) AND the
      five aggregated external plugin names (set-equality, both directions).
-  3. Counts match: README group headers (20)/(10)/(5) and each plugin.json's "N first-party".
+  3. Counts match: README group headers (20)/(12)/(5), the Install one-liner comments,
+     and each plugin.json's "N first-party".
   4. README.zh-Hant.md exists and its embedded src-sha == git hash-object README.md.
   5. All plugin/marketplace JSON parse; the two subdir plugin sources resolve to dirs;
      marketplace.json lists exactly the 7 plugins (2 local + 5 externals).
@@ -74,6 +75,11 @@ for plugin, expected in PLUGINS.items():
     except Exception as e: fail(f"[manifest] {plugin}/plugin.json invalid: {e}"); continue
     for c in re.findall(r"(\d+)\s+first-party", d.get("description", "")):
         if int(c) != expected: fail(f"[manifest] {plugin} says '{c} first-party', expected {expected}")
+
+# 3b. Install one-liner comments (outside the Catalog section, so scoped() misses them)
+for plugin, n in re.findall(r"/plugin install (\S+?)@apple-dev-skills\s+#\s*(\d+)\b", readme):
+    if plugin in PLUGINS and int(n) != PLUGINS[plugin]:
+        fail(f"[readme] Install comment says '{n}' for {plugin}, expected {PLUGINS[plugin]}")
 
 # 4. zh-Hant freshness
 zh = ROOT / "README.zh-Hant.md"


### PR DESCRIPTION
Resolves the actionable findings from the Upkeep audit in #17.

## What the audit found
A stale collaboration-skills count of **10** lingered in human-facing artifacts after the catalog grew to **12 (32 total)**. The drift escaped the consistency gate because its count check is scoped only to the `## Catalog` section.

## Changes
- **README.md** — Install one-liner comment `10 → 12`; Option-B submodule pin example `v1.2.0 → v1.3.1` (current release).
- **README.zh-Hant.md** — mirror the two code-fence lines + refresh `src-sha`. Hand-mirrored rather than full `mise run readme-zh` regen because README's only changes are two **verbatim code-fence lines** (no translatable prose changed) — a full regen produced ~40 lines of non-deterministic synonym churn for a 2-line content fix. Translation stays faithful; `src-sha` does not lie.
- **scripts/check-consistency.py** — fix stale docstring counts (`30→32`, `(20)/(10)/(5) → (20)/(12)/(5)`); **add check 3b** validating the Install one-liner comments against `PLUGINS`, so this drift class is caught automatically going forward.

## Decisions (per maintainer)
- **Spec doc** (`docs/superpowers/specs/…from-scratch-design.md`) left **as-is** — point-in-time historical design artifact (the 2 extra skills were added later; its `30 → 20/10` narrative is accurate for what that design did).
- **Orphan plan docs** — expected for terminal design artifacts; no action.

## Verification
```
$ python3 scripts/check-consistency.py
OK — 2 plugins (20/12), catalog + counts + zh-Hant consistent.
```
Negative-tested the new check: reverting the Install comment to `10` fires
`[readme] Install comment says '10' for collaboration-skills, expected 12`.

Closes #17

🤖 Generated with [Claude Code](https://claude.com/claude-code)