### PR TITLE
fix(scripts): flag-order bug, stale-zh laundering, zh Catalog + YAML-quote gates

### DIFF
--- a/scripts/bump-version.py
+++ b/scripts/bump-version.py
@@ -50,6 +50,17 @@ def set_plugin_version(plugin_dir: str, version: str):
 
 
 def set_marketplace_version(version: str):
+    # Refuse to bump while the zh mirror is already stale — otherwise the re-stamp
+    # below just re-freshens a src-sha that was never an honest mirror of README.md
+    # (regression: bump-version.py --marketplace silently launders a stale zh mirror
+    # into a green gate, see check-consistency.py rule 4).
+    zh = ROOT / "README.zh-Hant.md"
+    pre_sha = subprocess.run(["git", "hash-object", "README.md"], cwd=ROOT,
+                             capture_output=True, text=True, check=True).stdout.strip()
+    m = re.search(r"<!-- src-sha: ([0-9a-f]+) -->", zh.read_text(encoding="utf-8"))
+    if not m or m.group(1) != pre_sha:
+        die("README.zh-Hant.md src-sha is stale vs README.md — run `mise run readme-zh` first, then re-run bump")
+
     MP.write_text(sub_once(MP.read_text(encoding="utf-8"),
                            r'("metadata"\s*:\s*\{[^}]*?"version"\s*:\s*")' + SEMVER + r'(")',
                            rf"\g<1>{version}\g<2>", "marketplace metadata"), encoding="utf-8")
@@ -61,7 +72,6 @@ def set_marketplace_version(version: str):
         p.write_text(text, encoding="utf-8")
     sha = subprocess.run(["git", "hash-object", "README.md"], cwd=ROOT,
                          capture_output=True, text=True, check=True).stdout.strip()
-    zh = ROOT / "README.zh-Hant.md"
     zh.write_text(sub_once(zh.read_text(encoding="utf-8"),
                            r"(<!-- src-sha: )[0-9a-f]+( -->)", rf"\g<1>{sha}\g<2>",
                            "zh-Hant src-sha"), encoding="utf-8")

--- a/scripts/check-consistency.py
+++ b/scripts/check-consistency.py
@@ -18,6 +18,12 @@ Checks
      always-on context for every consumer session; keeps Lens-3 compression durable).
   8. Each plugin's `.claude-plugin/plugin.json` "version" == the corresponding
      marketplace.json plugins[] entry "version" (the pair bump-version.py maintains).
+  9. README.zh-Hant.md's `## 目錄` section covers the same first-party skills +
+     externals as README.md's Catalog (mirrors check 2; count regex also accepts
+     full-width parens, since the zh mirror is hand-typed).
+  10. Each SKILL.md frontmatter description that is not quoted must not contain
+      ": " or start with a YAML indicator character (PR #42: an unquoted value
+      containing ": " breaks strict YAML parsers).
 Stdlib only.
 """
 from __future__ import annotations
@@ -58,6 +64,12 @@ for plugin, expected in PLUGINS.items():
         if desc is None: fail(f"[skill] {plugin}/{name}: no frontmatter description")
         elif len(desc) > DESC_MAX:
             fail(f"[skill] {plugin}/{name}: description {len(desc)} chars > {DESC_MAX}")
+        # 10. description must survive a strict YAML parse — fm_field() returns the
+        # raw value (quotes intact, not stripped), so check quoting directly on it.
+        if desc:
+            quoted = len(desc) >= 2 and desc[0] in "'\"" and desc[-1] == desc[0]
+            if not quoted and (": " in desc or desc[0] in "[]{}&*>|#%@`"):
+                fail(f"[skill] {plugin}/{name}: description must be quoted (contains ': ' or a YAML indicator)")
 
 # helper: scope README Catalog section
 def scoped(text: str, *markers: str) -> str:
@@ -82,6 +94,24 @@ else:
         if required not in g:
             fail(f"[readme] Catalog counts {sorted(g)} must include {sorted((*PLUGINS.values(), len(EXTERNALS)))}")
             break
+
+# 9. README.zh-Hant.md's 目錄 (Catalog) section — same token coverage check as
+# above, mirrored: it's hand-typed so a translator can silently drop/mistype a
+# skill token without English README.md or the src-sha check ever noticing.
+zh_path = ROOT / "README.zh-Hant.md"
+if zh_path.is_file():
+    zh_sec = scoped(zh_path.read_text(encoding="utf-8"), "## 目錄")
+    if not zh_sec:
+        fail("[zh] no '## 目錄' section")
+    else:
+        zh_tokens = set(re.findall(r"`([a-z0-9][a-z0-9-]+)`", zh_sec))
+        zh_missing = (all_skills | EXTERNALS) - zh_tokens
+        if zh_missing: fail(f"[zh] 目錄 missing: {sorted(zh_missing)}")
+        zg = [int(x) for x in re.findall(r"[\(（](\d+)[\)）]", zh_sec)]
+        for required in (*PLUGINS.values(), len(EXTERNALS)):
+            if required not in zg:
+                fail(f"[zh] 目錄 counts {sorted(zg)} must include {sorted((*PLUGINS.values(), len(EXTERNALS)))}")
+                break
 
 # plugin.json counts
 plugin_json_versions: dict[str, str] = {}

--- a/scripts/install-flat.sh
+++ b/scripts/install-flat.sh
@@ -5,11 +5,48 @@
 # the aggregated externals. This script walks marketplace.json (the SSOT) and
 # adds every plugin source, externals included, from their authors' repos.
 # Usage: scripts/install-flat.sh [--dry-run] [extra `npx skills add` flags, e.g. -g]
+#   --dry-run may appear in any position; every other argument is forwarded.
 set -eu
-cd "$(git rev-parse --show-toplevel)"
 
+TOP="$(git rev-parse --show-toplevel 2>/dev/null || true)"
+if [ -z "$TOP" ] || [ ! -f "$TOP/.claude-plugin/marketplace.json" ]; then
+  echo "install-flat.sh reads this repo's marketplace.json, so it must run from inside a clone:" >&2
+  echo "  git clone https://github.com/wei18/apple-dev-skills" >&2
+  echo "  cd apple-dev-skills && scripts/install-flat.sh --dry-run" >&2
+  exit 1
+fi
+cd "$TOP"
+
+# Pull --dry-run out of any position, keeping the remaining args in "$@" (rotate-and-shift).
 DRY=0
-if [ "${1:-}" = "--dry-run" ]; then DRY=1; shift; fi
+argc=$#
+while [ "$argc" -gt 0 ]; do
+  case "$1" in
+    --dry-run) DRY=1 ;;
+    *) set -- "$@" "$1" ;;
+  esac
+  shift
+  argc=$((argc - 1))
+done
+
+# Quote one argument the way a shell would, so a dry-run line pastes back verbatim.
+quote() {
+  case "$1" in
+    *[!A-Za-z0-9@%_+=:,./-]*) printf "'%s'" "$(printf '%s' "$1" | sed "s/'/'\\\\''/g")" ;;
+    *) printf '%s' "$1" ;;
+  esac
+}
+
+# One argv, two consumers: print it (dry-run) or exec it (real run) — never two spellings.
+install_one() {
+  if [ "$DRY" -eq 1 ]; then
+    sep=''
+    for a in "$@"; do printf '%s' "$sep"; quote "$a"; sep=' '; done
+    printf '\n'
+  else
+    "$@"
+  fi
+}
 
 SOURCES="$(python3 - <<'PY'
 import json
@@ -23,14 +60,13 @@ for p in json.load(open(".claude-plugin/marketplace.json"))["plugins"]:
     elif s.get("source") == "github":
         print(s["repo"])
     elif s.get("source") == "git-subdir":
-        print(s["url"])
+        # `skills add` takes a subdirectory as a GitHub tree URL; printing the bare
+        # url would name a different (whole-repo) install than the one that runs.
+        ref = s.get("sha") or s.get("ref") or "main"
+        print(f"{s['url'].rstrip('/')}/tree/{ref}/{s['path'].strip('/')}")
 PY
 )"
 
 for src in $SOURCES; do
-  if [ "$DRY" -eq 1 ]; then
-    echo "npx skills add $src --skill '*' -y $*"
-  else
-    npx -y skills add "$src" --skill '*' -y "$@"
-  fi
+  install_one npx -y skills add "$src" --skill '*' -y "$@"
 done


### PR DESCRIPTION
## Summary
- `install-flat.sh`: `--dry-run` now parses at any argv position (previously only `$1`, so `-g --dry-run` silently ran the real install); dry-run and real run now share one argv; `git-subdir` sources print the full tree URL (path was being dropped); running outside a clone now prints a human-readable message and exits 1 instead of failing obscurely.
- `bump-version.py`: `--marketplace` now refuses to run when `README.zh-Hant.md`'s embedded `src-sha` is already stale vs `README.md`, so it can no longer re-stamp (and thereby launder) an out-of-date zh mirror into a green gate.
- `check-consistency.py`: two new rules —
  - rule 9: the same Catalog token/count coverage check now also runs against `README.zh-Hant.md`'s hand-typed `## 目錄` section (count regex accepts full-width parens too).
  - rule 10: a frontmatter `description` containing `": "` or starting with a YAML indicator character must be quoted (stdlib-only regression guard for the bug fixed in #42).

## Test plan
- [x] `python3 scripts/check-consistency.py` on a clean tree — `OK`, exit 0.
- [x] Negative test (a): PATH-stub `npx`, `sh scripts/install-flat.sh -g --dry-run` → 0 stub invocations (previously would have made 7 real calls).
- [x] Negative test (b): appended a line to `README.md`, ran `python3 scripts/bump-version.py --marketplace 1.6.1` → exits non-zero with the stale-zh message; `git status` shows only the deliberately-polluted `README.md` changed, no other file touched.
- [x] Negative test (c): mangled one skill token in `README.zh-Hant.md`'s 目錄 (README.md untouched) → gate fails with `[zh] 目錄 missing: [...]`.
- [x] Negative test (d): stripped the surrounding quotes from `ios-design-mockup`'s description (which contains `": "`) → gate fails with the new quoting message.
- [x] All four negative-test files restored to their original content afterward (`git status` clean apart from the three script diffs).
- [x] `install-flat.sh --dry-run` output is copy-paste runnable shell.
- [x] `rg -n 'TODO|FIXME|stub|placeholder'` on the diff — no hits.

Scope note: does not touch any `SKILL.md`, `README.md`, `README.zh-Hant.md`, or `CONTRIBUTING.md` — those are handled by a separate PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)