### PR TITLE
feat(tooling): version-pin + description-length gate checks, one-shot release bump

### DIFF
--- a/.mise.toml
+++ b/.mise.toml
@@ -8,3 +8,7 @@ run = "python3 scripts/check-consistency.py"
 [tasks.readme-zh]
 description = "Regenerate README.zh-Hant.md from README.md (needs claude on PATH)"
 run = "scripts/gen-readme-zh.sh"
+
+[tasks.bump]
+description = "Bump release versions on all gate-checked surfaces (e.g. mise run bump -- --marketplace 1.4.0 --collab 1.4.0)"
+run = "python3 scripts/bump-version.py"

--- a/scripts/bump-version.py
+++ b/scripts/bump-version.py
@@ -1,0 +1,93 @@
+#!/usr/bin/env python3
+"""Bump release versions across every surface the gate checks, in one shot.
+
+Surfaces (previously a 4-file manual dance, see v1.3.1 / PR #16):
+  --marketplace X.Y.Z  -> marketplace.json metadata.version
+                          + `git checkout vX.Y.Z` pin in README.md AND README.zh-Hant.md
+                          + re-stamp README.zh-Hant.md src-sha (pin line is hand-mirrored;
+                            no full zh regeneration needed for this one-line change)
+  --apple X.Y.Z        -> apple-dev-skills/.claude-plugin/plugin.json version
+                          + its marketplace.json plugins[] entry version
+  --collab X.Y.Z       -> same pair for collaboration-skills
+
+Edits are targeted text substitutions (never a JSON load->dump round-trip, which
+would reflow the hand-formatted single-line objects into a noise diff).
+Ends by running check-consistency.py. Tag `vX.Y.Z` manually after the PR merges.
+
+Usage: mise run bump -- --marketplace 1.4.0 --collab 1.4.0
+Stdlib only.
+"""
+from __future__ import annotations
+import argparse, json, re, subprocess, sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+MP = ROOT / ".claude-plugin" / "marketplace.json"
+SEMVER = r"\d+\.\d+\.\d+"
+
+
+def die(msg: str):
+    print(f"ERROR: {msg}", file=sys.stderr); sys.exit(1)
+
+
+def sub_once(text: str, pattern: str, repl: str, where: str) -> str:
+    new, n = re.subn(pattern, repl, text, count=1, flags=re.DOTALL)
+    if n != 1: die(f"pattern not found in {where}: {pattern}")
+    return new
+
+
+def set_plugin_version(plugin_dir: str, version: str):
+    pj = ROOT / plugin_dir / ".claude-plugin" / "plugin.json"
+    pj.write_text(sub_once(pj.read_text(encoding="utf-8"),
+                           r'("version"\s*:\s*")' + SEMVER + r'(")',
+                           rf"\g<1>{version}\g<2>", str(pj)), encoding="utf-8")
+    mp_text = MP.read_text(encoding="utf-8")
+    MP.write_text(sub_once(mp_text,
+                           rf'("name"\s*:\s*"{plugin_dir}"[^}}]*?"version"\s*:\s*")' + SEMVER + r'(")',
+                           rf"\g<1>{version}\g<2>", f"marketplace plugins[{plugin_dir}]"),
+                  encoding="utf-8")
+    print(f"  {plugin_dir}: -> {version} (plugin.json + marketplace entry)")
+
+
+def set_marketplace_version(version: str):
+    MP.write_text(sub_once(MP.read_text(encoding="utf-8"),
+                           r'("metadata"\s*:\s*\{[^}]*?"version"\s*:\s*")' + SEMVER + r'(")',
+                           rf"\g<1>{version}\g<2>", "marketplace metadata"), encoding="utf-8")
+    for name in ("README.md", "README.zh-Hant.md"):
+        p = ROOT / name
+        text, n = re.subn(rf"git checkout v{SEMVER}", f"git checkout v{version}",
+                          p.read_text(encoding="utf-8"))
+        if n == 0: die(f"no 'git checkout v<semver>' pin in {name}")
+        p.write_text(text, encoding="utf-8")
+    sha = subprocess.run(["git", "hash-object", "README.md"], cwd=ROOT,
+                         capture_output=True, text=True, check=True).stdout.strip()
+    zh = ROOT / "README.zh-Hant.md"
+    zh.write_text(sub_once(zh.read_text(encoding="utf-8"),
+                           r"(<!-- src-sha: )[0-9a-f]+( -->)", rf"\g<1>{sha}\g<2>",
+                           "zh-Hant src-sha"), encoding="utf-8")
+    print(f"  marketplace metadata + README pins: -> {version} (zh src-sha re-stamped)")
+
+
+def main():
+    sys.stdout.reconfigure(line_buffering=True)  # keep our lines ordered before the gate subprocess's
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--marketplace", metavar="X.Y.Z")
+    ap.add_argument("--apple", metavar="X.Y.Z")
+    ap.add_argument("--collab", metavar="X.Y.Z")
+    args = ap.parse_args()
+    if not (args.marketplace or args.apple or args.collab):
+        ap.error("nothing to bump — pass at least one of --marketplace/--apple/--collab")
+    for v in (args.marketplace, args.apple, args.collab):
+        if v and not re.fullmatch(SEMVER, v): die(f"not a semver: {v}")
+
+    if args.apple: set_plugin_version("apple-dev-skills", args.apple)
+    if args.collab: set_plugin_version("collaboration-skills", args.collab)
+    if args.marketplace: set_marketplace_version(args.marketplace)
+
+    json.loads(MP.read_text(encoding="utf-8"))  # still valid JSON after text edits
+    print("running gate...")
+    sys.exit(subprocess.run([sys.executable, str(ROOT / "scripts" / "check-consistency.py")]).returncode)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/check-consistency.py
+++ b/scripts/check-consistency.py
@@ -10,6 +10,10 @@ Checks
   4. README.zh-Hant.md exists and its embedded src-sha == git hash-object README.md.
   5. All plugin/marketplace JSON parse; the two subdir plugin sources resolve to dirs;
      marketplace.json lists exactly the 7 plugins (2 local + 5 externals).
+  6. The `git checkout v<semver>` pin in both READMEs' Install section ==
+     marketplace.json metadata.version (drifted silently before: v1.2.0 → #17).
+  7. Each SKILL.md frontmatter description <= DESC_MAX chars (descriptions are
+     always-on context for every consumer session; keeps Lens-3 compression durable).
 Stdlib only.
 """
 from __future__ import annotations
@@ -19,15 +23,16 @@ from pathlib import Path
 ROOT = Path(__file__).resolve().parent.parent
 PLUGINS = {"apple-dev-skills": 20, "collaboration-skills": 12}
 EXTERNALS = {"apple-skills", "swiftui-expert", "swiftui-pro", "caveman", "ponytail"}
+DESC_MAX = 800  # current max is 795 (github-contribution-workflow); cap future growth
 errors: list[str] = []
 def fail(m): errors.append(m)
 
-def fm_name(p: Path):
+def fm_field(p: Path, field: str):
     t = p.read_text(encoding="utf-8")
     if not t.startswith("---"): return None
     end = t.find("\n---", 3)
     if end == -1: return None
-    m = re.search(r"^name:\s*(.+?)\s*$", t[3:end], re.MULTILINE)
+    m = re.search(rf"^{field}:\s*(.+?)\s*$", t[3:end], re.MULTILINE)
     return m.group(1).strip() if m else None
 
 # 1. skill dirs + frontmatter
@@ -41,8 +46,13 @@ for plugin, expected in PLUGINS.items():
         all_skills.add(name)
         md = sdir / name / "SKILL.md"
         if not md.is_file(): fail(f"[skill] {plugin}/{name}: no SKILL.md"); continue
-        fn = fm_name(md)
+        fn = fm_field(md, "name")
         if fn != name: fail(f"[skill] {plugin}/{name}: frontmatter name={fn!r} != dir")
+        # 7. description length budget
+        desc = fm_field(md, "description")
+        if desc is None: fail(f"[skill] {plugin}/{name}: no frontmatter description")
+        elif len(desc) > DESC_MAX:
+            fail(f"[skill] {plugin}/{name}: description {len(desc)} chars > {DESC_MAX}")
 
 # helper: scope README Catalog section
 def scoped(text: str, *markers: str) -> str:
@@ -104,6 +114,16 @@ try:
     expected_names = set(PLUGINS) | EXTERNALS
     if names != expected_names:
         fail(f"[marketplace] plugin set mismatch — missing: {sorted(expected_names - names)}, extra: {sorted(names - expected_names)}")
+    # 6. README Install pin == marketplace metadata.version
+    mp_version = d.get("metadata", {}).get("version", "")
+    for readme_name in ("README.md", "README.zh-Hant.md"):
+        text = (ROOT / readme_name).read_text(encoding="utf-8") if (ROOT / readme_name).is_file() else ""
+        pins = re.findall(r"git checkout v(\d+\.\d+\.\d+)", text)
+        if not pins:
+            fail(f"[readme] {readme_name}: no 'git checkout v<semver>' pin found")
+        for pin in pins:
+            if pin != mp_version:
+                fail(f"[readme] {readme_name}: Install pin v{pin} != marketplace metadata.version {mp_version} — run `mise run bump`")
 except Exception as e:
     fail(f"[marketplace] invalid: {e}")
 


### PR DESCRIPTION
Hardens two recurrence-proven drift points and mechanizes the release bump:

- **Gate check 6 — version pin**: the `git checkout vX.Y.Z` example in both READMEs' Install section must equal `marketplace.json` `metadata.version`. This drifted silently before (v1.2.0, fixed in #18); now it fails CI instead.
- **Gate check 7 — description budget**: every SKILL.md frontmatter description ≤ 800 chars (current max 795). Descriptions are always-on context for every consumer session; this makes the Lens-3 compression durable rather than one-time.
- **`mise run bump`** (`scripts/bump-version.py`): bumps marketplace metadata version, per-plugin versions (plugin.json + marketplace entry), both README pins, and re-stamps the zh-Hant `src-sha` in one shot, then runs the gate. Previously a 4-surface manual dance (v1.3.1 release). Targeted text substitution — no JSON load→dump reflow noise.

Verified: gate green on unchanged tree; negative tests red for a drifted pin and a 900-char description; full bump dry-run (`--marketplace 1.4.0 --collab 1.4.0`) on a scratch copy touches exactly the 6 intended lines and ends green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)