### PR TITLE
feat(skills): add asc-api-automation + swiftui-navigation-architecture

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,7 +9,7 @@
     {
       "name": "apple-dev-skills",
       "source": "./apple-dev-skills",
-      "description": "20 first-party Apple/Swift skills. Namespaced apple-dev-skills:<skill>.",
+      "description": "22 first-party Apple/Swift skills. Namespaced apple-dev-skills:<skill>.",
       "version": "1.1.1",
       "author": { "name": "Wei18" },
       "keywords": ["swift", "ios", "macos", "apple-platform", "claude-code", "agent-skills"],

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ This repo is one **marketplace** hosting two first-party plugins and several agg
 
 ```
 /plugin marketplace add wei18/apple-dev-skills
-/plugin install apple-dev-skills@apple-dev-skills          # 20 Apple/Swift skills
+/plugin install apple-dev-skills@apple-dev-skills          # 22 Apple/Swift skills
 /plugin install collaboration-skills@apple-dev-skills      # 12 agent-collaboration skills
 ```
 
@@ -59,7 +59,7 @@ npx skills add wei18/apple-dev-skills --skill swift6-concurrency
 
 ## Catalog
 
-### apple-dev-skills (20) — Apple/Swift
+### apple-dev-skills (22) — Apple/Swift
 
 | Skill | One-liner |
 |---|---|
@@ -80,7 +80,9 @@ npx skills add wei18/apple-dev-skills --skill swift6-concurrency
 | `build-time-secret-injection` | xcconfig + Info.plist `$()` + `Bundle.main` for ship-in-binary-but-out-of-diff IDs |
 | `monetization-sdk-integration` | Add/upgrade/audit a monetization SDK; isolate `import` to one bridge file |
 | `app-store-review-rejections` | Diagnose & pre-empt App Review rejection classes for free + ads + IAP + CloudKit + GC |
+| `asc-api-automation` | ES256 JWT from the `.p8` + curl against the ASC REST API — TestFlight, metadata, submission, reports; no fastlane |
 | `swiftui-interaction-footguns` | Known SwiftUI interaction bugs that slip past pure-code review |
+| `swiftui-navigation-architecture` | Typed `Route` enum + `@Observable` router; value-based `NavigationStack`; deep links; SplitView / per-tab paths |
 | `app-icon-rasterize` | Rasterize a 1024 SVG icon to asset-catalog PNG via `qlmanage` — no Homebrew |
 | `ios-design-mockup` | Single-file HTML iOS design mockup from a spec — iPhone frames + tokens |
 

--- a/README.zh-Hant.md
+++ b/README.zh-Hant.md
@@ -18,7 +18,7 @@
 
 ```
 /plugin marketplace add wei18/apple-dev-skills
-/plugin install apple-dev-skills@apple-dev-skills          # 20 Apple/Swift skills
+/plugin install apple-dev-skills@apple-dev-skills          # 22 Apple/Swift skills
 /plugin install collaboration-skills@apple-dev-skills      # 12 agent-collaboration skills
 ```
 
@@ -59,7 +59,7 @@ npx skills add wei18/apple-dev-skills --skill swift6-concurrency
 
 ## 目錄
 
-### apple-dev-skills (20) — Apple/Swift
+### apple-dev-skills (22) — Apple/Swift
 
 | Skill | 一句話說明 |
 |---|---|
@@ -80,7 +80,9 @@ npx skills add wei18/apple-dev-skills --skill swift6-concurrency
 | `build-time-secret-injection` | xcconfig + Info.plist `$()` + `Bundle.main`，用於隨二進位出貨但不進 diff 的 ID |
 | `monetization-sdk-integration` | 新增／升級／稽核變現 SDK；將 `import` 隔離到單一橋接檔 |
 | `app-store-review-rejections` | 診斷並預先化解免費 + 廣告 + IAP + CloudKit + GC 的 App Review 退件類型 |
+| `asc-api-automation` | 以 `.p8` 簽 ES256 JWT + curl 直呼 ASC REST API — TestFlight、metadata、送審、報表；不用 fastlane |
 | `swiftui-interaction-footguns` | 會躲過純程式碼審查的已知 SwiftUI 互動 bug |
+| `swiftui-navigation-architecture` | 型別化 `Route` enum + `@Observable` router；value-based `NavigationStack`；deep link；SplitView / 分頁各自 path |
 | `app-icon-rasterize` | 透過 `qlmanage` 將 1024 SVG 圖示點陣化為 asset-catalog PNG——無需 Homebrew |
 | `ios-design-mockup` | 從規格產生單檔 HTML iOS 設計稿——iPhone 外框 + token |
 
@@ -126,4 +128,4 @@ npx skills add wei18/apple-dev-skills --skill swift6-concurrency
 出貨 Apple 平台遊戲作品集——再加上對公開的 Apple / WCAG / Swift 標準的原創撰述。
 彙整的外部來源仍屬其作者所有，僅以引用方式呈現。MIT——見 [LICENSE](LICENSE)。
 
-<!-- src-sha: 158e9f0e69deee37fcd0f56deb30ebb02745bfcf -->
+<!-- src-sha: 7a753dfd60186a5361b732f169217e955df6ae08 -->

--- a/apple-dev-skills/.claude-plugin/plugin.json
+++ b/apple-dev-skills/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "apple-dev-skills",
   "version": "1.1.1",
-  "description": "20 first-party Apple/Swift skills for AI-agent development — Swift 6 / SwiftPM / testing / CI / L10n / telemetry defaults, security & secrets, monetization, App Review, SwiftUI footguns, plus accessibility, dependency injection, and performance engineering. Distilled from a real shipping project and public Apple/standards docs.",
+  "description": "22 first-party Apple/Swift skills for AI-agent development — Swift 6 / SwiftPM / testing / CI / L10n / telemetry defaults, security & secrets, monetization, App Review, ASC API automation, SwiftUI footguns & navigation, plus accessibility, dependency injection, and performance engineering. Distilled from a real shipping project and public Apple/standards docs.",
   "author": { "name": "Wei18" },
   "homepage": "https://github.com/wei18/apple-dev-skills",
   "license": "MIT"

--- a/apple-dev-skills/skills/asc-api-automation/SKILL.md
+++ b/apple-dev-skills/skills/asc-api-automation/SKILL.md
@@ -1,0 +1,149 @@
+---
+name: asc-api-automation
+description: Use when automating App Store Connect from a CLI or CI — mint the ES256 JWT from an ASC API `.p8` key (`kid`, `iss` = Issuer ID, `aud` `appstoreconnect-v1`, exp ≤ 20 min), then drive `api.appstoreconnect.apple.com` with curl for TestFlight `betaGroups` / `betaBuildLocalizations`, `appStoreVersions` metadata, `reviewSubmissions` submit-for-review, `salesReports` / `analyticsReportRequests`. No fastlane, no Ruby — a CryptoKit token script + curl. Invoke when asked "automate TestFlight / submission / release notes", writing release tooling, or debugging 401 NOT_AUTHORIZED / 429 RATE_LIMIT_EXCEEDED. API-side ops only: build & upload → xcode-cloud-single-track-ci; `.p8` storage / leak prevention → build-time-secret-injection + apple-public-repo-security.
+---
+
+# App Store Connect API Automation
+
+This catalog's default way to drive App Store Connect from scripts and CI: an Apple-native toolchain — a ~30-line Swift/CryptoKit script mints the JWT, plain curl calls the REST API. No fastlane/spaceship, no Ruby gems, no Homebrew, consistent with the catalog's mise + no-third-party baselines.
+
+## When to invoke
+
+- Writing release tooling: distribute a build to TestFlight groups, set what's-new, create the next App Store version, submit for review
+- Pulling sales or App Store analytics reports on a schedule
+- Debugging ASC API auth failures (401 `NOT_AUTHORIZED`) or rate limiting (429)
+- Asked "should I use fastlane for this?"
+
+## Scope
+
+Owns: token minting, curl conventions, and the endpoint cookbook below. Does NOT own:
+
+- **Building / uploading the binary** — there is no REST endpoint for `.ipa` upload; builds arrive in ASC via Xcode Cloud (→ [[xcode-cloud-single-track-ci]]), Xcode Organizer, or Transporter. This skill picks up *after* the build exists in ASC.
+- **`.p8` key storage & leak prevention** → [[build-time-secret-injection]] (Layer 2 `secrets/.env`) + [[apple-public-repo-security]] (rotate-first SOP).
+- **What metadata will pass review** → [[app-store-review-rejections]]; this skill is *how* to submit, not *what*.
+
+## Keys: create, scope, store
+
+| Key kind | Where | JWT identity claim | Use for |
+|---|---|---|---|
+| **Team key** (default) | Users and Access → Integrations; role-scoped | `iss` = Issuer ID | CI and shared tooling — pick the least-privilege role that works (App Manager covers release ops; avoid Admin) |
+| **Individual key** | Your user profile → Individual API Key | `sub: "user"` (no `iss`) | Personal one-off scripts; inherits *your* permissions |
+
+Store per [[build-time-secret-injection]] Layer 2:
+
+```bash
+# secrets/.env (gitignored; .env.example committed)
+ASC_KEY_ID=2X9R4HXF34
+ASC_ISSUER_ID=57246542-96fe-1a63-e053-0824d011072a
+ASC_KEY_PATH=secrets/AuthKey_2X9R4HXF34.p8
+```
+
+## Mint the token (CryptoKit, zero dependencies)
+
+Claims (verified against Apple's *Generating tokens for API requests*, 2026-07): header `alg: ES256` (the only accepted algorithm), `kid`, `typ: JWT`; payload `iss` (**Issuer ID**, the UUID from Users and Access → Integrations — not your Team ID), `iat`, `exp` (invalid if more than 20 minutes ahead), `aud: "appstoreconnect-v1"`, optional `scope` (array of allowed requests like `"GET /v1/apps"` — pin single-purpose tokens to single endpoints).
+
+`scripts/mint-asc-token.swift`:
+
+```swift
+#!/usr/bin/env swift
+import CryptoKit
+import Foundation
+
+let env = ProcessInfo.processInfo.environment
+guard let keyID = env["ASC_KEY_ID"], let issuerID = env["ASC_ISSUER_ID"],
+      let keyPath = env["ASC_KEY_PATH"] else {
+    FileHandle.standardError.write(Data("Set ASC_KEY_ID / ASC_ISSUER_ID / ASC_KEY_PATH (source secrets/.env)\n".utf8))
+    exit(1)
+}
+
+func b64url(_ data: Data) -> String {
+    data.base64EncodedString()
+        .replacingOccurrences(of: "+", with: "-")
+        .replacingOccurrences(of: "/", with: "_")
+        .replacingOccurrences(of: "=", with: "")
+}
+
+let now = Int(Date().timeIntervalSince1970)
+let header = #"{"alg":"ES256","kid":"\#(keyID)","typ":"JWT"}"#
+// Apple rejects exp > 20 min ahead; 10 min leaves slack for clock skew.
+let payload = #"{"iss":"\#(issuerID)","iat":\#(now),"exp":\#(now + 600),"aud":"appstoreconnect-v1"}"#
+let signingInput = b64url(Data(header.utf8)) + "." + b64url(Data(payload.utf8))
+
+let pem = try String(contentsOfFile: keyPath, encoding: .utf8)
+let key = try P256.Signing.PrivateKey(pemRepresentation: pem)
+let signature = try key.signature(for: Data(signingInput.utf8))  // ECDSA + SHA-256 = ES256
+print(signingInput + "." + b64url(signature.rawRepresentation))  // rawRepresentation = r‖s, the JWT wire format
+```
+
+```bash
+source secrets/.env
+ASC_TOKEN=$(swift scripts/mint-asc-token.swift)
+curl -sf -H "Authorization: Bearer $ASC_TOKEN" "https://api.appstoreconnect.apple.com/v1/apps?limit=200"
+```
+
+Mint fresh per run; a job that outlives the token re-mints instead of extending `exp`.
+
+## curl conventions
+
+- **JSON:API shape** — write calls send `Content-Type: application/json` with the body wrapped as `{"data": {"type": ..., "id": ..., "attributes": {...}, "relationships": {...}}}`.
+- **Pagination** — pass `limit=200` (the max) and follow `links.next` until absent; the small default page size silently truncates lists otherwise.
+- **Rate limit** — every response carries `X-Rate-Limit: user-hour-lim:3500; user-hour-rem:…` (rolling hour, per key; Apple says actual limits vary). Exceeding returns 429 `RATE_LIMIT_EXCEEDED` — back off and re-queue; a 429 lockout hits *everything* sharing that key, including CI.
+- **Errors are structured** — read `.errors[].detail`. Triage: 401 = token/claims problem, 403 = key role or `scope` problem, 409 = resource state problem (e.g. version not in a submittable state).
+
+## Endpoint cookbook
+
+| Goal | Call |
+|---|---|
+| App's ASC id | `GET /v1/apps?filter[bundleId]=<bundle-id>` |
+| Latest processed builds | `GET /v1/builds?filter[app]=<appId>&sort=-uploadedDate&limit=5` |
+| TestFlight what's-new | `GET /v1/builds/<id>/betaBuildLocalizations` → `PATCH /v1/betaBuildLocalizations/<locId>` with `attributes.whatsNew` |
+| Add build to a beta group | `POST /v1/betaGroups/<groupId>/relationships/builds` with `{"data":[{"type":"builds","id":"<buildId>"}]}` |
+| Create next App Store version | `POST /v1/appStoreVersions` — relationship `app`, attributes `platform: "IOS"`, `versionString` |
+| Set description / what's-new | `GET /v1/appStoreVersions/<id>/appStoreVersionLocalizations` → `PATCH /v1/appStoreVersionLocalizations/<locId>` |
+| Attach build to version | `PATCH /v1/appStoreVersions/<id>/relationships/build` |
+| Submit for review | `POST /v1/reviewSubmissions` (app + platform) → `POST /v1/reviewSubmissionItems` (reviewSubmission + appStoreVersion) → `PATCH /v1/reviewSubmissions/<id>` with `attributes.submitted: true` |
+| Daily sales report | `GET /v1/salesReports?filter[frequency]=DAILY&filter[reportType]=SALES&filter[reportSubType]=SUMMARY&filter[vendorNumber]=<n>` (+ `filter[reportDate]=YYYY-MM-DD` for a specific day) — response is a **gzipped TSV**, not JSON: `curl -o report.gz` then `gunzip` |
+| App Store analytics | `POST /v1/analyticsReportRequests` (`accessType: "ONGOING"`) once per app, then poll its `reports` → instances → segments for download URLs |
+
+The review-submission flow is the 2022+ `reviewSubmissions` model, which replaced the deprecated one-shot `appStoreVersionSubmissions`.
+
+## Rationale
+
+- **No fastlane by default**: spaceship drags a Ruby toolchain into a repo whose only Ruby consumer would be release tooling — against the catalog's mise/no-Homebrew baseline — and inserts a drift layer that breaks whenever ASC changes ahead of a spaceship release. Direct REST against Apple's own docs has zero intermediary.
+- **CryptoKit mint script**: token minting is the only genuinely fiddly step (ES256, raw-signature format); everything after is plain curl. A 30-line Apple-native script beats installing PyJWT or hand-rolling openssl DER conversion.
+- **Least privilege**: token-leak blast radius scales with the key's role; the `scope` claim can pin a single script to a single request.
+
+## Deviation considerations
+
+- **Already on fastlane** with maintained lanes and a Gemfile → keep it; this skill is the default for repos *without* a Ruby toolchain, not a migration mandate.
+- **Heavy tooling** (dozens of endpoints, typed models, retries) → generate a client from Apple's published App Store Connect OpenAPI spec instead of hand-rolled curl; still no fastlane required.
+- **One-off manual task** → the ASC web UI is faster; scripting has a floor cost.
+
+## Common Mistakes
+
+1. **`iss` set to Team ID** — ASC API wants the **Issuer ID** (UUID); Team ID belongs to other Apple JWTs (e.g. APNs). Symptom: 401 `NOT_AUTHORIZED` with a well-formed token.
+2. **`exp` more than 20 minutes ahead** — token rejected outright; also watch local clock skew on `iat`.
+3. **openssl-signed tokens failing** — `openssl dgst` emits a DER-encoded signature; JWT ES256 requires the raw 64-byte r‖s form. CryptoKit's `rawRepresentation` is already correct.
+4. **Uploading the binary via REST** — no such endpoint exists; route builds through Xcode Cloud / Organizer / Transporter.
+5. **Ignoring pagination** — the default page size silently truncates; always `limit=200` + follow `links.next`.
+6. **Parsing `salesReports` as JSON** — it's a gzipped TSV file.
+7. **Tight-polling build processing or analytics** without reading `X-Rate-Limit` — 429 locks out every consumer of the key.
+8. **Admin-role key in CI** when App Manager or a `scope`d token suffices.
+9. **`.p8` committed to the repo** — stop and run the rotate-first SOP in [[apple-public-repo-security]]; storage layout per [[build-time-secret-injection]].
+
+## Review Checklist
+
+- [ ] Team key with least-privilege role; `.p8` + IDs stored per build-time-secret-injection Layer 2, nothing tracked by git
+- [ ] Token claims: ES256, `kid` header, `iss` = Issuer ID (or `sub: "user"` for individual keys), `exp` ≤ 20 min, `aud` `appstoreconnect-v1`
+- [ ] Every collection call sets `limit` and follows `links.next`
+- [ ] 429 handled with backoff; no tight polling loops
+- [ ] Write calls use the JSON:API `{"data": {...}}` wrapper
+- [ ] No REST binary-upload attempt; build side delegated to xcode-cloud-single-track-ci
+- [ ] `grep` for key IDs / issuer ID / `.p8` contents across tracked files returns zero hits
+
+## Related skills
+
+- [[xcode-cloud-single-track-ci]] — build & upload side; this skill starts after the build exists in ASC
+- [[build-time-secret-injection]] — where `ASC_KEY_ID` / `ASC_ISSUER_ID` / the `.p8` live (Layer 2 `secrets/.env`)
+- [[apple-public-repo-security]] — `.p8` leak prevention and the rotate-first SOP
+- [[app-store-review-rejections]] — *what* to submit so review passes; this skill is *how* to submit

--- a/apple-dev-skills/skills/swiftui-navigation-architecture/SKILL.md
+++ b/apple-dev-skills/skills/swiftui-navigation-architecture/SKILL.md
@@ -1,0 +1,141 @@
+---
+name: swiftui-navigation-architecture
+description: Default navigation shape for SwiftUI Apps (iOS 18 / macOS 15, Swift 6) — value-based `NavigationStack(path:)` over a typed `Route` enum, one `@Observable @MainActor` Router injected via `.environment`, `navigationDestination(for:)` at the stack root (never inside a lazy container), sheets as a separate `Modal` enum, one `.onOpenURL` mapping deep links to `[Route]`, `NavigationSplitView` for iPad/Mac, per-tab paths owned by the router, `Codable` route restoration. Invoke when wiring a new App's navigation, adding deep links or state restoration, migrating off `NavigationView` / `NavigationLink(destination:)`, or asked "router / coordinator pattern in SwiftUI". Owns the architecture; individual interaction bugs → swiftui-interaction-footguns.
+---
+
+# SwiftUI Navigation Architecture
+
+The default navigation shape for Apps on this catalog's baseline ([[apple-platform-targets]]: iOS 18 / macOS 15, Swift 6 language mode): navigation state is **data** — a typed route enum in one observable router — so flows are unit-testable (assert on `[Route]`), deep-linkable (URL → routes is a pure function), and restorable (routes are `Codable`).
+
+## When to invoke
+
+- Wiring navigation in a new App target, or adding a second entry point (deep link, widget tap, notification, tab)
+- Adding deep links / universal links or state restoration to an existing App
+- Migrating off `NavigationView` or view-payload `NavigationLink(destination:)`
+- Asked "how do I do a router / coordinator in SwiftUI?"
+
+## Scope
+
+Owns container choice (Stack / SplitView / Tab), route modeling, the router object, deep-link funneling, and restoration. Does NOT own: known interaction bugs in nav components → [[swiftui-interaction-footguns]]; injecting the services destination views need → [[swift-dependency-injection]]; nav-chrome accessibility → [[ios-accessibility-engineering]].
+
+## Pick the container
+
+| App shape | Container |
+|---|---|
+| Single drill-down flow (iPhone-first) | `NavigationStack(path:)` |
+| 2–5 top-level peer sections | `TabView` + one `NavigationStack` per tab, each with its own path |
+| Source list → detail (iPad / Mac) | `NavigationSplitView`; sidebar selection is router state, the detail column hosts its own `NavigationStack` |
+
+Never `NavigationView` in new code — deprecated since iOS 16.
+
+## The default shape
+
+```swift
+enum Route: Hashable, Codable {
+    case board(id: UUID)      // payloads are IDs, not model objects
+    case settings
+}
+
+enum Modal: String, Identifiable {  // presentation is NOT navigation
+    case paywall, onboarding
+    var id: String { rawValue }
+}
+
+@Observable @MainActor
+final class Router {
+    var path: [Route] = []
+    var modal: Modal?
+
+    // One pure mapping: URL → navigation state. Unit-test without UI.
+    func open(_ url: URL) {
+        guard url.scheme == "myapp" else { return }
+        switch url.host {
+        case "board": path = [.board(id: UUID(uuidString: url.lastPathComponent) ?? UUID())]
+        case "settings": path = [.settings]
+        default: break
+        }
+    }
+}
+
+@main struct MyApp: App {
+    @State private var router = Router()
+
+    var body: some Scene {
+        WindowGroup {
+            NavigationStack(path: $router.path) {
+                HomeView()
+                    .navigationDestination(for: Route.self) { route in
+                        switch route {                 // exhaustive — compiler catches new routes
+                        case .board(let id): BoardView(id: id)
+                        case .settings: SettingsView()
+                        }
+                    }
+            }
+            .environment(router)
+            .sheet(item: $router.modal) { ModalHost($0) }
+            .onOpenURL { router.open($0) }
+        }
+    }
+}
+```
+
+Rules the shape encodes:
+
+- **Push with values** — `NavigationLink(value:)` or `router.path.append(...)`; never `NavigationLink(destination:)` in a path-managed stack (those pushes bypass `path`, desyncing back-stack, deep links, and restoration).
+- **`navigationDestination(for:)` on the stack's root content, outside lazy containers.** Apple's docs: "Do not put a navigation destination modifier inside a 'lazy' container, like `List` or `LazyVStack`. … Add the navigation destination modifier outside these containers so that the navigation stack can always see the destination."
+- **Typed `[Route]` over `NavigationPath`** — pattern-matchable, exhaustively switched, `Codable` for free.
+- **Modal ≠ push** — sheets / fullScreenCover hang off `router.modal`; a presented flow is never a `Route` case.
+- **Router is `@MainActor`** (it is UI state; Swift 6 enforces it), routes are `Hashable + Codable` value types.
+
+## Deep links & restoration
+
+- Every URL entry point (`onOpenURL`, universal links, `NSUserActivity`, notification taps) funnels into `router.open(_:)` at the scene root — one handler, one mapping function, unit tests assert `URL → [Route]` directly.
+- Restoration: on `scenePhase == .background`, `JSONEncoder` the `[Route]` into `@SceneStorage`(a `String` slot); on launch, decode and assign. Routes that reference store objects carry IDs — resolve at display time and drop routes that no longer resolve instead of crashing.
+
+## Multi-column & tabs
+
+- `NavigationSplitView`: sidebar selection lives in the router; only the detail column hosts a `NavigationStack`. Don't nest stacks in the sidebar.
+- `TabView`: the router owns `selectedTab` *and* one path per tab — paths kept in per-view `@State` reset whenever tab identity churns. Selecting the already-active tab popping to root becomes a 2-line router method.
+- iPad / Mac footguns in these containers (sizeClass on Mac, inert sidebar Labels) → [[swiftui-interaction-footguns]].
+
+## Rationale
+
+- **Navigation state as data**: view-payload links hide "where is the user" inside the view tree; a typed path makes it assertable, loggable, and reproducible from a URL or a saved session.
+- **One router in `.environment`**: a single owner instead of bindings threaded through N view layers; `@Observable` keeps invalidation scoped to views that actually read `path`.
+- **Typed enum over `NavigationPath`**: exhaustive `switch` in `navigationDestination` means the compiler flags every unhandled route; `NavigationPath` trades that away for type erasure most single-module apps don't need.
+
+## Deviation considerations
+
+- **Heterogeneous route types across feature packages** that genuinely can't share one enum → `NavigationPath` + its `CodableRepresentation` for restoration; you give up exhaustive matching.
+- **A 2-screen utility** → a bare `NavigationStack` without router or path is fine; adopt the shape when the second entry point appears, not speculatively.
+- **UIKit-hosted hybrids** (heavy `UIViewController` interop) → keep coordination at the UIKit layer; don't force a SwiftUI router across the hosting bridge.
+- **iOS 17 floor** → the shape works unchanged (`@Observable`, `NavigationStack` both available); below that, `ObservableObject` replaces `@Observable`.
+
+## Common Mistakes
+
+1. **`NavigationView` in new code** — deprecated since iOS 16, unpredictable column behavior. Use `NavigationStack` / `NavigationSplitView`.
+2. **`navigationDestination(for:)` inside `List` / `LazyVStack`** — the lazy container may not have created the registering view yet, so pushes silently fail (runtime console warning). Register at the stack root.
+3. **Mixing `NavigationLink(destination:)` into a path-based stack** — pushes invisible to `path`; back-stack count, deep links, and restoration all desync.
+4. **Sheets modeled as pushed routes** — back-button vs dismiss semantics conflict; keep a separate `Modal` enum.
+5. **Per-tab paths in view `@State`** — switching tabs (or any identity churn) resets the stack; paths belong to the router.
+6. **`onOpenURL` sprinkled across views** — multiple competing handlers; one scene-root handler feeding one mapping function.
+7. **Router not `@MainActor`** — Swift 6 isolation errors the first time a `Task` mutates `path`; annotate the class, not call sites.
+8. **Model objects as route payloads** — bloats `Hashable`/`Codable`, goes stale after edits; carry IDs and resolve at display.
+
+## Review Checklist
+
+- [ ] No `NavigationView`; no `NavigationLink(destination:)` inside path-managed stacks
+- [ ] One `Route` enum, `Hashable + Codable`; payloads are IDs, not model objects
+- [ ] `navigationDestination(for:)` registered at the stack root, outside lazy containers
+- [ ] Single `@Observable @MainActor` router in `.environment`; all paths (incl. per-tab) live on it
+- [ ] Sheets / covers driven by a `Modal` enum, never a `Route` case
+- [ ] One `.onOpenURL` at the scene root; `URL → [Route]` mapping has unit tests
+- [ ] Restoration decodes saved routes and drops unresolvable IDs gracefully
+- [ ] SplitView: sidebar selection in router, stack only in detail; footguns checklist run
+
+## Related skills
+
+- [[swiftui-interaction-footguns]] — known bugs in the nav components this skill wires together
+- [[swift-dependency-injection]] — how destination views get their services
+- [[apple-platform-targets]] — the iOS 18 / macOS 15 baseline this shape assumes
+- [[ios-accessibility-engineering]] — accessibility of the navigation chrome

--- a/scripts/check-consistency.py
+++ b/scripts/check-consistency.py
@@ -3,10 +3,10 @@
 
 Checks
   1. Each <plugin>/skills/<dir>/ has a SKILL.md whose frontmatter name == <dir>.
-  2. README.md Catalog contains every first-party skill (both plugins, 32) AND the
+  2. README.md Catalog contains every first-party skill (both plugins, 34) AND the
      five aggregated external plugin names (missing-direction only; extra kebab
      tokens are tolerated by design — Catalog prose legitimately names other things).
-  3. Counts present: the values 20/12/5 each appear among the Catalog's "(N)" group
+  3. Counts present: the values 22/12/5 each appear among the Catalog's "(N)" group
      headers (set membership, not per-header association); the Install one-liner
      comments and each plugin.json's "N first-party" are checked exactly.
   4. README.zh-Hant.md exists and its embedded src-sha == git hash-object README.md.
@@ -23,7 +23,7 @@ import json, re, subprocess, sys
 from pathlib import Path
 
 ROOT = Path(__file__).resolve().parent.parent
-PLUGINS = {"apple-dev-skills": 20, "collaboration-skills": 12}
+PLUGINS = {"apple-dev-skills": 22, "collaboration-skills": 12}
 EXTERNALS = {"apple-skills", "swiftui-expert", "swiftui-pro", "caveman", "ponytail"}
 DESC_MAX = 800  # current max is 795 (github-contribution-workflow); cap future growth
 errors: list[str] = []


### PR DESCRIPTION
## What

Two new first-party Apple/Swift skills (catalog 20 → 22), filling the two gaps ranked highest in this session's catalog review:

### `asc-api-automation`
App Store Connect automation without fastlane — the catalog previously covered ASC API keys only as *secrets to protect*, never *how to use them*.
- CryptoKit ES256 JWT mint script (zero dependencies, no Ruby/Homebrew — consistent with catalog baselines)
- curl conventions: JSON:API write shape, `limit=200` + `links.next` pagination, `X-Rate-Limit` / 429 handling
- Endpoint cookbook: TestFlight, `appStoreVersions` metadata, `reviewSubmissions` submit flow, `salesReports` (gzipped TSV), analytics requests
- Scope boundaries to `xcode-cloud-single-track-ci` (build/upload) and `build-time-secret-injection` + `apple-public-repo-security` (key storage)

### `swiftui-navigation-architecture`
The opinionated navigation default the catalog lacked (`swiftui-interaction-footguns` is a bug checklist, not an architecture):
- Typed `Route` enum + single `@Observable @MainActor` router in `.environment`
- Value-based `NavigationStack(path:)`, `Modal` enum for presentation, one `.onOpenURL` deep-link funnel, per-tab paths, `Codable` restoration
- `NavigationSplitView` guidance for iPad/Mac with cross-refs to the footguns checklist

## Verification

- `mise run check` green (negative test: gate correctly failed on 4 count mismatches before the canonical `PLUGINS` constant was updated)
- JWT mint script extracted from the skill and run end-to-end with a throwaway PKCS#8 P-256 key: correct ES256 header/claims, 64-byte raw r‖s signature
- Falsifiable claims spot-checked against Apple docs (token claims + 20-min exp, `X-Rate-Limit` format + 429 `RATE_LIMIT_EXCEEDED`, lazy-container caveat quoted verbatim from `navigationDestination(for:)` docs)
- zh-Hant README hand-mirrored (4 content lines, ≤5 rule) with src-sha restamped

Version bump / release intentionally left for a follow-up `release` task.

🤖 Generated with [Claude Code](https://claude.com/claude-code)