### PR TITLE
fix: resolve upkeep audit findings from #25

### DIFF
--- a/apple-dev-skills/skills/swift-testing-baseline/SKILL.md
+++ b/apple-dev-skills/skills/swift-testing-baseline/SKILL.md
@@ -120,3 +120,4 @@ pixels (above) is the only viable content gate.
 - `swiftpm-modularization`: one-to-one test target layout and shared `<Project>KitTesting`.
 - `xcode-cloud-single-track-ci`: CI Xcode lock and when PR CI runs tests.
 - `mise-tool-management`: Xcode version managed by mise.
+- `cloudkit-schema-source-of-truth`: this skill's "unentitled runner" section is the seam that keeps live CloudKit/Game Center access — and the schema SSOT concerns it gates — out of the unentitled SwiftPM test run; use its test-doubles instead of a live container.

--- a/docs/superpowers/specs/2026-06-24-apple-dev-skills-from-scratch-design.md
+++ b/docs/superpowers/specs/2026-06-24-apple-dev-skills-from-scratch-design.md
@@ -54,7 +54,7 @@ is out of scope and untouched.
 ```
 wei18/apple-dev-skills/                  # marketplace repo (root)
 ├── .claude-plugin/
-│   └── marketplace.json                 # lists both first-party plugins + 3 externals
+│   └── marketplace.json                 # lists both first-party plugins + aggregated externals
 ├── apple-dev-skills/                    # first-party plugin 1 — Apple/Swift (20)
 │   ├── .claude-plugin/plugin.json
 │   └── skills/<skill>/SKILL.md
@@ -195,7 +195,7 @@ the current source of truth):
 2. The README Catalog contains every first-party skill across both plugins **plus**
    the five aggregated external plugin names — missing-direction only; extra kebab-case
    tokens in Catalog prose are tolerated by design.
-3. Hardcoded counts (README group headers `(22)`/`(12)`/`(5)`, the Install one-liner
+3. Hardcoded counts (README group headers, the Install one-liner
    comments, each `plugin.json` description's "N first-party") == actual. The group
    headers are checked by set-membership only — the values just need to appear
    somewhere among the Catalog's `(N)` headers, not per-header association.
@@ -220,7 +220,7 @@ the current source of truth):
 3. Move the root `.claude-plugin/plugin.json` into `apple-dev-skills/.claude-plugin/`;
    author a new `collaboration-skills/.claude-plugin/plugin.json`.
 4. Rewrite root `.claude-plugin/marketplace.json`: change the first-party plugin source
-   from `./` to `./apple-dev-skills`, add the `collaboration-skills` entry, keep the three
+   from `./` to `./apple-dev-skills`, add the `collaboration-skills` entry, keep the five
    externals as-is.
 5. Delete `ROADMAP.md` and `CURATION.md`; rewrite `README.md` to the §3 structure; update
    `CONTRIBUTING.md` to drop `CURATION.md` links (criteria already live there) **and document

--- a/scripts/check-consistency.py
+++ b/scripts/check-consistency.py
@@ -105,7 +105,7 @@ if not zh.is_file():
 else:
     m = re.search(r"src-sha:\s*([0-9a-f]+)", zh.read_text(encoding="utf-8"))
     cur = subprocess.run(["git", "hash-object", "README.md"], cwd=ROOT,
-                         capture_output=True, text=True).stdout.strip()
+                         capture_output=True, text=True, check=True).stdout.strip()
     if not m: fail("[zh] no embedded src-sha")
     elif m.group(1) != cur: fail("[zh] stale — run `mise run readme-zh` (src-sha != README.md)")
 


### PR DESCRIPTION
Resolves all 4 findings from the 2026-07-20 Upkeep Report.

- **MEDIUM — spec count drift**: architecture-tree comment now defers the externals count ("aggregated externals"); migration step 4 says "five externals", consistent with the doc's own marketplace table and success criteria.
- **LOW — stale as-built headers**: gate-check description drops the hardcoded `(22)`/`(12)`/`(5)` group-header values and defers to the README SSOT.
- **LOW — one-directional cross-ref**: `swift-testing-baseline/SKILL.md` now links back to `cloudkit-schema-source-of-truth` under Related skills, completing the bidirectional link intended by release #33.
- **LOW — inconsistent git call handling**: `check-consistency.py`'s `git hash-object README.md` call now passes `check=True`, matching `bump-version.py`, so git failures surface directly instead of masquerading as a stale-zh error.

Verification: `mise run check` → `OK — 2 plugins (25/12), catalog + counts + zh-Hant consistent.`

Closes #25

🤖 Generated with [Claude Code](https://claude.com/claude-code)