### PR TITLE
chore(release): bump apple-dev-skills minor + cross-ref cloudkit↔testing

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -3,14 +3,14 @@
   "owner": { "name": "Wei18" },
   "metadata": {
     "description": "A curated catalog of skills for AI coding agents — first-party Apple/Swift and agent-collaboration skills, plus aggregated best-of-breed external plugins (credited to their authors)",
-    "version": "1.4.0"
+    "version": "1.5.0"
   },
   "plugins": [
     {
       "name": "apple-dev-skills",
       "source": "./apple-dev-skills",
       "description": "25 first-party Apple/Swift skills. Namespaced apple-dev-skills:<skill>.",
-      "version": "1.1.1",
+      "version": "1.2.0",
       "author": { "name": "Wei18" },
       "keywords": ["swift", "ios", "macos", "apple-platform", "claude-code", "agent-skills"],
       "category": "workflow"

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ plugins load from the pinned submodule (collaborators are prompted to trust the 
 
 ```bash
 git submodule add https://github.com/wei18/apple-dev-skills.git .claude/skills/apple-dev-skills
-cd .claude/skills/apple-dev-skills && git checkout v1.4.0 && cd -
+cd .claude/skills/apple-dev-skills && git checkout v1.5.0 && cd -
 ```
 
 `.claude/settings.json` (committed):

--- a/README.zh-Hant.md
+++ b/README.zh-Hant.md
@@ -31,7 +31,7 @@
 
 ```bash
 git submodule add https://github.com/wei18/apple-dev-skills.git .claude/skills/apple-dev-skills
-cd .claude/skills/apple-dev-skills && git checkout v1.4.0 && cd -
+cd .claude/skills/apple-dev-skills && git checkout v1.5.0 && cd -
 ```
 
 `.claude/settings.json`（已提交）：
@@ -131,4 +131,4 @@ npx skills add wei18/apple-dev-skills --skill swift6-concurrency
 出貨 Apple 平台遊戲作品集——再加上對公開的 Apple / WCAG / Swift 標準的原創撰述。
 彙整的外部來源仍屬其作者所有，僅以引用方式呈現。MIT——見 [LICENSE](LICENSE)。
 
-<!-- src-sha: b3a3db89b59e2cebd8a601998aca0d5846f828cb -->
+<!-- src-sha: 9e8656ae78d8dcebce38adbb3babf8bc88104b48 -->

--- a/apple-dev-skills/.claude-plugin/plugin.json
+++ b/apple-dev-skills/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "apple-dev-skills",
-  "version": "1.1.1",
+  "version": "1.2.0",
   "description": "25 first-party Apple/Swift skills for AI-agent development — Swift 6 / SwiftPM / testing / CI / L10n / telemetry defaults, security & secrets, monetization, App Review, ASC API automation, SwiftUI footguns & navigation, plus accessibility, dependency injection, performance engineering, interactive simulator UX audits, host-driven XCUITest E2E, and CloudKit schema source of truth. Distilled from a real shipping project and public Apple/standards docs.",
   "author": { "name": "Wei18" },
   "homepage": "https://github.com/wei18/apple-dev-skills",

--- a/apple-dev-skills/skills/cloudkit-schema-source-of-truth/SKILL.md
+++ b/apple-dev-skills/skills/cloudkit-schema-source-of-truth/SKILL.md
@@ -184,5 +184,6 @@ correspondingly irreversible, deliberately manual approval step.
 ## Related skills
 
 - `swift-dependency-injection` — how CloudKit access is injected and faked, keeping schema concerns out of call sites.
+- `swift-testing-baseline` — gate live CloudKit/Game Center access behind a test-only suppression seam; constructing a live container or auth handler inside a test blocks the unentitled SwiftPM runner indefinitely (its "unentitled runner" section covers this landmine — this skill's schema is only ever tested against, never through a live container in CI).
 - `apple-public-repo-security` — why the management token is a stricter secret class than a build-time public identifier.
 - `build-time-secret-injection` — the general env-file-based secret pattern this workflow's token handling follows.


### PR DESCRIPTION
## Summary

Two follow-ups from PR #32's review, on top of latest `main` (includes #30/#31/#32):

- **Cross-reference**: `cloudkit-schema-source-of-truth`'s "Related skills" now points to `swift-testing-baseline`'s "unentitled runner" section — the CloudKit skill documents writing schema, but a reader also needs to know that constructing a *live* CloudKit container or auth handler inside a SwiftPM test blocks the unentitled test runner indefinitely; that landmine (and the test-only suppression-seam fix) already lives in `swift-testing-baseline`, this just links it.
- **Minor version bump** for the Wave 2 3-skill addition: `apple-dev-skills` `1.1.1` → `1.2.0`, marketplace metadata `1.4.0` → `1.5.0` (`collaboration-skills` untouched — no change there this round). Done via `python3 scripts/bump-version.py --apple 1.2.0 --marketplace 1.5.0`, which pairs `plugin.json` + the `marketplace.json` entry, rewrites both READMEs' `git checkout v<semver>` install pins, and re-stamps `README.zh-Hant.md`'s `src-sha` for that one-line pin change only (no full retranslation triggered).

## Test plan

- [x] `python3 scripts/check-consistency.py` (ran automatically at the end of `bump-version.py`, and re-run standalone) — `OK — 2 plugins (25/12), catalog + counts + zh-Hant consistent.`, including the new check 8 (`plugin.json` ↔ `marketplace.json` version parity)
- [x] `git show --stat HEAD` confirms the diff is exactly the 5 files claimed (marketplace.json, README.md, README.zh-Hant.md, apple-dev-skills/plugin.json, the one cross-ref line) — no unrelated drift

🤖 Generated with [Claude Code](https://claude.com/claude-code)
