### PR TITLE
chore(gate): sync check-consistency docs + assert plugin/marketplace version parity

### DIFF
--- a/docs/superpowers/specs/2026-06-24-apple-dev-skills-from-scratch-design.md
+++ b/docs/superpowers/specs/2026-06-24-apple-dev-skills-from-scratch-design.md
@@ -186,18 +186,27 @@ stays lean):
 
 ## 6. Consistency gate (`scripts/check-consistency.py`, extended)
 
-Checks, failing CI/pre-commit on any mismatch:
+Checks, failing CI/pre-commit on any mismatch (as-built; grown past the checks
+originally scoped here — see `scripts/check-consistency.py`'s own docstring for
+the current source of truth):
 
 1. Both `apple-dev-skills/skills/<dir>/` and `collaboration-skills/skills/<dir>/` have a
    `SKILL.md` whose frontmatter `name:` == `<dir>`.
-2. The README Catalog lists exactly: every first-party skill across both plugins **plus**
-   the five aggregated external plugins (set-equality, both directions).
-3. Hardcoded counts (README group headers `(20)`/`(10)`/`(5)`, each `plugin.json`
-   description count) == actual.
+2. The README Catalog contains every first-party skill across both plugins **plus**
+   the five aggregated external plugin names — missing-direction only; extra kebab-case
+   tokens in Catalog prose are tolerated by design.
+3. Hardcoded counts (README group headers `(22)`/`(12)`/`(5)`, the Install one-liner
+   comments, each `plugin.json` description's "N first-party") == actual.
 4. `README.zh-Hant.md` exists and its embedded `src-sha` matches `git hash-object
    README.md` (freshness).
 5. Both `plugin.json` and `marketplace.json` parse as JSON; the two subdir plugin sources
-   resolve to existing directories.
+   resolve to existing directories; marketplace.json lists exactly the 7 plugins (2 local
+   + 5 externals).
+6. The `git checkout v<semver>` pin in both READMEs' Install section ==
+   marketplace.json `metadata.version`.
+7. Each `SKILL.md` frontmatter `description` <= `DESC_MAX` chars.
+8. Each plugin's `.claude-plugin/plugin.json` `"version"` == the corresponding
+   `marketplace.json` `plugins[]` entry `"version"` (the pair `bump-version.py` maintains).
 
 `.github/workflows/consistency.yml` runs `mise run check` on push/PR.
 

--- a/docs/superpowers/specs/2026-06-24-apple-dev-skills-from-scratch-design.md
+++ b/docs/superpowers/specs/2026-06-24-apple-dev-skills-from-scratch-design.md
@@ -196,7 +196,9 @@ the current source of truth):
    the five aggregated external plugin names — missing-direction only; extra kebab-case
    tokens in Catalog prose are tolerated by design.
 3. Hardcoded counts (README group headers `(22)`/`(12)`/`(5)`, the Install one-liner
-   comments, each `plugin.json` description's "N first-party") == actual.
+   comments, each `plugin.json` description's "N first-party") == actual. The group
+   headers are checked by set-membership only — the values just need to appear
+   somewhere among the Catalog's `(N)` headers, not per-header association.
 4. `README.zh-Hant.md` exists and its embedded `src-sha` matches `git hash-object
    README.md` (freshness).
 5. Both `plugin.json` and `marketplace.json` parse as JSON; the two subdir plugin sources

--- a/scripts/check-consistency.py
+++ b/scripts/check-consistency.py
@@ -16,6 +16,8 @@ Checks
      marketplace.json metadata.version (drifted silently before: v1.2.0 → #17).
   7. Each SKILL.md frontmatter description <= DESC_MAX chars (descriptions are
      always-on context for every consumer session; keeps Lens-3 compression durable).
+  8. Each plugin's `.claude-plugin/plugin.json` "version" == the corresponding
+     marketplace.json plugins[] entry "version" (the pair bump-version.py maintains).
 Stdlib only.
 """
 from __future__ import annotations
@@ -25,7 +27,8 @@ from pathlib import Path
 ROOT = Path(__file__).resolve().parent.parent
 PLUGINS = {"apple-dev-skills": 22, "collaboration-skills": 12}
 EXTERNALS = {"apple-skills", "swiftui-expert", "swiftui-pro", "caveman", "ponytail"}
-DESC_MAX = 800  # current max is 795 (github-contribution-workflow); cap future growth
+DESC_MAX = 800  # ceiling on frontmatter description length; which skill is currently
+                # longest shifts as skills are added — don't hardcode a name here
 errors: list[str] = []
 def fail(m): errors.append(m)
 
@@ -81,12 +84,14 @@ else:
             break
 
 # plugin.json counts
+plugin_json_versions: dict[str, str] = {}
 for plugin, expected in PLUGINS.items():
     pj = ROOT / plugin / ".claude-plugin" / "plugin.json"
     try: d = json.loads(pj.read_text(encoding="utf-8"))
     except Exception as e: fail(f"[manifest] {plugin}/plugin.json invalid: {e}"); continue
     for c in re.findall(r"(\d+)\s+first-party", d.get("description", "")):
         if int(c) != expected: fail(f"[manifest] {plugin} says '{c} first-party', expected {expected}")
+    plugin_json_versions[plugin] = d.get("version")
 
 # 3b. Install one-liner comments (outside the Catalog section, so scoped() misses them)
 for plugin, n in re.findall(r"/plugin install (\S+?)@apple-dev-skills\s+#\s*(\d+)\b", readme):
@@ -116,6 +121,12 @@ try:
     expected_names = set(PLUGINS) | EXTERNALS
     if names != expected_names:
         fail(f"[marketplace] plugin set mismatch — missing: {sorted(expected_names - names)}, extra: {sorted(names - expected_names)}")
+    # 8. plugin.json version == marketplace.json plugins[].version (pair bump-version.py maintains)
+    mp_versions = {p.get("name"): p.get("version") for p in d.get("plugins", [])}
+    for plugin in PLUGINS:
+        pj_v, mp_v = plugin_json_versions.get(plugin), mp_versions.get(plugin)
+        if pj_v != mp_v:
+            fail(f"[manifest] {plugin} plugin.json version {pj_v!r} != marketplace.json plugins[].version {mp_v!r} — run `mise run bump`")
     # 6. README Install pin == marketplace metadata.version
     mp_version = d.get("metadata", {}).get("version", "")
     for readme_name in ("README.md", "README.zh-Hant.md"):

--- a/scripts/check-consistency.py
+++ b/scripts/check-consistency.py
@@ -125,7 +125,9 @@ try:
     mp_versions = {p.get("name"): p.get("version") for p in d.get("plugins", [])}
     for plugin in PLUGINS:
         pj_v, mp_v = plugin_json_versions.get(plugin), mp_versions.get(plugin)
-        if pj_v != mp_v:
+        if pj_v is None or mp_v is None:
+            fail(f"[manifest] {plugin} version missing — plugin.json={pj_v!r}, marketplace.json={mp_v!r}")
+        elif pj_v != mp_v:
             fail(f"[manifest] {plugin} plugin.json version {pj_v!r} != marketplace.json plugins[].version {mp_v!r} — run `mise run bump`")
     # 6. README Install pin == marketplace metadata.version
     mp_version = d.get("metadata", {}).get("version", "")


### PR DESCRIPTION
## Summary

addresses the two Low findings in #25:

- `scripts/check-consistency.py`'s `DESC_MAX` comment named a specific skill as the current-longest description, which drifts every time a longer one ships — reworded to stop hardcoding a name.
- Spec §6 (`docs/superpowers/specs/2026-06-24-apple-dev-skills-from-scratch-design.md`) described a 5-check gate with README-Catalog set-equality in both directions; synced it to the shipped 7(→8)-check, missing-direction-only behavior.
- Added the one real coverage gap the gate was missing: an assertion that each plugin's `.claude-plugin/plugin.json` `"version"` equals its `marketplace.json` `plugins[]` entry `"version"` — the pair `bump-version.py` maintains but the gate never verified.

## Test plan

- [x] `python3 scripts/check-consistency.py` passes on the unmodified repo.
- [x] Negative test: mutated `apple-dev-skills/.claude-plugin/plugin.json` version to `9.9.9` → gate fails with `[manifest] apple-dev-skills plugin.json version '9.9.9' != marketplace.json plugins[].version '1.1.1'`; reverted → gate passes again.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
