### PR TITLE
fix: resolve upkeep audit findings — archive frozen docs, bidirectional language switcher, honest gate docstring

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 > and **AI-agent-collaboration** skills, plus best-of-breed **external** skill plugins aggregated
 > **by reference** (credited to their authors, never copied).
 >
-> 繁體中文：[`README.zh-Hant.md`](README.zh-Hant.md)
+> Languages: [English](README.md) · [繁體中文](README.zh-Hant.md)
 
 This repo is one **marketplace** hosting two first-party plugins and several aggregated externals.
 

--- a/README.zh-Hant.md
+++ b/README.zh-Hant.md
@@ -5,7 +5,7 @@
 > 與 **AI 代理協作**技能，外加**以引用方式**彙整的同類最佳**外部**技能外掛
 > （歸功於原作者，絕不複製）。
 >
-> 繁體中文：[`README.zh-Hant.md`](README.zh-Hant.md)
+> 語言：[English](README.md) · [繁體中文](README.zh-Hant.md)
 
 本倉庫是一個**市集（marketplace）**，內含兩個第一方外掛，並彙整數個外部來源。
 
@@ -126,4 +126,4 @@ npx skills add wei18/apple-dev-skills --skill swift6-concurrency
 出貨 Apple 平台遊戲作品集——再加上對公開的 Apple / WCAG / Swift 標準的原創撰述。
 彙整的外部來源仍屬其作者所有，僅以引用方式呈現。MIT——見 [LICENSE](LICENSE)。
 
-<!-- src-sha: 02506caa506203bf93586deef094661ef9a5f9a4 -->
+<!-- src-sha: 158e9f0e69deee37fcd0f56deb30ebb02745bfcf -->

--- a/collaboration-skills/skills/skill-authoring-patterns/SKILL.md
+++ b/collaboration-skills/skills/skill-authoring-patterns/SKILL.md
@@ -43,9 +43,9 @@ GOOD: description: VoiceOver / Dynamic Type / touch-target implementation for Sw
 Order the middle by the topic's pedagogy, but keep these conventions:
 
 - **`## Rationale`** — *why* this default was chosen. Unique to this catalog; keep it.
-- **`## Deviation`** — *when to override* the default, and the cost. Also ours; keep it. (Example: "Drop to iOS 17 when targeting education devices — you lose full Observation behaviour.")
-- **`## Common Mistakes`** — concrete, anti-pattern-named items ("Using `DateFormatter()` in `body`"), as many as are real — do not pad to a number.
-- **`## Review Checklist`** — a `- [ ]` list at the **end**, runnable top-to-bottom.
+- **`## Deviation considerations`** — *when to override* the default, and the cost. Also ours; keep it. (Example: "Drop to iOS 17 when targeting education devices — you lose full Observation behaviour." This heading is the catalog-wide form — most first-party skills use it.)
+- **`## Common Mistakes`** — concrete, anti-pattern-named items ("Using `DateFormatter()` in `body`"), as many as are real — do not pad to a number. *For new skills*; most pre-existing skills express this as inline anti-pattern sections instead and are not retrofitted.
+- **`## Review Checklist`** — a `- [ ]` list at the **end**, runnable top-to-bottom. *For new skills*; older skills use a prose `## Verification checklist` and are not retrofitted.
 - **`## Related skills`** — siblings by name.
 
 Use a **scope-boundary** line in the body wherever a sibling is close ("owns X; does NOT own Y → route to `<sibling>`") — this is what stops two framework skills both claiming the same request.
@@ -63,7 +63,7 @@ description: <precision router — see above>
 ## Scope            ← what it does NOT own → sibling
 ## <body: triage/workflow → decision table → rules → code>
 ## Rationale
-## Deviation
+## Deviation considerations
 ## Common Mistakes
 ## Review Checklist
 ## References        ← only if it has references/

--- a/docs/superpowers/README.md
+++ b/docs/superpowers/README.md
@@ -1,0 +1,16 @@
+# docs/superpowers — historical archive
+
+These are the **frozen** design specs and implementation plans that produced the
+current repo shape. They are terminal artifacts, superseded by the shipped repo:
+**`README.md` is the SSOT** — counts, versions, and structure in these documents
+reflect the moment they were written (e.g. "10 collaboration skills / 30 total",
+"version 1.3.0") and are intentionally **not** kept current.
+
+| Document | Produced |
+|---|---|
+| [specs/2026-06-24-apple-dev-skills-from-scratch-design.md](specs/2026-06-24-apple-dev-skills-from-scratch-design.md) | Two-plugin marketplace restructure (design) |
+| [plans/2026-06-24-apple-dev-skills-restructure.md](plans/2026-06-24-apple-dev-skills-restructure.md) | Two-plugin restructure (implementation plan) |
+| [specs/2026-06-25-github-contribution-workflow-design.md](specs/2026-06-25-github-contribution-workflow-design.md) | `github-contribution-workflow` skill (design) |
+| [plans/2026-06-25-github-contribution-workflow.md](plans/2026-06-25-github-contribution-workflow.md) | `github-contribution-workflow` skill (implementation plan) |
+
+Do not update these documents; write new dated ones for new work.

--- a/docs/superpowers/plans/2026-06-24-apple-dev-skills-restructure.md
+++ b/docs/superpowers/plans/2026-06-24-apple-dev-skills-restructure.md
@@ -1,5 +1,9 @@
 # apple-dev-skills Two-Plugin Restructure — Implementation Plan
 
+> Status: Implemented — historical archive, superseded by the shipped repo.
+> Counts/versions below are as-written (10 collaboration skills / 30 total);
+> current numbers live in the SSOT [`README.md`](../../../README.md).
+
 > **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
 
 **Goal:** Re-lay out `wei18/apple-dev-skills` from one 30-skill plugin into one marketplace hosting two first-party plugins (`apple-dev-skills` 20 / `collaboration-skills` 10) plus five by-reference externals, with a lean SSOT README, a pre-commit-generated zh-Hant mirror, and a consistency gate — all driven through mise tasks.

--- a/docs/superpowers/plans/2026-06-25-github-contribution-workflow.md
+++ b/docs/superpowers/plans/2026-06-25-github-contribution-workflow.md
@@ -1,5 +1,9 @@
 # github-contribution-workflow Skill — Implementation Plan
 
+> Status: Implemented — historical archive, superseded by the shipped repo.
+> Version targets below are as-written (1.2.0 → 1.3.0); current versions live
+> in the SSOT [`README.md`](../../../README.md) and the manifests.
+
 > **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
 
 **Goal:** Add the first-party `github-contribution-workflow` skill (12th collaboration skill) and wire it through the SSOT/consistency gate.

--- a/docs/superpowers/specs/2026-06-24-apple-dev-skills-from-scratch-design.md
+++ b/docs/superpowers/specs/2026-06-24-apple-dev-skills-from-scratch-design.md
@@ -1,7 +1,9 @@
 # apple-dev-skills — from-scratch redesign (design spec)
 
 Date: 2026-06-24
-Status: DRAFT (awaiting user review)
+Status: Implemented — historical archive, superseded by the shipped repo (see
+[`README.md`](../../../README.md) Catalog for current counts/versions; this doc
+intentionally keeps its as-written numbers, e.g. 10 collaboration skills / 30 total)
 Supersedes the doc/structure decisions in `2026-06-24-apple-dev-skills-shared-plugin-design.md`
 for the repo layout, doc set, and zh-Hant handling. Skill *content* is unchanged.
 

--- a/docs/superpowers/specs/2026-06-25-github-contribution-workflow-design.md
+++ b/docs/superpowers/specs/2026-06-25-github-contribution-workflow-design.md
@@ -1,7 +1,8 @@
 # github-contribution-workflow — first-party skill (design spec)
 
 Date: 2026-06-25
-Status: APPROVED (design approved by user; spec for review)
+Status: Implemented — historical archive, superseded by the shipped repo (SSOT:
+[`README.md`](../../../README.md))
 
 ## Context
 

--- a/scripts/check-consistency.py
+++ b/scripts/check-consistency.py
@@ -3,10 +3,12 @@
 
 Checks
   1. Each <plugin>/skills/<dir>/ has a SKILL.md whose frontmatter name == <dir>.
-  2. README.md Catalog lists exactly the union of both plugins' skills (32) AND the
-     five aggregated external plugin names (set-equality, both directions).
-  3. Counts match: README group headers (20)/(12)/(5), the Install one-liner comments,
-     and each plugin.json's "N first-party".
+  2. README.md Catalog contains every first-party skill (both plugins, 32) AND the
+     five aggregated external plugin names (missing-direction only; extra kebab
+     tokens are tolerated by design — Catalog prose legitimately names other things).
+  3. Counts present: the values 20/12/5 each appear among the Catalog's "(N)" group
+     headers (set membership, not per-header association); the Install one-liner
+     comments and each plugin.json's "N first-party" are checked exactly.
   4. README.zh-Hant.md exists and its embedded src-sha == git hash-object README.md.
   5. All plugin/marketplace JSON parse; the two subdir plugin sources resolve to dirs;
      marketplace.json lists exactly the 7 plugins (2 local + 5 externals).


### PR DESCRIPTION
Resolves all 9 findings from the 2026-07-02 upkeep report (#19), grouped by the audit's own root causes:

**Staleness + orphan cluster (1 medium + 5 low)** — took the *archive* branch of the audit's proposed either/or: `docs/superpowers/` is now an explicitly declared historical archive — new index `docs/superpowers/README.md` links all 4 plan/spec docs (kills the orphan findings), and each doc gets a superseded status banner stating its counts/versions are as-written by design with the SSOT pointer. This codifies the decision already made implicitly in #17's session ("intentionally left as a historical artifact") so future audits stop re-flagging it.

**Unenforced consistency claims (2 low)** — weakened the words to match the code rather than the reverse: check 2's extra-token leniency is *intentional* (Catalog prose legitimately names other kebab things — documented in the restructure plan's self-review), and check 3 is count-set membership, not per-header association. `skill-authoring-patterns` now names the heading the catalog actually uses (`## Deviation considerations`, 14 skills) and marks the Common-Mistakes/Review-Checklist bookends as for-new-skills, no retrofit.

**i18n dead-end (1 low)** — SSOT switcher is now bidirectional (`Languages: English · 繁體中文`), so the zh-Hant mirror links back to English instead of self-linking. zh line hand-mirrored + src-sha re-stamped per the CONTRIBUTING convention (#21).

Gate green locally. Closes #19.

🤖 Generated with [Claude Code](https://claude.com/claude-code)