### PR TITLE
chore(release): bump marketplace to 1.6.0

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -3,7 +3,7 @@
   "owner": { "name": "Wei18" },
   "metadata": {
     "description": "A curated catalog of skills for AI coding agents — first-party Apple/Swift and agent-collaboration skills, plus aggregated best-of-breed external plugins (credited to their authors)",
-    "version": "1.5.0"
+    "version": "1.6.0"
   },
   "plugins": [
     {

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ plugins load from the pinned submodule (collaborators are prompted to trust the 
 
 ```bash
 git submodule add https://github.com/wei18/apple-dev-skills.git .claude/skills/apple-dev-skills
-cd .claude/skills/apple-dev-skills && git checkout v1.5.0 && cd -
+cd .claude/skills/apple-dev-skills && git checkout v1.6.0 && cd -
 ```
 
 `.claude/settings.json` (committed):

--- a/README.zh-Hant.md
+++ b/README.zh-Hant.md
@@ -31,7 +31,7 @@
 
 ```bash
 git submodule add https://github.com/wei18/apple-dev-skills.git .claude/skills/apple-dev-skills
-cd .claude/skills/apple-dev-skills && git checkout v1.5.0 && cd -
+cd .claude/skills/apple-dev-skills && git checkout v1.6.0 && cd -
 ```
 
 `.claude/settings.json`（納入版控）：
@@ -132,4 +132,4 @@ npx skills add wei18/apple-dev-skills --skill swift6-concurrency
 已出貨的 Apple 平台遊戲作品集——再加上對公開 Apple / WCAG / Swift 標準的原創撰述。
 匯集的外部技能仍是其作者的作品，僅以引用方式呈現。MIT——見 [LICENSE](LICENSE)。
 
-<!-- src-sha: 8b04d1d1cfa8cda2fbd6eabdabaeaec1f1d82343 -->
+<!-- src-sha: 099acb9f2a083db1b4fc931542d9af33cd295864 -->


### PR DESCRIPTION
Release bump for the i-have-adhd aggregation (#39): marketplace metadata.version + README install pins → 1.6.0. Gate green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)