### PR TITLE
feat(skills): swiftui-navigation-architecture — presentation semantics + iOS/macOS parity

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ npx skills add wei18/apple-dev-skills --skill swift6-concurrency
 | `app-store-review-rejections` | Diagnose & pre-empt App Review rejection classes for free + ads + IAP + CloudKit + GC |
 | `asc-api-automation` | ES256 JWT from the `.p8` + curl against the ASC REST API — TestFlight, metadata, submission, reports; no fastlane |
 | `swiftui-interaction-footguns` | Known SwiftUI interaction bugs that slip past pure-code review |
-| `swiftui-navigation-architecture` | Typed `Route` enum + `@Observable` router; value-based `NavigationStack`; deep links; SplitView / per-tab paths |
+| `swiftui-navigation-architecture` | Typed `Route` enum + `@Observable` router; value-based `NavigationStack`; per-transition presentation semantics with macOS fallbacks; deep links; per-tab paths |
 | `app-icon-rasterize` | Rasterize a 1024 SVG icon to asset-catalog PNG via `qlmanage` — no Homebrew |
 | `ios-design-mockup` | Single-file HTML iOS design mockup from a spec — iPhone frames + tokens |
 

--- a/README.zh-Hant.md
+++ b/README.zh-Hant.md
@@ -82,7 +82,7 @@ npx skills add wei18/apple-dev-skills --skill swift6-concurrency
 | `app-store-review-rejections` | 診斷並預先化解免費 + 廣告 + IAP + CloudKit + GC 的 App Review 退件類型 |
 | `asc-api-automation` | 以 `.p8` 簽 ES256 JWT + curl 直呼 ASC REST API — TestFlight、metadata、送審、報表；不用 fastlane |
 | `swiftui-interaction-footguns` | 會躲過純程式碼審查的已知 SwiftUI 互動 bug |
-| `swiftui-navigation-architecture` | 型別化 `Route` enum + `@Observable` router；value-based `NavigationStack`；deep link；SplitView / 分頁各自 path |
+| `swiftui-navigation-architecture` | 型別化 `Route` enum + `@Observable` router；value-based `NavigationStack`；每個 transition 的呈現語意（含 macOS fallback）；deep link；分頁各自 path |
 | `app-icon-rasterize` | 透過 `qlmanage` 將 1024 SVG 圖示點陣化為 asset-catalog PNG——無需 Homebrew |
 | `ios-design-mockup` | 從規格產生單檔 HTML iOS 設計稿——iPhone 外框 + token |
 
@@ -128,4 +128,4 @@ npx skills add wei18/apple-dev-skills --skill swift6-concurrency
 出貨 Apple 平台遊戲作品集——再加上對公開的 Apple / WCAG / Swift 標準的原創撰述。
 彙整的外部來源仍屬其作者所有，僅以引用方式呈現。MIT——見 [LICENSE](LICENSE)。
 
-<!-- src-sha: 7a753dfd60186a5361b732f169217e955df6ae08 -->
+<!-- src-sha: 611aaa20d1e272335606fced5259044b18925f1d -->

--- a/apple-dev-skills/skills/swiftui-navigation-architecture/SKILL.md
+++ b/apple-dev-skills/skills/swiftui-navigation-architecture/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: swiftui-navigation-architecture
-description: Default navigation shape for SwiftUI Apps (iOS 18 / macOS 15, Swift 6) — value-based `NavigationStack(path:)` over a typed `Route` enum, one `@Observable @MainActor` Router injected via `.environment`, `navigationDestination(for:)` at the stack root (never inside a lazy container), sheets as a separate `Modal` enum, one `.onOpenURL` mapping deep links to `[Route]`, `NavigationSplitView` for iPad/Mac, per-tab paths owned by the router, `Codable` route restoration. Invoke when wiring a new App's navigation, adding deep links or state restoration, migrating off `NavigationView` / `NavigationLink(destination:)`, or asked "router / coordinator pattern in SwiftUI". Owns the architecture; individual interaction bugs → swiftui-interaction-footguns.
+description: Default navigation shape for SwiftUI Apps (iOS 18 / macOS 15, Swift 6) — value-based `NavigationStack(path:)` over a typed `Route` enum, one `@Observable @MainActor` Router in `.environment`, `navigationDestination(for:)` at the stack root (never in a lazy container), per-transition presentation semantics (push / sheet / `fullScreenCover` / popover / alert / root-swap) incl. macOS behavior (no native `fullScreenCover` → push fallback, pop-to-landing), `item:`-driven modal optionals, `.onOpenURL` deep-link funnel, `NavigationSplitView`, per-tab paths, `Codable` restoration. Invoke when wiring an App's navigation, choosing sheet vs cover vs push, adding deep links / restoration, migrating off `NavigationView`, or asked "router / coordinator in SwiftUI". Bugs → swiftui-interaction-footguns.
 ---
 
 # SwiftUI Navigation Architecture
@@ -84,8 +84,53 @@ Rules the shape encodes:
 - **Push with values** — `NavigationLink(value:)` or `router.path.append(...)`; never `NavigationLink(destination:)` in a path-managed stack (those pushes bypass `path`, desyncing back-stack, deep links, and restoration).
 - **`navigationDestination(for:)` on the stack's root content, outside lazy containers.** Apple's docs: "Do not put a navigation destination modifier inside a 'lazy' container, like `List` or `LazyVStack`. … Add the navigation destination modifier outside these containers so that the navigation stack can always see the destination."
 - **Typed `[Route]` over `NavigationPath`** — pattern-matchable, exhaustively switched, `Codable` for free.
-- **Modal ≠ push** — sheets / fullScreenCover hang off `router.modal`; a presented flow is never a `Route` case.
+- **Modal ≠ push** — presented flows hang off router optionals (`item:`-driven; one optional per presentation kind — sheet, cover, alert. Parallel `isPresented:` Bools race and can present blank); a presented flow is never a `Route` case. *Which* kind → next section.
 - **Router is `@MainActor`** (it is UI state; Swift 6 enforces it), routes are `Hashable + Codable` value types.
+
+## Presentation semantics (decide per transition — iOS and macOS)
+
+"Where does the user land when this closes?" is decided by the semantic you pick, not by the destination view. Pick the tag first; the API and its back/dismiss behavior follow.
+
+| Semantic | API | Dismissal | iOS / iPadOS | macOS |
+|---|---|---|---|---|
+| **push** | `NavigationStack` + `navigationDestination` | back pops one level; edge-swipe on by default | — | same model, toolbar back |
+| **sheet** | `.sheet(item:)` (+ `.presentationDetents`) | swipe-to-dismiss on by default; `interactiveDismissDisabled(true)` to force completion | detents resize; >1 detent shows the grabber | window-styled sheet — detents don't drive sizing, size the content itself |
+| **full-screen cover** | `.fullScreenCover(item:)` | no interactive dismiss; exit only via explicit close | opaque, covers everything | **unavailable on native macOS** (Mac Catalyst only) — fall back to push/sheet, see below |
+| **popover** | `.popover` | tap outside | collapses to a sheet in compact width unless `.presentationCompactAdaptation(.popover)` | always a true anchored popover |
+| **alert** | `.alert(_:isPresented:presenting:)` | button tap only — no scrim tap, no swipe | data-drive off one optional | same |
+| **dialog** | `.confirmationDialog` | Cancel **or** tap outside | bottom action sheet | rendered alert-style |
+| **root-swap** | conditional root content on `@Observable` state | none — the outgoing tree is destroyed | auth gates, onboarding-done | same |
+
+Two contract rules the table enforces:
+
+- **"Closes on outside tap" is a semantic, not a style** — if that's the requirement, it's a `confirmationDialog` or popover, never an `.alert`, regardless of visual intent.
+- **Login/logout is root-swap, not a modal.** Conditionally render `LoginView` vs `AppView` at the root off auth state: success flips the flag and the login tree is destroyed; logout flips it back and tears down the entire app stack (paths, sheets, all of it). Presenting the app *over* login couples app lifetime to a presentation and turns logout into "dismiss a modal" with login still alive underneath.
+
+### macOS fallback for full-screen flows
+
+A flow covered by `fullScreenCover` on iOS ships as a push (or sheet) on macOS — and Close must land on the same screen on both platforms. The trap: `dismiss()` closes the whole cover, but the pushed variant's naive `path.removeLast()` pops one level and strands the user mid-flow.
+
+```swift
+extension Router {
+    // One flow, two containers: cover on iOS, push on macOS.
+    func startGame(id: UUID) {
+        #if os(macOS)
+        path.append(.board(id: id))
+        #else
+        cover = .board(id: id)     // .fullScreenCover(item: $router.cover)
+        #endif
+    }
+    func closeGame() {             // lands on the hub on BOTH platforms
+        #if os(macOS)
+        path.removeAll()           // pop the whole flow — pop-one strands mid-flow
+        #else
+        cover = nil
+        #endif
+    }
+}
+```
+
+Route both entry and exit through router methods (as above) so no view ever encodes the platform branch.
 
 ## Deep links & restoration
 
@@ -110,6 +155,7 @@ Rules the shape encodes:
 - **A 2-screen utility** → a bare `NavigationStack` without router or path is fine; adopt the shape when the second entry point appears, not speculatively.
 - **UIKit-hosted hybrids** (heavy `UIViewController` interop) → keep coordination at the UIKit layer; don't force a SwiftUI router across the hosting bridge.
 - **iOS 17 floor** → the shape works unchanged (`@Observable`, `NavigationStack` both available); below that, `ObservableObject` replaces `@Observable`.
+- **Mac Catalyst** → `fullScreenCover` *is* available there; the push/sheet fallback is for native (AppKit-based) macOS targets.
 
 ## Common Mistakes
 
@@ -121,6 +167,9 @@ Rules the shape encodes:
 6. **`onOpenURL` sprinkled across views** — multiple competing handlers; one scene-root handler feeding one mapping function.
 7. **Router not `@MainActor`** — Swift 6 isolation errors the first time a `Task` mutates `path`; annotate the class, not call sites.
 8. **Model objects as route payloads** — bloats `Hashable`/`Codable`, goes stale after edits; carry IDs and resolve at display.
+9. **`@Environment(\.dismiss)` read in the presenter** — it only dismisses when read *inside* the presented content; in the presenter it's a no-op. Presenter-side closing = nil out the router optional.
+10. **Shared Close across an iOS cover / macOS push split that pops one level** — on macOS the user lands mid-flow instead of on the hub; branch close to pop-to-landing (see the macOS fallback).
+11. **Relying on automatic dismiss cascades** across stacked presentations — model `dismiss()` vs `dismissAll()` as distinct router methods; chain a follow-up presentation in the prior one's `onDismiss`, never present-while-presenting.
 
 ## Review Checklist
 
@@ -128,7 +177,10 @@ Rules the shape encodes:
 - [ ] One `Route` enum, `Hashable + Codable`; payloads are IDs, not model objects
 - [ ] `navigationDestination(for:)` registered at the stack root, outside lazy containers
 - [ ] Single `@Observable @MainActor` router in `.environment`; all paths (incl. per-tab) live on it
-- [ ] Sheets / covers driven by a `Modal` enum, never a `Route` case
+- [ ] Sheets / covers driven by `item:` off router optionals (one per presentation kind), never a `Route` case or parallel Bools
+- [ ] Every transition names its presentation semantic and where close/back lands
+- [ ] Full-screen flows branch per platform; Close lands identically on iOS and macOS (pop-to-landing, not pop-one)
+- [ ] Auth / onboarding gates are root-swap, not modals over the app
 - [ ] One `.onOpenURL` at the scene root; `URL → [Route]` mapping has unit tests
 - [ ] Restoration decodes saved routes and drops unresolvable IDs gracefully
 - [ ] SplitView: sidebar selection in router, stack only in detail; footguns checklist run


### PR DESCRIPTION
## What

Folds the **implementation-layer** value of Sudoku's `screen-contract-spec` into `swiftui-navigation-architecture` (the spec/contract methodology itself stays a separate future skill — different altitude):

- **Per-transition presentation-semantic table** — push / sheet / full-screen cover / popover / alert / dialog / root-swap, each with API, dismissal behavior, and separate iOS vs macOS columns
- **macOS fallback recipe for full-screen flows** — `fullScreenCover` has no native-macOS API, so the flow ships as a push there; entry *and* exit go through platform-branched router methods so Close lands on the same screen on both platforms (pop-to-landing, not pop-one)
- **root-swap rule** for auth/onboarding gates — login/logout is a conditional root, never a modal over the app
- **`item:`-driven modal optionals** (one per presentation kind) over parallel `isPresented:` Bools; explicit `dismiss()` vs `dismissAll()` router methods
- +3 Common Mistakes, +3 Review Checklist rows, description + README one-liners (en + zh-Hant hand-mirror) updated

## Verification

- Platform claims checked against Apple docs JSON: `fullScreenCover` platform list has **no native macOS** (Catalyst only); `presentationDetents` exists on macOS 13+ but macOS sheets are window-styled — wording reflects both
- `mise run check` green (also enforced the 800-char description budget — trimmed from 843)
- zh-Hant hand-mirrored (2 content lines) with src-sha restamped

🤖 Generated with [Claude Code](https://claude.com/claude-code)