### PR TITLE
chore(release): v1.4.0 — gate hardening + release tooling + feedback loop

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -3,7 +3,7 @@
   "owner": { "name": "Wei18" },
   "metadata": {
     "description": "A curated catalog of skills for AI coding agents — first-party Apple/Swift and agent-collaboration skills, plus aggregated best-of-breed external plugins (credited to their authors)",
-    "version": "1.3.1"
+    "version": "1.4.0"
   },
   "plugins": [
     {

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ plugins load from the pinned submodule (collaborators are prompted to trust the 
 
 ```bash
 git submodule add https://github.com/wei18/apple-dev-skills.git .claude/skills/apple-dev-skills
-cd .claude/skills/apple-dev-skills && git checkout v1.3.1 && cd -
+cd .claude/skills/apple-dev-skills && git checkout v1.4.0 && cd -
 ```
 
 `.claude/settings.json` (committed):

--- a/README.zh-Hant.md
+++ b/README.zh-Hant.md
@@ -31,7 +31,7 @@
 
 ```bash
 git submodule add https://github.com/wei18/apple-dev-skills.git .claude/skills/apple-dev-skills
-cd .claude/skills/apple-dev-skills && git checkout v1.3.1 && cd -
+cd .claude/skills/apple-dev-skills && git checkout v1.4.0 && cd -
 ```
 
 `.claude/settings.json`（已提交）：
@@ -126,4 +126,4 @@ npx skills add wei18/apple-dev-skills --skill swift6-concurrency
 出貨 Apple 平台遊戲作品集——再加上對公開的 Apple / WCAG / Swift 標準的原創撰述。
 彙整的外部來源仍屬其作者所有，僅以引用方式呈現。MIT——見 [LICENSE](LICENSE)。
 
-<!-- src-sha: 4e4537e5aac82af649dccfa8eddf7141fb205def -->
+<!-- src-sha: 02506caa506203bf93586deef094661ef9a5f9a4 -->


### PR DESCRIPTION
Bumps marketplace metadata + both README Install pins to **v1.4.0** (this PR was produced by the new `mise run bump -- --marketplace 1.4.0` — 4 surgical lines, gate auto-ran green; committed per the new `LEFTHOOK_EXCLUDE=readme-zh` hand-mirror convention).

Plugin versions intentionally unchanged (no skill content changed since v1.3.1): apple-dev-skills 1.1.1, collaboration-skills 1.3.1.

Release notes since v1.3.1: #20 (gate checks 6+7, bump task), #21 (zh-Hant hand-mirror convention), #22 (field-note template).

Tag `v1.4.0` follows after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)