### PR TITLE
feat(marketplace): aggregate i-have-adhd as 6th external — by reference, credited

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -58,6 +58,13 @@
       "description": "Aggregated (not authored here). 'Lazy senior dev' mode — forces the simplest, shortest solution. General agent-behavior skill. By DietrichGebert, MIT.",
       "author": { "name": "DietrichGebert" },
       "category": "workflow"
+    },
+    {
+      "name": "i-have-adhd",
+      "source": { "source": "github", "repo": "ayghri/i-have-adhd" },
+      "description": "Aggregated (not authored here). ADHD-friendly output mode — leads with the next action, numbers steps, restates state each turn, makes wins visible. General agent-behavior skill. By Ayoub G. (ayghri), MIT.",
+      "author": { "name": "Ayoub G. (ayghri)" },
+      "category": "workflow"
     }
   ]
 }

--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ npx skills add wei18/apple-dev-skills --skill swift6-concurrency
 | `skill-authoring-patterns` | Apple/Swift catalog layer over `superpowers:writing-skills` — router descriptions, bookend sections, two-tier references, evidence-based CR |
 | `github-contribution-workflow` | gh-CLI contribution loop — PRs, issues, GitHub file ops, secrets, contribution-flow repo settings; conventions + CLEAN-before-merge |
 
-### Aggregated external (5) — by reference, credited
+### Aggregated external (6) — by reference, credited
 
 Listed here but **not authored here**; they install from their authors' own repos (you get
 their latest), credited in full. **Aggregate, don't appropriate**: only MIT-compatible,
@@ -123,6 +123,7 @@ slipped past review). Where a topic overlaps, they differ by altitude, not dupli
 | [`swiftui-pro`](https://github.com/twostraws/SwiftUI-Agent-Skill) | Paul Hudson (MIT) | SwiftUI pitfalls, deprecated-API watchlist, iOS 26 / Liquid Glass |
 | [`caveman`](https://github.com/JuliusBrussee/caveman) | JuliusBrussee (MIT) | Ultra-compressed communication mode — cuts ~75% of tokens (general agent behavior) |
 | [`ponytail`](https://github.com/DietrichGebert/ponytail) | DietrichGebert (MIT) | "Lazy senior dev" mode — forces the simplest, shortest solution (general agent behavior) |
+| [`i-have-adhd`](https://github.com/ayghri/i-have-adhd) | Ayoub G. (MIT) | Always-on ADHD-friendly output mode — action-first, numbered steps, state restated each turn; vs `caveman` (token compression) and `ponytail` (solution simplicity), this shapes structure (general agent behavior) |
 
 ## Provenance
 

--- a/README.zh-Hant.md
+++ b/README.zh-Hant.md
@@ -1,18 +1,18 @@
 # apple-dev-skills
 
-> 一份**為 AI 編碼代理打造的精選技能目錄**（[Claude Code](https://code.claude.com)）——
-> 由一位開發者自身的出貨經驗所建立與蒐集。第一方的 **Apple/Swift**
-> 與 **AI 代理協作**技能，外加**以引用方式**彙整的同類最佳**外部**技能外掛
-> （歸功於原作者，絕不複製）。
+> 一份**為 AI 編程代理精選的技能目錄**（[Claude Code](https://code.claude.com)）——
+> 由一位開發者的實際出貨經驗打造與收集而成。第一方的 **Apple/Swift** 與
+> **AI 代理協作**技能，外加以**引用方式**匯集的同類最佳**外部**技能外掛
+> （完整歸功於原作者，絕不複製）。
 >
 > 語言：[English](README.md) · [繁體中文](README.zh-Hant.md)
 
-本倉庫是一個**市集（marketplace）**，內含兩個第一方外掛，並彙整數個外部來源。
+本 repo 是一個**市集（marketplace）**，托管兩個第一方外掛與數個匯集的外部外掛。
 
 ## 安裝
 
-> Claude Code 透過**外掛（plugin）**系統來發現共享技能。本倉庫既是
-> 市集，也是兩個第一方外掛的所在地。
+> Claude Code 透過**外掛（plugin）**系統來發現共享技能。本 repo 既是一個
+> 市集，也是兩個第一方外掛的家。
 
 ### A — 市集（最簡單）
 
@@ -22,19 +22,19 @@
 /plugin install collaboration-skills@apple-dev-skills      # 12 agent-collaboration skills
 ```
 
-兩者擇一或全裝皆可。外部來源以相同方式安裝，例如 `/plugin install swiftui-expert@apple-dev-skills`。
+安裝其中一個或兩個都裝。外部外掛以相同方式安裝，例如 `/plugin install swiftui-expert@apple-dev-skills`。
 
-### B — 倉庫層級（vendored submodule，已釘選版本）
+### B — repo 層級（vendored 子模組，釘選版本）
 
-將其 vendor 並釘選進單一倉庫，接著註冊一個 project-scope 的本機路徑市集，讓
-外掛從釘選的 submodule 載入（協作者會被提示信任此工作區）：
+將其 vendor 並釘選進單一 repo，再註冊一個 project-scope 的 local-path 市集，讓
+外掛從釘選的子模組載入（協作者會被提示信任該工作區）：
 
 ```bash
 git submodule add https://github.com/wei18/apple-dev-skills.git .claude/skills/apple-dev-skills
 cd .claude/skills/apple-dev-skills && git checkout v1.5.0 && cd -
 ```
 
-`.claude/settings.json`（已提交）：
+`.claude/settings.json`（納入版控）：
 
 ```json
 {
@@ -48,9 +48,9 @@ cd .claude/skills/apple-dev-skills && git checkout v1.5.0 && cd -
 }
 ```
 
-單憑一個裸 submodule 是**不會**被發現的——真正載入技能的是市集註冊。
+僅有一個裸子模組**不會**被發現——真正載入技能的是市集註冊。
 
-### C — `npx skills`（扁平，無外掛）
+### C — `npx skills`（扁平式，無外掛）
 
 ```bash
 npx skills add wei18/apple-dev-skills --list
@@ -63,72 +63,73 @@ npx skills add wei18/apple-dev-skills --skill swift6-concurrency
 
 | Skill | 一句話說明 |
 |---|---|
-| `swift6-concurrency` | Swift 6 語言模式 + 完整並行檢查；Sendable 為預設 |
-| `apple-platform-targets` | 預設 iOS 18 / macOS 15、Xcode 16+；僅在使用最新 OS 限定 API 時才升到 26 |
-| `swiftpm-modularization` | 單一 Package、多 target、薄 App、DI composition root、一對一測試 |
-| `swift-testing-baseline` | swift-testing + pointfreeco snapshot；protocol fake；嚴格／寬容 snapshot 閘門 |
-| `xcode-cloud-single-track-ci` | 單軌 Xcode Cloud；PR / Main / Release / Periodic；合併前 PR CI |
-| `mise-tool-management` | mise 管理二進位 CLI 工具；dev + CI 共用 `.mise.toml`；macOS 限定 `os` 防護 |
-| `oslog-logger-defaults` | `os.Logger`（不用第三方）；subsystem = bundle ID；`.private` 預設 |
-| `apple-three-piece-analytics` | ASC Analytics + MetricKit + Game Center；無第三方追蹤；PrivacyInfo 必備 |
-| `telemetry-facade-pattern` | 單一 `Telemetry` target、扇出 facade；OSLog / NoOp / MetricKit / GameCenter sink |
-| `ai-translated-localization` | 預設 7 種語系；AI 翻譯流程；`Localizable.xcstrings`；完整度閘門 |
-| `ios-accessibility-engineering` | SwiftUI 與 UIKit 的 VoiceOver / Dynamic Type / 觸控目標 / Reduce Motion；WCAG 2.2 |
+| `swift6-concurrency` | Swift 6 語言模式 + 完整並行檢查；預設 Sendable |
+| `apple-platform-targets` | 預設 iOS 18 / macOS 15、Xcode 16+；僅在需要 latest-OS-only API 時才升到 26 |
+| `swiftpm-modularization` | 單一 Package、多 target、精簡 App、DI composition root、一對一測試 |
+| `swift-testing-baseline` | swift-testing + pointfreeco snapshot；protocol fake；嚴格/寬容 snapshot 閘門 |
+| `xcode-cloud-single-track-ci` | 單軌 Xcode Cloud；PR / Main / Release / Periodic；合併前的 PR CI |
+| `mise-tool-management` | mise 管理二進位 CLI 工具；dev 與 CI 共用 `.mise.toml`；macOS-only 的 `os` 防護 |
+| `oslog-logger-defaults` | `os.Logger`（不用第三方）；subsystem = bundle ID；預設 `.private` |
+| `apple-three-piece-analytics` | ASC Analytics + MetricKit + Game Center；不用第三方追蹤；PrivacyInfo 必備 |
+| `telemetry-facade-pattern` | 單一 `Telemetry` target、fan-out facade；OSLog / NoOp / MetricKit / GameCenter sink |
+| `ai-translated-localization` | 預設 7 個 locale；AI 翻譯流程；`Localizable.xcstrings`；完整度閘門 |
+| `ios-accessibility-engineering` | 為 SwiftUI 與 UIKit 做 VoiceOver / Dynamic Type / 觸控目標 / Reduce Motion；WCAG 2.2 |
 | `swift-dependency-injection` | Protocol 注入 + composition root；environment vs constructor；`@TaskLocal`；Sendable |
 | `ios-performance-engineering` | Instruments / xctrace / hang-hitch 預算 / 啟動 / 記憶體 / 二進位大小 / MetricKit |
-| `apple-public-repo-security` | 公開 iOS/macOS 倉庫的三道防線 + rotate-first 洩漏 SOP |
-| `build-time-secret-injection` | xcconfig + Info.plist `$()` + `Bundle.main`，用於隨二進位出貨但不進 diff 的 ID |
-| `monetization-sdk-integration` | 新增／升級／稽核變現 SDK；將 `import` 隔離到單一橋接檔 |
-| `app-store-review-rejections` | 診斷並預先化解免費 + 廣告 + IAP + CloudKit + GC 的 App Review 退件類型 |
-| `asc-api-automation` | 以 `.p8` 簽 ES256 JWT + curl 直呼 ASC REST API — TestFlight、metadata、送審、報表；不用 fastlane |
-| `swiftui-interaction-footguns` | 會躲過純程式碼審查的已知 SwiftUI 互動 bug |
-| `swiftui-navigation-architecture` | 型別化 `Route` enum + `@Observable` router；value-based `NavigationStack`；每個 transition 的呈現語意（含 macOS fallback）；deep link；分頁各自 path |
-| `app-icon-rasterize` | 透過 `qlmanage` 將 1024 SVG 圖示點陣化為 asset-catalog PNG——無需 Homebrew |
-| `ios-design-mockup` | 從規格產生單檔 HTML iOS 設計稿——iPhone 外框 + token |
-| `interactive-simulator-ux-audit` | 用 `idb`（tap/describe/screenshot）驅動已開機的模擬器，抓出 snapshot 抓不到的導覽／彈窗／安全區域 bug |
-| `host-driven-xcuitest-e2e` | 透過 Tuist 執行「啟動 app」型 XCUITest E2E——專屬 scheme 接線 + macOS 視窗座標點擊驅動 |
-| `cloudkit-schema-source-of-truth` | 已提交的 `.ckdb` + `cktool` export/validate/deploy 到 Development；Production 是使用者專屬的 Console-only gate |
+| `apple-public-repo-security` | 公開 iOS/macOS repo 的三道防線 + 洩漏優先輪替 SOP |
+| `build-time-secret-injection` | xcconfig + Info.plist `$()` + `Bundle.main`，用於「隨二進位出貨但不進 diff」的 ID |
+| `monetization-sdk-integration` | 新增/升級/稽核變現 SDK；將 `import` 隔離到單一 bridge 檔 |
+| `app-store-review-rejections` | 診斷並預先化解 free + ads + IAP + CloudKit + GC 的 App Review 拒審類別 |
+| `asc-api-automation` | 以 `.p8` 產生 ES256 JWT + curl 呼叫 ASC REST API——TestFlight、metadata、送審、報表；不用 fastlane |
+| `swiftui-interaction-footguns` | 純程式碼審查漏掉的已知 SwiftUI 互動 bug |
+| `swiftui-navigation-architecture` | 型別化 `Route` enum + `@Observable` router；value-based `NavigationStack`；每次轉場的呈現語意含 macOS fallback；deep link；每個 tab 各自的 path |
+| `app-icon-rasterize` | 用 `qlmanage` 將 1024 SVG 圖示點陣化為 asset-catalog PNG——不用 Homebrew |
+| `ios-design-mockup` | 從規格產生單檔 HTML iOS 設計 mockup——iPhone 框架 + tokens |
+| `interactive-simulator-ux-audit` | 用 `idb` 驅動已啟動的 Simulator（tap/describe/screenshot）以捕捉 snapshot 抓不到的 nav/modal/safe-area bug |
+| `host-driven-xcuitest-e2e` | 透過 Tuist 的啟動 App XCUITest E2E——專屬 scheme 接線 + macOS 視窗框架點擊驅動 |
+| `cloudkit-schema-source-of-truth` | 納入版控的 `.ckdb` + `cktool` 匯出/驗證/部署到 Development；Production 是使用者自持、僅限 Console 的閘門 |
 
 ### collaboration-skills (12) — AI 代理流程
 
 | Skill | 一句話說明 |
 |---|---|
-| `spec-phase-orchestration` | 實作前文件管線；逐節核准 |
-| `subagent-review-cycles` | Leader / Developer / Code-Reviewer 三角；第一輪外觀問題 inline；limit(N) |
-| `leader-developer-handoff-contract` | 派發 sub-agent 時的 5 個必要元素 |
-| `agent-impl-notes-log` | sub-agent 任務中持續記錄 impl-notes——決策、偏離、待解問題 |
-| `subagent-conflict-detection` | 檢查新 sub-agent 的目標不與進行中的 worktree 重疊 |
+| `spec-phase-orchestration` | 實作前的文件流水線；逐節逐節核准 |
+| `subagent-review-cycles` | Leader / Developer / Code-Reviewer 三方；第一輪外觀性 inline；limit(N) |
+| `leader-developer-handoff-contract` | 派工子代理時的 5 個必要元素 |
+| `agent-impl-notes-log` | 子代理任務進行中的即時 impl-notes——決策、偏離、待解問題 |
+| `subagent-conflict-detection` | 檢查新子代理的目標不與進行中的 worktree 重疊 |
 | `methodology-pattern-extractor` | 從會議記錄中萃取重複出現 ≥3 次的模式 |
-| `session-to-meeting-log` | 將一段 Claude Code session 整併成會議記錄；摘要而非逐字 |
-| `pr-diff-verification` | push/PR 前，驗證 `git show --stat HEAD` 與 commit 宣稱一致 |
-| `backlog-routing-by-topic` | 依主題將零散點子導向對應 spec 檔的 §Backlog |
-| `claude-skill-plugin-packaging` | 散布／安裝 Claude Code 技能——depth-1 規則、plugin + marketplace、彙整 |
-| `skill-authoring-patterns` | 疊在 `superpowers:writing-skills` 之上的 Apple/Swift 目錄層——router 描述、首尾段落、兩層引用、基於證據的 CR |
-| `github-contribution-workflow` | gh-CLI 貢獻迴圈——PR、issue、GitHub 檔案操作、secret、contribution-flow 倉庫設定；慣例 + 合併前 CLEAN |
+| `session-to-meeting-log` | 將一個 Claude Code session 整併成會議記錄；摘要，非逐字 |
+| `pr-diff-verification` | push/PR 前，驗證 `git show --stat HEAD` 與 commit 宣稱相符 |
+| `backlog-routing-by-topic` | 依主題將零散想法路由到對應 spec 檔的 §Backlog |
+| `claude-skill-plugin-packaging` | 發布/安裝 Claude Code 技能——depth-1 規則、plugin + marketplace、匯集 |
+| `skill-authoring-patterns` | 在 `superpowers:writing-skills` 之上的 Apple/Swift 目錄層——router 描述、bookend 章節、兩層式引用、以證據為本的 CR |
+| `github-contribution-workflow` | gh-CLI 貢獻循環——PR、issue、GitHub 檔案操作、secrets、contribution-flow repo 設定；慣例 + 合併前 CLEAN |
 
-### 彙整的外部來源 (5) — 以引用方式，已歸功
+### 匯集的外部技能 (6) — 以引用方式，完整歸功
 
-此處列出但**並非在此撰寫**；它們從原作者自己的倉庫安裝（你拿到的是
-其最新版），並完整歸功。**彙整，不據為己有**：僅列出 MIT 相容、
+於此列出但**非在此撰寫**；它們從原作者自己的 repo 安裝（你取得的是
+其最新版本），並完整歸功。**匯集，不據為己有**：僅列出 MIT 相容、
 非重複的外掛——第一方技能只為真正的缺口而寫。
-外部來源屬於廣泛的**參考**（「這是 API／這是怎麼建 X」）；第一方
-技能位於其下一層，作為**有主見的預設值與出貨實戰故事**
-（用 iOS 18、單一 Package、swift-testing + snapshot、OSLog 不用第三方、躲過審查的執行期 bug）。
-凡主題重疊處，它們是高度不同，而非重複。
+外部技能是廣泛的**參考**（「這是 API／這是怎麼建 X」）；第一方技能
+位於其下一層，作為**有主張的預設值與已出貨的實戰故事**
+（用 iOS 18、單一 Package、swift-testing + snapshot、OSLog 不用第三方、審查漏掉的
+執行期 bug）。當主題重疊時，它們差在高度，而非重複。
 
-| Plugin | 作者 | 涵蓋範圍 |
+| Plugin | 作者 | 涵蓋 |
 |---|---|---|
 | [`apple-skills`](https://github.com/vabole/apple-skills) | vabole (MIT) | 廣泛的 Apple 框架——SwiftUI、SwiftData、App Intents、WidgetKit、StoreKit、HealthKit … |
 | [`swiftui-expert`](https://github.com/AvdLee/SwiftUI-Agent-Skill) | Antoine van der Lee (MIT) | SwiftUI 模式、Swift Charts、Liquid Glass、Instruments 工具鏈 |
-| [`swiftui-pro`](https://github.com/twostraws/SwiftUI-Agent-Skill) | Paul Hudson (MIT) | SwiftUI 陷阱、deprecated-API 觀察清單、iOS 26 / Liquid Glass |
+| [`swiftui-pro`](https://github.com/twostraws/SwiftUI-Agent-Skill) | Paul Hudson (MIT) | SwiftUI 陷阱、已棄用 API 觀察清單、iOS 26 / Liquid Glass |
 | [`caveman`](https://github.com/JuliusBrussee/caveman) | JuliusBrussee (MIT) | 超壓縮溝通模式——削減約 75% token（通用代理行為） |
-| [`ponytail`](https://github.com/DietrichGebert/ponytail) | DietrichGebert (MIT) | 「懶惰資深開發者」模式——強制採用最簡單、最短的解法（通用代理行為） |
+| [`ponytail`](https://github.com/DietrichGebert/ponytail) | DietrichGebert (MIT) | 「懶惰資深開發者」模式——強制最簡最短的解法（通用代理行為） |
+| [`i-have-adhd`](https://github.com/ayghri/i-have-adhd) | Ayoub G. (MIT) | 常駐的 ADHD 友善輸出模式——行動優先、編號步驟、每回合重述狀態；相對於 `caveman`（token 壓縮）與 `ponytail`（解法簡化），本項塑造的是結構（通用代理行為） |
 
 ## 出處
 
 第一方技能是從 [`wei18/Sudoku`](https://github.com/wei18/Sudoku) 的
-`.claude/skills/` 提煉並通用化而來——一個 spec-first、由 AI-Leader/Developer 打造的
-出貨 Apple 平台遊戲作品集——再加上對公開的 Apple / WCAG / Swift 標準的原創撰述。
-彙整的外部來源仍屬其作者所有，僅以引用方式呈現。MIT——見 [LICENSE](LICENSE)。
+`.claude/skills/` 蒸餾與泛化而來——一個 spec-first、由 AI-Leader/Developer 打造、
+已出貨的 Apple 平台遊戲作品集——再加上對公開 Apple / WCAG / Swift 標準的原創撰述。
+匯集的外部技能仍是其作者的作品，僅以引用方式呈現。MIT——見 [LICENSE](LICENSE)。
 
-<!-- src-sha: 9e8656ae78d8dcebce38adbb3babf8bc88104b48 -->
+<!-- src-sha: 8b04d1d1cfa8cda2fbd6eabdabaeaec1f1d82343 -->

--- a/scripts/check-consistency.py
+++ b/scripts/check-consistency.py
@@ -4,14 +4,14 @@
 Checks
   1. Each <plugin>/skills/<dir>/ has a SKILL.md whose frontmatter name == <dir>.
   2. README.md Catalog contains every first-party skill (both plugins, 37) AND the
-     five aggregated external plugin names (missing-direction only; extra kebab
+     six aggregated external plugin names (missing-direction only; extra kebab
      tokens are tolerated by design — Catalog prose legitimately names other things).
-  3. Counts present: the values 25/12/5 each appear among the Catalog's "(N)" group
+  3. Counts present: the values 25/12/6 each appear among the Catalog's "(N)" group
      headers (set membership, not per-header association); the Install one-liner
      comments and each plugin.json's "N first-party" are checked exactly.
   4. README.zh-Hant.md exists and its embedded src-sha == git hash-object README.md.
   5. All plugin/marketplace JSON parse; the two subdir plugin sources resolve to dirs;
-     marketplace.json lists exactly the 7 plugins (2 local + 5 externals).
+     marketplace.json lists exactly the 8 plugins (2 local + 6 externals).
   6. The `git checkout v<semver>` pin in both READMEs' Install section ==
      marketplace.json metadata.version (drifted silently before: v1.2.0 → #17).
   7. Each SKILL.md frontmatter description <= DESC_MAX chars (descriptions are
@@ -26,7 +26,7 @@ from pathlib import Path
 
 ROOT = Path(__file__).resolve().parent.parent
 PLUGINS = {"apple-dev-skills": 25, "collaboration-skills": 12}
-EXTERNALS = {"apple-skills", "swiftui-expert", "swiftui-pro", "caveman", "ponytail"}
+EXTERNALS = {"apple-skills", "swiftui-expert", "swiftui-pro", "caveman", "ponytail", "i-have-adhd"}
 DESC_MAX = 800  # ceiling on frontmatter description length; which skill is currently
                 # longest shifts as skills are added — don't hardcode a name here
 errors: list[str] = []


### PR DESCRIPTION
## What

Adds [`ayghri/i-have-adhd`](https://github.com/ayghri/i-have-adhd) (8.6k ⭐, MIT) to the aggregated-externals roster — an ADHD-friendly output mode: lead with the next action, number steps, restate state each turn, make wins visible.

## Why this fits the roster

- **By reference, never copied** — installs from the author's repo via `{"source": "github"}`, same as `caveman`/`ponytail`; users always get upstream's latest.
- **Criteria check**: MIT ✓ · best-of-breed (8.6k stars, eval suite, multilingual docs) ✓ · valid plugin structure (root `plugin.json` + `.claude-plugin/` + `skills/`, verified via GitHub API) ✓.
- **Non-duplicate**: third agent-behavior external, but a distinct axis — `caveman` compresses tokens, `ponytail` simplifies solutions, `i-have-adhd` shapes *structure* (action-first, numbered, stateful). The Covers column spells out the distinction.

## Changes

- `.claude-plugin/marketplace.json` — new github-source entry, credited to Ayoub G. (ayghri)
- `README.md` — externals table row; heading (5)→(6); `README.zh-Hant.md` regenerated (full-retranslation churn is inherent to `gen-readme-zh.sh`)
- `scripts/check-consistency.py` — `EXTERNALS` set + docstring counts

## Verification

`mise run check` green: `OK — 2 plugins (25/12), catalog + counts + zh-Hant consistent.`

🤖 Generated with [Claude Code](https://claude.com/claude-code)