### PR TITLE
fix(skills): correct factual errors and project residue in skill content

### DIFF
--- a/apple-dev-skills/skills/app-icon-rasterize/SKILL.md
+++ b/apple-dev-skills/skills/app-icon-rasterize/SKILL.md
@@ -7,7 +7,7 @@ description: Rasterize a designer-authored 1024×1024 SVG into the PNG that Appl
 
 Use when a designer hands off the icon as SVG and you need the PNG that `AppIcon.appiconset/Contents.json` references.
 
-This is the gap discovered during first-pass icon production on a real project — the SVG → 1024 PNG step was undocumented (only the downstream Pillow Lanczos *downscale* to the macOS ladder was written up). Each appearance — Light, Dark, Tinted — is a single 1024 universal PNG produced by exactly one rasterize step, documented here. (Tinted is now a standard third appearance alongside Light and Dark; all apps in the reference project ship `AppIcon-Tinted.png`.)
+This is the gap discovered during first-pass icon production on a real project — the SVG → 1024 PNG step was undocumented (only the downstream Pillow Lanczos *downscale* to the macOS ladder was written up). Each appearance — Light, Dark, Tinted — is a single 1024 universal PNG produced by exactly one rasterize step, documented here. (Tinted is now a standard third appearance alongside Light and Dark; shipped apps ship `AppIcon-Tinted.png`.)
 
 ## When to use
 
@@ -169,7 +169,7 @@ Tinted entry present — `AppIcon-Tinted.png`, `appearance: luminosity / value: 
 
 | Tool | Reason rejected |
 |---|---|
-| `rsvg-convert` (librsvg) | Requires Homebrew, not installed on this Mac |
+| `rsvg-convert` (librsvg) | Requires Homebrew, not assumed present |
 | `inkscape --export-png` | Requires Homebrew or .app install |
 | `imagemagick convert` | Requires Homebrew |
 | `sips` | Does not read SVG input on macOS as of Sequoia |
@@ -180,6 +180,10 @@ Tinted entry present — `AppIcon-Tinted.png`, `appearance: luminosity / value: 
 
 `qlmanage` ships with macOS, takes one command, outputs the exact PNG shape Apple wants. The trade-off is that QuickLook's SVG generator may diverge slightly from full-spec SVG 1.1 — keep the SVG simple (flat shapes, no filters, no text) and the output is faithful.
 
-## Companion skill
+## iOS vs macOS: which output applies
 
-The macOS size-ladder downscale workflow is documented in the "macOS ladder reality check" section above; it is superseded by the universal single-PNG approach for new projects, but remains useful as a reference for older Xcode targets that still require the explicit size ladder.
+For new projects: iOS targets use the single universal 1024 PNG produced by this skill's
+Procedure section. macOS targets additionally need the size-ladder downscale documented in
+"macOS ladder reality check" above — that ladder is not superseded or optional, it's a
+platform requirement that stays in force as of Xcode 26 / macOS Sequoia (see that section
+for the reality check and re-verification note).

--- a/apple-dev-skills/skills/app-store-review-rejections/SKILL.md
+++ b/apple-dev-skills/skills/app-store-review-rejections/SKILL.md
@@ -15,31 +15,31 @@ Game Center** realistically hits, to a concrete pre-submission fix. These exampl
 assume a free app with banner ads + a Remove-Ads IAP + CloudKit + Game Center; the
 guideline classes apply broadly — skip sections that don't fit your app's feature set.
 
-It is the *content* companion to your ASC submission-ops workflow (which says **who** may push
-each ASC button); this says **why a build gets bounced and how to pre-empt it**.
+It is the *content* companion to `asc-api-automation` (which drives **who**/**how** each ASC
+call gets made); this says **why a build gets bounced and how to pre-empt it**.
 
 ## When to use
 
-- Before any TestFlight→App Store submission (your TestFlight upload workflow got the build up; this gates whether it passes review).
+- Before any TestFlight→App Store submission (`asc-api-automation` got the build up; this gates whether it passes review).
 - A Resolution Center message arrived citing "Guideline X.Y" — find the row, apply the fix.
 - Auditing a new app/game for submission-readiness.
-- NOT for the *mechanics* of submitting (that's your ASC submission-ops workflow) or screenshot generation (that's your screenshot-generation pipeline).
+- NOT for the *mechanics* of submitting or distributing (that's `asc-api-automation`).
 
 ## Quick reference — rejection class → fix (weighted to these apps)
 
 | Guideline | Why it bounces a puzzle-game-with-ads | Pre-submit fix here |
 |---|---|---|
 | **2.1 App Completeness** | Crash on reviewer's device/OS, dead-end flow, placeholder content, ad fails to load → blank space, debug/test ad shown in the prod build | Run the build on a *clean* device + the oldest supported OS. Ensure ads degrade gracefully (no empty frame on no-fill). TF builds should carry **prod** (not test) ad IDs — verify real ads render, not test units. No `<TRANSLATE>` / lorem strings. |
-| **2.3.1 Hidden features** | Shipping dormant code / hidden toggles reviewers can reach | No DEBUG-only surfaces (NearWin hooks) reachable in Release. |
+| **2.3.1 Hidden features** | Shipping dormant code / hidden toggles reviewers can reach | No DEBUG-only surfaces (debug menus) reachable in Release. |
 | **2.3.3 Screenshots** | Screenshots don't match the actual app, wrong dimensions, contain device frames Apple disallows, alpha channel | Do **not** upload snapshot-test baselines directly — they have an alpha channel + wrong dims (use your screenshot-generation pipeline). Use real device/sim captures at exact spec sizes. |
 | **2.3.10 Irrelevant metadata** | Mentioning Android / "also on Google Play", other platform names in description/keywords | Strip platform references from all 7 locales' metadata. |
-| **3.1.1 In-App Purchase** | Remove-Ads unlock sold outside IAP; **no "Restore Purchases" control**; price/benefit unclear | Remove-Ads must be StoreKit IAP (it is — [[monetization-sdk-integration]]). Apple's wording is "you *should* have a restore mechanism," but it is enforced in practice as mandatory — ship a visible **Restore Purchases** button; non-consumable must restore on reinstall. |
+| **3.1.1 In-App Purchase** | Remove-Ads unlock sold outside IAP; **no "Restore Purchases" control**; price/benefit unclear | Remove-Ads must be StoreKit IAP (it is — `monetization-sdk-integration`). Apple's wording is "you *should* have a restore mechanism," but it is enforced in practice as mandatory — ship a visible **Restore Purchases** button; non-consumable must restore on reinstall. |
 | **4.3(a)/(b) Spam / saturation** | **Highest latent risk** — saturated genres (puzzle, utility) face 4.3(b) "indistinguishable from what's already available" risk. (Apple's *enumerated* 4.3(b) examples are flashlight/sound-effects/wallpaper/timer/fortune-telling — puzzle games aren't named; the risk is inferred from saturation, not an explicit callout.) A thin clone gets bounced as spam. | Lead with genuine differentiation (design system, content hub, Game Center, cross-platform). Distinct app name/icon/screenshots per app; never ship two near-identical binaries under different names (4.3(a) = same app under multiple Bundle IDs). |
 | **4.0 / 4.2 Minimum functionality** | Too simple, feels like a web wrapper or template | Native features (haptics, Game Center, iCloud resume, widgets if any) demonstrate platform depth. |
 | **5.1.1(v) Account deletion / data** | App "supports account creation" but offers no in-app deletion path | Apple's text triggers the deletion requirement only for apps that **"support account creation"**. If the app has no app-specific account-creation flow (identity via iCloud / Game Center), 5.1.1(v) likely doesn't apply — confirm for your app. But **Apple publishes NO explicit iCloud/Game-Center exemption**, so don't assert one as fact. Still: provide a way to clear the user's CloudKit data + a reachable privacy-policy URL. If rejected on 5.1.1(v), reply to Review that the app creates no app-specific account and data-clearing is available, rather than claiming a blanket exemption. |
 | **5.1.1 Privacy policy** | Missing/unreachable privacy policy URL in ASC + in-app | Privacy policy URL set in App Privacy + reachable; covers ads (AdMob) + analytics data. |
 | **5.1.2 Data Use — ATT** | **The AdMob trap.** App accesses `ASIdentifierManager.advertisingIdentifier` (IDFA) or presents the ATT prompt via UMP but lacks `NSUserTrackingUsageDescription`, or never shows the prompt at all | ATT is required when the app accesses IDFA (`ASIdentifierManager.advertisingIdentifier`) or presents the ATT prompt via UMP. **AdMob can serve limited/non-personalized ads without accessing IDFA — in that case ATT is not required** (though UMP/GDPR consent may still apply). When ATT is required: `NSUserTrackingUsageDescription` present in **all 7 locales**, ATT prompt shown via UMP before personalized ads. Ensure each new app in a multi-app repo has its own ATT primer coordinator component — it is a submission blocker if missing. If you do NOT access IDFA, declare so and don't link to it. Note: reviewers sometimes cite **2.1 (Information Needed)** instead of 5.1.2 when they simply can't *find* where the prompt fires — the sim-verify checklist item below covers both. |
-| **Privacy-label parity** | App Privacy "nutrition" answers in ASC contradict `PrivacyInfo.xcprivacy` / actual SDK behavior (AdMob collects identifiers + usage data) | ASC App Privacy answers must match the committed `PrivacyInfo.xcprivacy` and AdMob's declared collection. Keep them in sync ([[apple-three-piece-analytics]]). |
+| **Privacy-label parity** | App Privacy "nutrition" answers in ASC contradict `PrivacyInfo.xcprivacy` / actual SDK behavior (AdMob collects identifiers + usage data) | ASC App Privacy answers must match the committed `PrivacyInfo.xcprivacy` and AdMob's declared collection. Keep them in sync (`apple-three-piece-analytics`). |
 | **Age rating / 1.3** | Ads can serve mature content but rating says 4+ | Set AdMob max ad content rating appropriately; age rating must cover ad content. |
 | **2.5.x / export compliance** | Build held "Processing" pending the encryption/export-compliance answer | Answer export compliance in ASC (uses standard crypto only) — user-owned, see your TestFlight upload workflow footgun. |
 
@@ -69,3 +69,7 @@ Transparency Report (performance = top rejection cause); Google AdMob iOS privac
 strategies (ATT / UMP / `NSUserTrackingUsageDescription`). Re-verify guideline
 numbers against the live Guidelines before quoting them in a Resolution Center
 reply — Apple renumbers.
+
+## Related skills
+
+- `asc-api-automation` — *how* to submit via the ASC REST API once a build exists; this skill covers *what* content has to be true for that submission to pass review.

--- a/apple-dev-skills/skills/asc-api-automation/SKILL.md
+++ b/apple-dev-skills/skills/asc-api-automation/SKILL.md
@@ -18,9 +18,9 @@ This catalog's default way to drive App Store Connect from scripts and CI: an Ap
 
 Owns: token minting, curl conventions, and the endpoint cookbook below. Does NOT own:
 
-- **Building / uploading the binary** — there is no REST endpoint for `.ipa` upload; builds arrive in ASC via Xcode Cloud (→ [[xcode-cloud-single-track-ci]]), Xcode Organizer, or Transporter. This skill picks up *after* the build exists in ASC.
-- **`.p8` key storage & leak prevention** → [[build-time-secret-injection]] (Layer 2 `secrets/.env`) + [[apple-public-repo-security]] (rotate-first SOP).
-- **What metadata will pass review** → [[app-store-review-rejections]]; this skill is *how* to submit, not *what*.
+- **Building / uploading the binary** — there is no REST endpoint for `.ipa` upload; builds arrive in ASC via Xcode Cloud (→ `xcode-cloud-single-track-ci`), Xcode Organizer, or Transporter. This skill picks up *after* the build exists in ASC.
+- **`.p8` key storage & leak prevention** → `build-time-secret-injection` (Layer 2 `secrets/.env`) + `apple-public-repo-security` (rotate-first SOP).
+- **What metadata will pass review** → `app-store-review-rejections`; this skill is *how* to submit, not *what*.
 
 ## Keys: create, scope, store
 
@@ -29,7 +29,7 @@ Owns: token minting, curl conventions, and the endpoint cookbook below. Does NOT
 | **Team key** (default) | Users and Access → Integrations; role-scoped | `iss` = Issuer ID | CI and shared tooling — pick the least-privilege role that works (App Manager covers release ops; avoid Admin) |
 | **Individual key** | Your user profile → Individual API Key | `sub: "user"` (no `iss`) | Personal one-off scripts; inherits *your* permissions |
 
-Store per [[build-time-secret-injection]] Layer 2:
+Store per `build-time-secret-injection` Layer 2:
 
 ```bash
 # secrets/.env (gitignored; .env.example committed)
@@ -110,7 +110,7 @@ The review-submission flow is the 2022+ `reviewSubmissions` model, which replace
 
 ## Release automation: SemVer, changelog, and explicit releaseType
 
-- **`versionString` = SemVer, sourced from the build, not reinvented in CI.** Set it to the same value as the archived build's `MARKETING_VERSION` (`CFBundleShortVersionString`) — bump that once at the Xcode-project level (→ [[xcode-cloud-single-track-ci]] build-number & version automation), then read it back for the `appStoreVersions` call instead of maintaining a second version counter in release tooling.
+- **`versionString` = SemVer, sourced from the build, not reinvented in CI.** Set it to the same value as the archived build's `MARKETING_VERSION` (`CFBundleShortVersionString`) — bump that once at the Xcode-project level (→ `xcode-cloud-single-track-ci` build-number & version automation), then read it back for the `appStoreVersions` call instead of maintaining a second version counter in release tooling.
 - **Changelog → `whatsNew`, generated once, written twice.** Build the "What's New" text from `git log <last-tag>..HEAD --oneline` (or your conventional-commit tooling) in the release job, then `PATCH` it into both `betaBuildLocalizations` (TestFlight) and `appStoreVersionLocalizations` (App Store) per locale — one generated string, two writes, so testers and reviewers see the same notes.
 - **`releaseType` — set it explicitly, every time.** The attribute is optional and Apple's schema documents no default value. The ASC web UI backs the same behavior with an explicit 3-way choice (*Manually release this version* / *Automatically release this version* / *Automatically release this version after App Review, no earlier than*); skipping `releaseType` in a scripted create/update leaves the version's release behavior to an undocumented default — in practice new versions show up as auto-release — instead of a decision your pipeline made on purpose. Default to `MANUAL` in automation unless auto-release is the deliberate intent.
 
@@ -136,7 +136,7 @@ The review-submission flow is the 2022+ `reviewSubmissions` model, which replace
 6. **Parsing `salesReports` as JSON** — it's a gzipped TSV file.
 7. **Tight-polling build processing or analytics** without reading `X-Rate-Limit` — 429 locks out every consumer of the key.
 8. **Admin-role key in CI** when App Manager or a `scope`d token suffices.
-9. **`.p8` committed to the repo** — stop and run the rotate-first SOP in [[apple-public-repo-security]]; storage layout per [[build-time-secret-injection]].
+9. **`.p8` committed to the repo** — stop and run the rotate-first SOP in `apple-public-repo-security`; storage layout per `build-time-secret-injection`.
 10. **Omitting `releaseType` on an `appStoreVersions` create/update** — the attribute has no documented default, so an unset value can leave a version on automatic release; it goes live the instant Apple approves it instead of waiting for a deliberate manual release. Set `releaseType: "MANUAL"` explicitly unless auto-release is intended.
 
 ## Review Checklist
@@ -152,7 +152,7 @@ The review-submission flow is the 2022+ `reviewSubmissions` model, which replace
 
 ## Related skills
 
-- [[xcode-cloud-single-track-ci]] — build & upload side; this skill starts after the build exists in ASC
-- [[build-time-secret-injection]] — where `ASC_KEY_ID` / `ASC_ISSUER_ID` / the `.p8` live (Layer 2 `secrets/.env`)
-- [[apple-public-repo-security]] — `.p8` leak prevention and the rotate-first SOP
-- [[app-store-review-rejections]] — *what* to submit so review passes; this skill is *how* to submit
+- `xcode-cloud-single-track-ci` — build & upload side; this skill starts after the build exists in ASC
+- `build-time-secret-injection` — where `ASC_KEY_ID` / `ASC_ISSUER_ID` / the `.p8` live (Layer 2 `secrets/.env`)
+- `apple-public-repo-security` — `.p8` leak prevention and the rotate-first SOP
+- `app-store-review-rejections` — *what* to submit so review passes; this skill is *how* to submit

--- a/apple-dev-skills/skills/build-time-secret-injection/SKILL.md
+++ b/apple-dev-skills/skills/build-time-secret-injection/SKILL.md
@@ -17,10 +17,10 @@ Examples:
 - Any third-party SDK app key (Firebase, RevenueCat, etc.) where the convention is "hold until ship"
 
 Do NOT invoke for:
-- True per-deploy secrets (signing certs, CloudKit production API keys, push notification keys) — those have stricter patterns (see [[apple-public-repo-security]])
+- True per-deploy secrets (signing certs, CloudKit production API keys, push notification keys) — those have stricter patterns (see `apple-public-repo-security`)
 - Values genuinely public from day 1 (bundle IDs, CKContainer IDs, IAP product IDs, marketing URLs)
 
-## The pattern (locked 2026-06-03)
+## The pattern
 
 ### Two storage layers, one mechanism per layer
 
@@ -57,7 +57,7 @@ secrets/
 ### Project.swift wiring (Tuist)
 
 ```swift
-let sudokuTarget = Target.target(
+let appTarget = Target.target(
     // ...
     settings: .settings(
         base: ["SWIFT_VERSION": "6"],
@@ -78,12 +78,12 @@ When one repo ships multiple app schemes (e.g. AppA + AppB), XCC sets `$CI_PRODU
 ```bash
 case "${CI_XCODE_SCHEME:-${CI_PRODUCT:-}}" in
   AppA)
-    APP_ID="${APPA_ADMOB_APP_ID:?missing APPA_ADMOB_APP_ID}"
-    BANNER_UNIT_ID="${APPA_ADMOB_BANNER_UNIT_ID:?missing APPA_ADMOB_BANNER_UNIT_ID}"
+    APP_ID="${APP_A_ADMOB_APP_ID:?missing APP_A_ADMOB_APP_ID}"
+    BANNER_UNIT_ID="${APP_A_ADMOB_BANNER_UNIT_ID:?missing APP_A_ADMOB_BANNER_UNIT_ID}"
     ;;
   AppB)
-    APP_ID="${APPB_ADMOB_APP_ID:?missing APPB_ADMOB_APP_ID}"
-    BANNER_UNIT_ID="${APPB_ADMOB_BANNER_UNIT_ID:?missing APPB_ADMOB_BANNER_UNIT_ID}"
+    APP_ID="${APP_B_ADMOB_APP_ID:?missing APP_B_ADMOB_APP_ID}"
+    BANNER_UNIT_ID="${APP_B_ADMOB_BANNER_UNIT_ID:?missing APP_B_ADMOB_BANNER_UNIT_ID}"
     ;;
   *)
     echo "Unknown CI_XCODE_SCHEME: ${CI_XCODE_SCHEME:-}" >&2
@@ -126,11 +126,11 @@ A future PR should add a build-phase script that asserts no `$()` literals survi
 
 1. **Production IDs in code comments, docstrings, PR descriptions, commit messages, or `Info.plist <!-- -->` blocks.** Even when the value field uses a sandbox stand-in, the surrounding prose leaks production via git history. **Including the literal ID anywhere in tracked text — even prefixed by TODO / FIXME / "will-replace" — IS the leak.** Reference a project-memory or secrets file by name; never paste the value inline.
 
-2. **Hardcoded production IDs in `Live.swift` with intent to "swap before release"** without an enforcement mechanism. The interim `fatalError("REPLACE_IN_v2.5.3:...")` pattern is acceptable as a TRANSITIONAL guard paired with xcconfig migration (see Migration §3), but is forbidden as a long-term standalone solution. Once xcconfig is in place, replace with: Info.plist `$()` + runtime guard verifying `Bundle.main.object(forInfoDictionaryKey:)` returns non-empty AND non-`$(...)`.
+2. **Hardcoded production IDs in `Live.swift` with intent to "swap before release"** without an enforcement mechanism. The interim `fatalError("REPLACE_BEFORE_RELEASE: ...")` pattern is acceptable as a TRANSITIONAL guard paired with xcconfig migration, but is forbidden as a long-term standalone solution. Once xcconfig is in place, replace with: Info.plist `$()` + runtime guard verifying `Bundle.main.object(forInfoDictionaryKey:)` returns non-empty AND non-`$(...)`.
 
 3. **Conflating GitHub Secrets with XCC env vars.** Apple's XCC does not read GH Secrets — they're separate storage. If CI builds on XCC, secrets must live in XCC's Environment Variables UI, not GH.
 
-4. **Most common mistake**: ❗ **Shell env vars do NOT feed xcconfig `$(VAR)` interpolation.** xcconfig variable resolution reads from the build settings table, not process env. `source admob.env && xcodebuild archive` does NOT populate `$(SUDOKU_ADMOB_APP_ID)`. Only positional `xcodebuild VAR=value` or `-xcconfig override.xcconfig` actually injects, OR a CI script writes the xcconfig file before build. Architect review §A documents this fatal assumption.
+4. **Most common mistake**: ❗ **Shell env vars do NOT feed xcconfig `$(VAR)` interpolation.** xcconfig variable resolution reads from the build settings table, not process env. `source admob.env && xcodebuild archive` does NOT populate `$(ADMOB_APP_ID)`. Only positional `xcodebuild VAR=value` or `-xcconfig override.xcconfig` actually injects, OR a CI script writes the xcconfig file before build.
 
 5. **`Bundle.main.object(forInfoDictionaryKey:) as! String`** — force cast bypasses SwiftLint AND crashes hard if CI generation skipped + xcconfig missing. Use `as? String` + `guard let ... else { preconditionFailure }` with the unresolved-`$()` check.
 
@@ -168,16 +168,16 @@ A future PR should add a build-phase script that asserts no `$()` literals survi
 
 ## Adjacent skills + memory
 
-- **REQUIRED background**: [[apple-public-repo-security]] — broader secret-leak prevention (gitleaks, lefthook, GitHub Secret Scanning)
-- **SIBLING**: [[monetization-sdk-integration]] — invoke together when wiring AdMob; this skill is the secret-handling layer
+- **REQUIRED background**: `apple-public-repo-security` — broader secret-leak prevention (gitleaks, lefthook, GitHub Secret Scanning)
+- **SIBLING**: `monetization-sdk-integration` — invoke together when wiring AdMob; this skill is the secret-handling layer
 - **SIBLING**: your ASC submission-ops workflow (who may push what) — ASC API key handling more broadly
 - Project memory file documenting the secret-scrubbing incident — the incident that triggered this skill pattern
 - Project memory files for each credential set — real values held outside repo (cite by memory-file name, never paste inline)
 
 ## AdMob env keys pattern
 
-`secrets/.env` carries per-app production pairs (e.g. `APPA_ADMOB_APP_ID` /
-`APPA_ADMOB_BANNER_UNIT_ID` and `APPB_*` twins). Two consumers render
+`secrets/.env` carries per-app production pairs (e.g. `APP_A_ADMOB_APP_ID` /
+`APP_A_ADMOB_BANNER_UNIT_ID` and `APP_B_*` twins). Two consumers render
 `Tuist/AdMob.xcconfig` from them: XCC `ci_post_clone.sh` (from workflow
 Secret env vars) and your TestFlight upload task (from `secrets/.env`).
 Values live in secrets/.env (primary) + the XCC workflow config + the

--- a/apple-dev-skills/skills/host-driven-xcuitest-e2e/SKILL.md
+++ b/apple-dev-skills/skills/host-driven-xcuitest-e2e/SKILL.md
@@ -104,8 +104,9 @@ Other macOS-driving specifics:
   by its now-stale label on each subsequent tap.
 - Test classes that touch `XCUIElement` APIs must be `@MainActor` under Swift 6 strict
   concurrency — those APIs are main-actor-isolated.
-- `-only-testing:<Target>/<Class>/<method>` requires all three path segments; a partial path
-  silently runs the whole target instead of failing.
+- `-only-testing:` identifiers have the form `TestTarget[/TestClass[/TestMethod]]` (per
+  `man xcodebuild`) — target-only and target/class are both valid, narrowing scope to
+  that target or class; a full three-segment path narrows to one method.
 
 ## Locale-stable queries
 
@@ -160,7 +161,7 @@ replaces them (see the test pyramid in `swift-testing-baseline`).
 - [ ] macOS taps go through window-frame anchoring, not `element.tap()` / `app.coordinate(...)`.
 - [ ] No `hittable` inside an NSPredicate string.
 - [ ] Locale-sensitive elements are queried by accessibility identifier, not label text.
-- [ ] `-only-testing:` invocations include all three path segments.
+- [ ] `-only-testing:` identifiers follow `TestTarget[/TestClass[/TestMethod]]` — only as many segments as the intended scope.
 - [ ] Any debug-only entry-point seam is compiled out of Release builds.
 
 ## Related skills

--- a/apple-dev-skills/skills/interactive-simulator-ux-audit/SKILL.md
+++ b/apple-dev-skills/skills/interactive-simulator-ux-audit/SKILL.md
@@ -33,11 +33,13 @@ to *pin* the fix.
 If your project's policy forbids Homebrew, a direct GitHub release download is a distinct,
 usually-allowed path — confirm against your own policy, then:
 
-1. **`idb_companion`**: download `idb-companion.universal.tar.gz` from
+1. **`idb_companion`**: download `idb-companion.macos-arm64.tar.gz` from
    https://github.com/facebook/idb/releases → extract to e.g.
-   `~/idb-tools/companion/idb-companion.universal/` (binary lives in `bin/`, with a sibling
+   `~/idb-tools/companion/idb-companion.macos-arm64/` (binary lives in `bin/`, with a sibling
    `Frameworks/` directory the binary loads via `@executable_path`). An objc
-   duplicate-class warning for `FBProcess` at launch is non-fatal.
+   duplicate-class warning for `FBProcess` at launch is non-fatal. The asset filename
+   changes across releases — confirm the current one first with
+   `gh release view --repo facebook/idb --json assets`.
 2. **`idb` CLI**: `pip3 install --user fb-idb`.
 3. Put both on `PATH`. Symlink `idb` directly. For the companion, use a **wrapper script**
    that `exec`s the real binary's *absolute path* — a bare symlink breaks the
@@ -46,7 +48,7 @@ usually-allowed path — confirm against your own policy, then:
    `idb ui describe-all --udid <udid>` returns the accessibility tree (element frames +
    labels) in **device-point** space (e.g. an iPhone 17 Pro reports 402×874 pt).
 
-## Preflight: how many simulators fit on this Mac
+## Preflight: how many simulators fit locally
 
 Before running multiple agents or audit sessions in parallel, size the fleet with
 arithmetic, not a tool — steps 1-2 need nothing beyond Activity Monitor or `xcrun simctl`

--- a/apple-dev-skills/skills/ios-design-mockup/SKILL.md
+++ b/apple-dev-skills/skills/ios-design-mockup/SKILL.md
@@ -154,3 +154,7 @@ Read these files when you need them:
 - `references/sf-symbols.md` — inline SVG snippets for the 20 most common SF Symbols
 
 Read `html-structure.md` before drawing your first screen. Read the other two as needed.
+
+## Related skills
+
+- `swiftui-navigation-architecture` — once a flow sketched here is approved, this is where the real navigation gets implemented; that skill produces working SwiftUI code, this one produces a static visual mockup only.

--- a/apple-dev-skills/skills/ios-performance-engineering/SKILL.md
+++ b/apple-dev-skills/skills/ios-performance-engineering/SKILL.md
@@ -22,7 +22,7 @@ Never guess at a performance problem; profile first. Instruments ships with Xcod
 
 **Allocations** — tracks every heap allocation. Use the "Generation" feature: take a snapshot before an action, perform the action repeatedly, take another snapshot, and diff. Any allocation that grew unboundedly across generations is a leak or an accumulation bug. The "Leaks" instrument detects reference cycles automatically but misses logical leaks (objects kept alive longer than needed).
 
-**SwiftUI instrument** — records View body invocation counts, `@State` change propagation, and diffing cost. Available from Xcode 15+. A body that fires more than expected usually means a dependency is too coarse (e.g. observing the whole model when only one field is needed). The instrument shows which property change triggered each body re-render.
+**SwiftUI instrument** — records View body invocation counts, `@State` change propagation, and diffing cost. Xcode 26 introduced a next-generation SwiftUI instrument that tracks the causes of each update. A body that fires more than expected usually means a dependency is too coarse (e.g. observing the whole model when only one field is needed). The instrument shows which property change triggered each body re-render.
 
 **Hangs instrument** (Xcode 14+) — captures main-thread spins longer than a configurable threshold (default 250 ms). Apple classifies blocks 250–500 ms as micro-hangs and ≥500 ms as full hangs. Pairs with the **App Launch** template for pre-first-frame blocking. The system also generates `MXHangDiagnostic` on-device (see MetricKit below).
 

--- a/apple-dev-skills/skills/monetization-sdk-integration/SKILL.md
+++ b/apple-dev-skills/skills/monetization-sdk-integration/SKILL.md
@@ -28,7 +28,7 @@ Default rule: **no third-party SDKs** in the app. Apple-platform native APIs pre
 
 If any of (1)-(5) fails: deny. Reject the SDK proposal; suggest Apple-native fallback or sit it out.
 
-## The isolation contract (§9.1)
+## The isolation contract
 
 For every accepted SDK:
 
@@ -147,3 +147,8 @@ If any field is "TBD" or "?", do NOT proceed — research first.
 - `Sources/<AdsBridge>/<SdkName>Bridge.swift` — protocol seam example
 - `Sources/<AdsBridge>/Live<SdkName>Bridge.swift` — single-import-site example
 - `<App>/Resources/PrivacyInfo.xcprivacy` — tracking domains declaration
+
+## Related skills
+
+- `build-time-secret-injection` — SIBLING; invoke together when wiring AdMob — that skill is the secret-handling layer (xcconfig injection), this skill is the SDK isolation and testing contract.
+- `app-store-review-rejections` — cites this skill's isolation contract when checking the Restore Purchases requirement under guideline 3.1.1.

--- a/apple-dev-skills/skills/swiftui-interaction-footguns/SKILL.md
+++ b/apple-dev-skills/skills/swiftui-interaction-footguns/SKILL.md
@@ -109,5 +109,5 @@ A class of bugs that look fine in code but break at runtime. These have shipped 
 ## Related skills
 
 - `subagent-review-cycles` — Code Reviewer dispatch brief should explicitly name this skill when reviewing SwiftUI Views.
-- `swiftui-expert-skill` — broader domain skill (Instruments traces, hang/hitch profiling); different scope.
+- `swiftui-expert-skill` (aggregated external) — broader domain skill (Instruments traces, hang/hitch profiling); different scope.
 - `swiftui-pro` (aggregated external) — a broad "SwiftUI mistakes LLMs make" catalog (navigation/layout/animation/state/deprecated-API). This skill is the narrower complement: runtime-only bugs that shipped **past code review** in one project, each with a reproduction note (vmid logging, blank-`fullScreenCover` race, stale-modal Dynamic Type, idb-verify-not-snapshot). Use both.

--- a/apple-dev-skills/skills/swiftui-navigation-architecture/SKILL.md
+++ b/apple-dev-skills/skills/swiftui-navigation-architecture/SKILL.md
@@ -5,7 +5,7 @@ description: Default navigation shape for SwiftUI Apps (iOS 18 / macOS 15, Swift
 
 # SwiftUI Navigation Architecture
 
-The default navigation shape for Apps on this catalog's baseline ([[apple-platform-targets]]: iOS 18 / macOS 15, Swift 6 language mode): navigation state is **data** — a typed route enum in one observable router — so flows are unit-testable (assert on `[Route]`), deep-linkable (URL → routes is a pure function), and restorable (routes are `Codable`).
+The default navigation shape for Apps on this catalog's baseline (`apple-platform-targets`: iOS 18 / macOS 15, Swift 6 language mode): navigation state is **data** — a typed route enum in one observable router — so flows are unit-testable (assert on `[Route]`), deep-linkable (URL → routes is a pure function), and restorable (routes are `Codable`).
 
 ## When to invoke
 
@@ -16,7 +16,7 @@ The default navigation shape for Apps on this catalog's baseline ([[apple-platfo
 
 ## Scope
 
-Owns container choice (Stack / SplitView / Tab), route modeling, the router object, deep-link funneling, and restoration. Does NOT own: known interaction bugs in nav components → [[swiftui-interaction-footguns]]; injecting the services destination views need → [[swift-dependency-injection]]; nav-chrome accessibility → [[ios-accessibility-engineering]].
+Owns container choice (Stack / SplitView / Tab), route modeling, the router object, deep-link funneling, and restoration. Does NOT own: known interaction bugs in nav components → `swiftui-interaction-footguns`; injecting the services destination views need → `swift-dependency-injection`; nav-chrome accessibility → `ios-accessibility-engineering`.
 
 ## Pick the container
 
@@ -26,7 +26,7 @@ Owns container choice (Stack / SplitView / Tab), route modeling, the router obje
 | 2–5 top-level peer sections | `TabView` + one `NavigationStack` per tab, each with its own path |
 | Source list → detail (iPad / Mac) | `NavigationSplitView`; sidebar selection is router state, the detail column hosts its own `NavigationStack` |
 
-Never `NavigationView` in new code — deprecated since iOS 16.
+Never `NavigationView` in new code — superseded by `NavigationStack` / `NavigationSplitView` since iOS 16, formally deprecated as of iOS 27.
 
 ## The default shape
 
@@ -141,7 +141,7 @@ Route both entry and exit through router methods (as above) so no view ever enco
 
 - `NavigationSplitView`: sidebar selection lives in the router; only the detail column hosts a `NavigationStack`. Don't nest stacks in the sidebar.
 - `TabView`: the router owns `selectedTab` *and* one path per tab — paths kept in per-view `@State` reset whenever tab identity churns. Selecting the already-active tab popping to root becomes a 2-line router method.
-- iPad / Mac footguns in these containers (sizeClass on Mac, inert sidebar Labels) → [[swiftui-interaction-footguns]].
+- iPad / Mac footguns in these containers (sizeClass on Mac, inert sidebar Labels) → `swiftui-interaction-footguns`.
 
 ## Rationale
 
@@ -159,7 +159,7 @@ Route both entry and exit through router methods (as above) so no view ever enco
 
 ## Common Mistakes
 
-1. **`NavigationView` in new code** — deprecated since iOS 16, unpredictable column behavior. Use `NavigationStack` / `NavigationSplitView`.
+1. **`NavigationView` in new code** — superseded since iOS 16, formally deprecated as of iOS 27, unpredictable column behavior. Use `NavigationStack` / `NavigationSplitView`.
 2. **`navigationDestination(for:)` inside `List` / `LazyVStack`** — the lazy container may not have created the registering view yet, so pushes silently fail (runtime console warning). Register at the stack root.
 3. **Mixing `NavigationLink(destination:)` into a path-based stack** — pushes invisible to `path`; back-stack count, deep links, and restoration all desync.
 4. **Sheets modeled as pushed routes** — back-button vs dismiss semantics conflict; keep a separate `Modal` enum.
@@ -187,7 +187,7 @@ Route both entry and exit through router methods (as above) so no view ever enco
 
 ## Related skills
 
-- [[swiftui-interaction-footguns]] — known bugs in the nav components this skill wires together
-- [[swift-dependency-injection]] — how destination views get their services
-- [[apple-platform-targets]] — the iOS 18 / macOS 15 baseline this shape assumes
-- [[ios-accessibility-engineering]] — accessibility of the navigation chrome
+- `swiftui-interaction-footguns` — known bugs in the nav components this skill wires together
+- `swift-dependency-injection` — how destination views get their services
+- `apple-platform-targets` — the iOS 18 / macOS 15 baseline this shape assumes
+- `ios-accessibility-engineering` — accessibility of the navigation chrome

--- a/apple-dev-skills/skills/xcode-cloud-single-track-ci/SKILL.md
+++ b/apple-dev-skills/skills/xcode-cloud-single-track-ci/SKILL.md
@@ -27,7 +27,7 @@ description: Default CI strategy for solo / small-team Apple-platform projects â
 | **PR CI** | PR open / push (**enable "Merge with base branch before building"**) | Build + Test (unit / integration with fakes / snapshot) |
 | **Main CI** | Merge to `main` | Build + Archive + upload to internal TestFlight; **do not re-run tests** (already verified by PR CI in pre-merged state) |
 | **Release** | git tag `v*` | Build + upload to App Store Connect (manual submission for review) |
-| **Periodic / Manual** | Scheduled + manual trigger | Project-specific batch jobs (puzzle generation, metadata updates, etc.) |
+| **Periodic / Manual** | Scheduled + manual trigger | Project-specific batch jobs (nightly export, metadata updates, etc.) |
 
 > **Scheduling granularity caveat**: Xcode Cloud's "On a Schedule" start condition supports **hourly / daily / weekly** granularity only â€” arbitrary cron expressions are not supported. For monthly-or-longer cadence, schedule weekly and add a script-side date guard inside `ci_post_clone.sh` that early-exits when the date doesn't match the desired condition.
 

--- a/collaboration-skills/skills/claude-skill-plugin-packaging/SKILL.md
+++ b/collaboration-skills/skills/claude-skill-plugin-packaging/SKILL.md
@@ -140,3 +140,8 @@ start with `./`), `github` (`repo`,`ref?`,`sha?`), `url` (git URL), `git-subdir`
 - `claude plugin details your-skills@your-skills` lists the bundled skills + scope.
 - For model B: `git ls-files .claude/settings.json` (it's committed) and the submodule
   gitlink point at the intended version.
+
+## Related skills
+
+- `github-contribution-workflow` — routes plugin distribution/installation questions here; that skill owns PR/issue mechanics, this one owns packaging and discovery.
+- `skill-authoring-patterns` — routes distribution/packaging questions here once a skill is authored; that skill owns authoring conventions, this one owns how the finished skill gets shared.

--- a/collaboration-skills/skills/pr-diff-verification/SKILL.md
+++ b/collaboration-skills/skills/pr-diff-verification/SKILL.md
@@ -88,3 +88,7 @@ If git log shows 1 commit (subagent squashed without saying) → OK if intention
 If git log shows 0 commits (commits lost to worktree wipe) → STOP, recover, re-push
 If git diff --stat shows different file count → investigate
 ```
+
+## Related skills
+
+- `github-contribution-workflow` — routes diff-vs-commit verification here before push/PR; that skill owns the gh CLI mechanics, this one owns the post-commit sanity check.

--- a/collaboration-skills/skills/subagent-conflict-detection/SKILL.md
+++ b/collaboration-skills/skills/subagent-conflict-detection/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: subagent-conflict-detection
-description: Use before dispatching a subagent (especially `isolation:"worktree"`) to avoid three dispatch hazards — file-scope overlap with an in-flight subagent, a stale dispatch base, and collisions with another live agent/session editing the same checkout or git-submodule path. Invoke when about to call the Agent tool with `isolation:"worktree"`; when another subagent is running; right after a merge or branch switch (verify the dispatch base first); or when another Claude session is editing a shared repo/submodule path.
+description: 'Use before dispatching a subagent with `isolation:"worktree"`, or while another subagent is in flight, to avoid three dispatch hazards — file-scope overlap with an in-flight subagent, a stale dispatch base, and collisions with another live agent/session editing the same checkout or git-submodule path. Invoke when about to call the Agent tool with `isolation:"worktree"`; when another subagent is running; right after a merge or branch switch (verify the dispatch base first); or when another Claude session is editing a shared repo/submodule path.'
 ---
 
 # Subagent Conflict Detection
@@ -43,11 +43,24 @@ For each in-flight subagent's dirty-file set vs the new dispatch's likely scope:
 - **Module overlap** (same target directory but different files): WARN but allow with `isolation: "worktree"`. Note in dispatch prompt: "in-flight subagent X is editing target Y; do not touch files Z."
 - **No overlap**: dispatch safely.
 
-## Pre-dispatch base correctness (verify HEAD before you dispatch)
+## Pre-dispatch base correctness (verify the worktree base before you dispatch)
 
-`isolation: "worktree"` branches the subagent's worktree from the **current HEAD of the dispatching checkout at dispatch time**. So WHAT HEAD points at is part of the dispatch contract — get it wrong and the agent silently works against the wrong base.
+`isolation: "worktree"` does **not** always branch from your current local HEAD. The base is
+decided by `worktree.baseRef`:
 
-The classic failure: you merge PR A to `main`, then immediately dispatch a subagent for follow-up work that depends on A. If HEAD is not actually on the post-merge `main` (e.g. a background build left it detached, you forgot to `git checkout main && git reset --hard origin/main`, or the branch you're on predates A), the worktree branches from a **pre-A base**. The agent then can't see A's new symbols/files — it fails to compile against APIs that "should exist", or worse, re-implements against the old shape. Code review may not catch it (the agent's local build can pass on the stale base); it surfaces only when you try to build the integrated result.
+- **`"fresh"` (the default)** — branches from the repository's **default branch on the
+  remote** (typically `origin/main`), not your local HEAD. Any commit you haven't pushed yet
+  is invisible to the worktree. If the dispatched work depends on your in-progress local
+  branch, push first, or set `worktree.baseRef: "head"` in settings.
+- **`"head"`** — branches from your local HEAD, dirty state included. Dispatching right after
+  a merge without syncing HEAD first branches from the pre-merge base (see the incident
+  below). Confirm with `git log --oneline -3` before dispatching.
+
+Two fallbacks worth knowing: with no remote configured, or when `origin/HEAD` isn't cached
+locally and can't be fetched, `"fresh"` falls back to your current local HEAD. And **before
+v2.1.208**, `"fresh"` used whatever `origin/HEAD` was already cached locally, without fetching
+a current one. Official docs:
+https://code.claude.com/docs/en/worktrees#choose-the-base-branch
 
 **Before dispatching, confirm the base:**
 
@@ -59,7 +72,7 @@ git merge-base --is-ancestor <dep-sha> HEAD && echo "base OK" || echo "STALE BAS
 
 If the work depends on a just-merged PR, sync first (`git checkout main && git fetch && git reset --hard origin/main` — `reset --hard` discards uncommitted local changes, so stash them first) THEN dispatch. `<dep-sha>` above is the commit your work depends on (e.g. the merged PR's commit on `main`). State the expected base SHA in the dispatch prompt and tell the agent to verify it (`git log --oneline -5`; confirm a key file/symbol exists) before coding.
 
-> Real incident: a DEBUG test-hook subagent was dispatched right after a fix merged to `main`, but the dispatching HEAD was a pre-merge commit. The worktree branched from the stale base, so the new code referenced an `init` parameter and a file that only existed post-merge → 2 compile errors that the agent's own package build hadn't surfaced. Cost a full cherry-pick-onto-correct-base + rebuild cycle.
+> Real incident (pre-v2.1.208 / local-HEAD-fallback behavior): a DEBUG test-hook subagent was dispatched right after a fix merged to `main`, but the dispatching HEAD was a pre-merge commit. The worktree branched from the stale base, so the new code referenced an `init` parameter and a file that only existed post-merge → 2 compile errors that the agent's own package build hadn't surfaced. Cost a full cherry-pick-onto-correct-base + rebuild cycle.
 
 ## Coexisting with another live agent / session on the same repo
 
@@ -122,3 +135,7 @@ Intersection: NONE (different AppUI subdir).
 
 Verdict: dispatch safely. Note in prompt: "in-flight subagent on MonetizationStateController — do not touch that file."
 ```
+
+## Related skills
+
+- `github-contribution-workflow` — routes worktree/submodule collision questions here; that skill owns PR/branch mechanics, this one owns pre-dispatch and cross-session conflict checks.


### PR DESCRIPTION
## Summary

Corrects factual errors and cleans up project-specific residue in skill content across `apple-dev-skills` and `collaboration-skills`, per a judge-verdict review (`70-verdict-defects.md` / `70-verdict-scope.md`). These are instructions agents follow literally, so a wrong filename, a reversed instruction, or a man-page-contradicting flag description leads an agent astray.

- `interactive-simulator-ux-audit`: idb release asset is `idb-companion.macos-arm64.tar.gz` — the `.universal.tar.gz` asset no longer exists (verified via `gh release view --repo facebook/idb --json assets`); added a note that the filename changes across releases.
- `app-icon-rasterize`: fixed a self-contradiction where the "Companion skill" section said the macOS size-ladder was "superseded" while the file's own reality-check section says it's still required as of Xcode 26; also fixed the mislabeled section heading.
- `host-driven-xcuitest-e2e`: `-only-testing:` was documented backwards from `man xcodebuild` — it accepts `TestTarget[/TestClass[/TestMethod]]`, a partial path narrows scope rather than silently running the whole target (verified via `man xcodebuild | col -b`).
- `swiftui-navigation-architecture`: `NavigationView` was superseded by `NavigationStack` in iOS 16 but only formally deprecated in iOS 27 (verified against Apple's platform-availability JSON), not "deprecated since iOS 16".
- `ios-performance-engineering`: the SwiftUI Instrument's "Available from Xcode 15+" claim had no basis; replaced with the Xcode 26 next-generation SwiftUI instrument, per Xcode 26 release notes.
- `subagent-conflict-detection`: rewrote the worktree-base premise — `isolation:"worktree"` defaults to `"fresh"` (the remote default branch), not local HEAD; documented the `"head"` option and both fallback behaviors, with a link to the official docs. Narrowed the description's first clause to reduce dispatch-time collision with other "before dispatching a subagent" skills.
- De-identified project-specific residue left over from the source project (`sudokuTarget`, `APPA_ADMOB_*`/`SUDOKU_ADMOB_APP_ID`, `NearWin hooks`, "the reference project", version-locked section headings, stray `§` doc-section citations) across `build-time-secret-injection`, `app-store-review-rejections`, `app-icon-rasterize`, `xcode-cloud-single-track-ci`, `monetization-sdk-integration`, and `interactive-simulator-ux-audit`.
- Pointed `app-store-review-rejections`' dangling "your ASC submission-ops / TestFlight upload workflow" references at the real `asc-api-automation` skill.
- Converted all `[[wikilink]]` cross-references to backtick `` `skill-name` `` form (22 in the originally-flagged files, plus 2 more found in `app-store-review-rejections` during verification).
- Marked `swiftui-expert-skill` as `(aggregated external)` in `swiftui-interaction-footguns` without renaming it (it really is the upstream skill's id).
- Added a `## Related skills` section to the 6 skills that lacked one but are referenced by other skills (`app-store-review-rejections`, `ios-design-mockup`, `monetization-sdk-integration`, `claude-skill-plugin-packaging`, `pr-diff-verification`, `subagent-conflict-detection`).

No skill directories were added or removed; `scripts/`, `README.md`, `README.zh-Hant.md`, and `CONTRIBUTING.md` are untouched.

## Test plan

- [x] `python3 scripts/check-consistency.py` → `OK — 2 plugins (25/12), catalog + counts + zh-Hant consistent.` (exit 0)
- [x] `rg -ri 'sudoku|nearwin|APPA_|§9.1|this Mac|universal\.tar\.gz' apple-dev-skills collaboration-skills` → no matches
- [x] `rg -n '\[\[' apple-dev-skills collaboration-skills` → no matches
- [x] All 15 touched `SKILL.md` frontmatters parse via `python3 -c "import yaml; ..."`
- [x] Verified externally before editing: `gh release view --repo facebook/idb --json assets`, `man xcodebuild | col -b | grep -A3 'Test identifiers'`, Apple's `NavigationView`/`NavigationStack` platform-availability JSON

🤖 Generated with [Claude Code](https://claude.com/claude-code)
