### PR TITLE
fix: resolve upkeep audit findings from #35

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -32,7 +32,7 @@ Full regeneration is non-deterministic — even for a 2-line content fix it rewr
   ```
 - **Larger / structural changes**: run `mise run readme-zh` for a full regeneration.
 
-## Two ways to contribute
+## Ways to contribute
 
 ### 1. Aggregate an external plugin (preferred when a good one exists)
 
@@ -48,3 +48,9 @@ Pick the plugin: Apple/Swift → `apple-dev-skills/skills/`, generic agent proce
 `collaboration-skills/skills/`. One dir per skill with a `SKILL.md` whose frontmatter
 `name:` equals the dir. Then update `README.md`'s Catalog table + the group `(N)` count and
 the plugin's `plugin.json` description count, and run `mise run check`.
+
+### 3. Report a field note (skill vs reality)
+
+Hit a real-world incident where a skill's guidance was wrong, incomplete, or missing —
+or a situation no skill covered? Open a [field note](.github/ISSUE_TEMPLATE/field-note.yml).
+Incidents are how this catalog's Sightings and known-trap entries grow.

--- a/docs/superpowers/specs/2026-06-24-apple-dev-skills-from-scratch-design.md
+++ b/docs/superpowers/specs/2026-06-24-apple-dev-skills-from-scratch-design.md
@@ -94,6 +94,10 @@ so existing consumers keep resolving (see Migration for the skill-count caveat).
 
 ## 2. Skill classification (30 → 20 / 10)
 
+The per-skill lists below are the same as-written historical snapshot as the header
+counts above — they name the 30 skills that existed at redesign time, not the current
+roster. For the current skill list, see [`README.md`](../../../README.md) Catalog.
+
 **`apple-dev-skills` (20 — Apple/Swift specific):**
 swift6-concurrency, apple-platform-targets, swiftpm-modularization, swift-testing-baseline,
 xcode-cloud-single-track-ci, mise-tool-management, oslog-logger-defaults,

--- a/scripts/gen-readme-zh.sh
+++ b/scripts/gen-readme-zh.sh
@@ -5,11 +5,18 @@ cd "$(git rev-parse --show-toplevel)"
 SHA="$(git hash-object README.md)"
 
 if command -v claude >/dev/null 2>&1; then
+  TMP="$(mktemp)"
+  trap 'rm -f "$TMP"' EXIT
   claude -p "Translate the markdown read from stdin into Traditional Chinese (zh-Hant).
 Preserve structure, code fences, links, table layout, and all identifiers (kebab-case
 skill/plugin names, install commands) verbatim. Translate only prose and table one-liners.
-Output ONLY the translated markdown, nothing else." < README.md > README.zh-Hant.md
-  printf '\n<!-- src-sha: %s -->\n' "$SHA" >> README.zh-Hant.md
+Output ONLY the translated markdown, nothing else." < README.md > "$TMP"
+  if [ ! -s "$TMP" ]; then
+    echo "claude produced empty output; leaving README.zh-Hant.md unchanged" >&2
+    exit 1
+  fi
+  printf '\n<!-- src-sha: %s -->\n' "$SHA" >> "$TMP"
+  mv "$TMP" README.zh-Hant.md
   git add README.zh-Hant.md
   echo "regenerated README.zh-Hant.md (src-sha $SHA)"
 else


### PR DESCRIPTION
Resolves all 4 findings from the 2026-07-21 Upkeep Report (findings 1+2 share one root cause).

- **LOW — spec roster drift**: extends the design spec's existing archival caveat to §2's per-skill lists — they are now explicitly marked as the as-written redesign-time snapshot, deferring the current roster to the README Catalog. No historical numbers rewritten; `check-consistency.py`'s 25/12 stays authoritative for the shipped side.
- **LOW — CONTRIBUTING gap**: adds the third contribution path ("Report a field note") linking `.github/ISSUE_TEMPLATE/field-note.yml`; section header updated to "Ways to contribute".
- **LOW — non-atomic translation write**: `gen-readme-zh.sh` now translates into a `mktemp` file, verifies non-empty output, appends the src-sha stamp, and only then `mv`s over `README.zh-Hant.md`; failures leave the previous good translation intact and exit non-zero (temp file cleaned via trap).

Verification: `mise run check` → `OK — 2 plugins (25/12), catalog + counts + zh-Hant consistent.`; `bash -n scripts/gen-readme-zh.sh` clean.

Closes #35

🤖 Generated with [Claude Code](https://claude.com/claude-code)