### PR TITLE
docs(skills): fold field-tested lessons into three existing skills

### DIFF
--- a/apple-dev-skills/skills/swift-testing-baseline/SKILL.md
+++ b/apple-dev-skills/skills/swift-testing-baseline/SKILL.md
@@ -63,6 +63,17 @@ pixels (above) is the only viable content gate.
 - Real interactions happen only on the dev machine for manual verification (or a nightly standalone job, explicitly excluded from PR CI).
 - Shared fakes are factored into a `<Project>KitTesting` target consumed by multiple test targets.
 
+### The unentitled runner: live-framework landmines
+
+- Constructing a **live CloudKit or Game Center object** inside a SwiftPM test — eager container initialization, or assigning a real auth/handshake handler — blocks the MainActor **synchronously and indefinitely** in the unentitled SwiftPM test runner (near-0% CPU; looks like a hang, not a crash). Both frameworks share this landmine class. Gate any live-framework touch behind a **test-only suppression seam** (a static flag or stub the driver checks before touching the real framework) so tests exercise your own state machine, never the real handshake.
+- If a run does stall, kill the stuck test-runner helper process before retrying — stacking concurrent retries just queues them behind the same stuck build lock and multiplies the mess.
+- A **parallel** test runner can also hang indefinitely on a package that links a framework like this, independent of any live-object bug. `--no-parallel` on that one package is a legitimate, fast workaround; diagnose with capped per-suite `--filter` runs (background the run, poll, kill-and-record-timeout) rather than stacking retries.
+
+### `swift build` is not `swift test`
+
+- Changing a **shared protocol requirement** only recompiles **sources** under `swift build` — test targets are not rebuilt. A test target's own conformer written against the OLD signature silently breaks and is invisible to `swift build`. **Rule:** after any protocol-requirement change, grep for conformers (`": <Protocol>"`) across every package including `Tests/`, and run `swift test` — not just `swift build` — on each package that has a test-target conformer.
+- IDE/SourceKit diagnostics ("no such member", "cannot infer contextual base") on a freshly-added helper are frequently **stale index**, not a real error — the in-editor index lags a beat behind source just written. Treat such diagnostics as a hint, not truth; confirm with a filtered `swift test`, not a re-read of the diagnostic.
+
 ### Test pyramid
 
 ```

--- a/apple-dev-skills/skills/swiftpm-modularization/SKILL.md
+++ b/apple-dev-skills/skills/swiftpm-modularization/SKILL.md
@@ -89,6 +89,18 @@ App target
             └── <Module>Tests/    # one-to-one
 ```
 
+## Common footguns
+
+### Pin parity across sibling apps
+
+- `swift package resolve` **always** re-resolves to the newest version each dependency's range allows — it does not consult a sibling app's committed pins. Running it to "materialize" a fresh `Package.resolved` for a second app silently drifts its pins away from the first app's committed versions.
+- To give app B pin-parity with app A: **copy** A's committed `Package.resolved` to B and swap only the `originHash` (obtained from one throwaway resolve on B), preserving the file's JSON formatting; then verify `swift build` leaves the file byte-identical (no churn). Diff the **full** pin list against the reference, not just the one dependency a task happened to mention.
+
+### Renaming a target or test directory
+
+- `swift build` plus an import-site `grep` are not sufficient verification for a target/test-directory rename. Non-Swift tooling — CI workflow files, task runners, code-gen scripts — often hard-code the **path string**, which compiles fine and passes the import grep but breaks at the tooling layer.
+- Before pushing a rename, also `grep -rn '<OldName>' <tooling dirs> .github ci_scripts` and run any gate that reads those paths (e.g. localization or fixture generation) locally to confirm it still resolves.
+
 ## Related skills
 
 - `swift6-concurrency`: Package applies `swiftLanguageModes: [.v6]` in one place.

--- a/apple-dev-skills/skills/swiftui-interaction-footguns/SKILL.md
+++ b/apple-dev-skills/skills/swiftui-interaction-footguns/SKILL.md
@@ -59,6 +59,12 @@ A class of bugs that look fine in code but break at runtime. These have shipped 
 
 - `.labelsHidden()` on `Picker` when the label is provided externally (avoids duplicated label rendering on Mac).
 - `.buttonStyle(.borderedProminent)` honours `.tint` from **iOS 15+ / macOS 12+**; both APIs were introduced together in SwiftUI 3.
+- `.foregroundStyle(...)` chained **after** `.buttonStyle(.borderedProminent)` on the `Button` itself is silently ignored — the prominent style keeps its own default label color, even though the code compiles and unit tests pass. **Fix:** apply `.foregroundStyle` to the label content **inside** the `Button { } label: { … }` closure, not chained on the `Button` call. Only a rendered screenshot exposes the ignored-placement variant.
+
+### `.onAppear` does not re-fire on `fullScreenCover` dismiss
+
+- When a `fullScreenCover` dismisses back to its presenting view, that view's `.onAppear` does **not** re-fire — an `.onAppear { refresh() }` wired for "refresh when the user returns from the modal" silently never runs. (Verified on-device across repeated open/dismiss cycles; the only fresh `.onAppear` fire in that round-trip is a transient re-mount at *open*, not at dismiss.)
+- **Fix:** drive post-dismiss refresh off an explicit teardown signal instead — a counter or flag the dismiss path sets, observed via `.onChange`, never `.onAppear`. Unit tests and code review both pass the wrong wiring; only an instrumented on-device or simulator run (a log probe in the refresh call, driving open→dismiss) exposes it.
 
 ### Touch target minimums
 


### PR DESCRIPTION
## Summary
- Folds field-tested lessons from a downstream project's real incidents into three existing skills, de-projected (no project/app names, no downstream issue numbers).
- `swiftui-interaction-footguns`: `.foregroundStyle` chained after `.buttonStyle(.borderedProminent)` is silently ignored (must go inside the label closure); `.onAppear` does not re-fire on `fullScreenCover` dismiss (post-dismiss refresh needs an explicit teardown signal via `.onChange`).
- `swift-testing-baseline`: unentitled-SwiftPM-runner landmines from constructing live CloudKit/Game-Center objects in tests (MainActor hang, needs a test-only suppression seam); `swift build` not rebuilding test-target conformers after a protocol-requirement change; stale SourceKit diagnostics vs. authoritative `swift test`.
- `swiftpm-modularization`: `swift package resolve` silently drifting pins away from a sibling app's committed versions (copy `Package.resolved` + swap `originHash` instead); target/test-directory renames breaking stringly-typed path refs in non-Swift tooling that `swift build` + import-grep can't catch.
- Three other originally-scoped targets (`mise-tool-management`, `ios-accessibility-engineering`, `app-store-review-rejections`) already carry the equivalent lessons from an earlier pass, verified by grep before starting — no changes needed there this round.

## Test plan
- [x] `python3 scripts/check-consistency.py` — green (catalog/count/zh-Hant parity; descriptions unchanged).
- [x] `git diff` and full-file grep for `sudoku|minesweeper|gameshellkit|gameappkit|#[0-9]+` (case-insensitive) across all six originally-scoped skill files — no genuine matches (one incidental "#1 cause" English idiom, pre-existing, not an issue reference).
- [x] No version fields, README counts, or frontmatter descriptions touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
