### PR TITLE
refactor(skills): converge kickoff description routing collisions

### DIFF
--- a/apple-dev-skills/skills/apple-platform-targets/SKILL.md
+++ b/apple-dev-skills/skills/apple-platform-targets/SKILL.md
@@ -12,6 +12,18 @@ description: Default minimum deployment targets for Apple-platform Swift Apps an
 - Deciding whether to adopt latest-OS-only APIs (Liquid Glass `.glassEffect()`, new Observation, new SwiftData behaviour, etc.).
 - User asks about minimum iOS / macOS version or whether to support the previous major version.
 
+## Kickoff order
+
+This skill is the entry point for a new Apple-platform project — decide these defaults in this order, each via its own skill:
+
+1. **Platform** (this skill) — minimum deployment target.
+2. `swiftpm-modularization` — package / module shape.
+3. `swift6-concurrency` — language mode and concurrency checking.
+4. `swift-testing-baseline` — test framework and snapshot strategy.
+5. `oslog-logger-defaults`, `telemetry-facade-pattern`, `apple-three-piece-analytics` — logging, telemetry facade, and analytics stack.
+6. `mise-tool-management` — CLI tool version manager.
+7. `xcode-cloud-single-track-ci` — CI pipeline.
+
 ## Default decisions
 
 - **iOS 18 / macOS 15** as the default minimum.

--- a/apple-dev-skills/skills/apple-three-piece-analytics/SKILL.md
+++ b/apple-dev-skills/skills/apple-three-piece-analytics/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: apple-three-piece-analytics
-description: Default analytics stack for solo / small Apple-platform Apps — App Store Connect Analytics + MetricKit + Game Center (for games), no third-party tracking SDK by default, PrivacyInfo.xcprivacy mandatory. Invoke when starting a new project, deciding analytics SDK (vs Firebase / TelemetryDeck / Amplitude), writing PrivacyInfo, or when asked "should I integrate Firebase / Mixpanel / TelemetryDeck".
+description: Default analytics stack for solo / small Apple-platform Apps — App Store Connect Analytics + MetricKit + Game Center (for games), no third-party tracking SDK by default, PrivacyInfo.xcprivacy mandatory. Invoke when deciding analytics SDK (vs Firebase / TelemetryDeck / Amplitude), writing PrivacyInfo, or when asked "should I integrate Firebase / Mixpanel / TelemetryDeck".
 ---
 
 # Apple Three-Piece Analytics

--- a/apple-dev-skills/skills/ios-accessibility-engineering/SKILL.md
+++ b/apple-dev-skills/skills/ios-accessibility-engineering/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: ios-accessibility-engineering
-description: Concrete VoiceOver / Dynamic Type / touch-target / Reduce Motion implementation guide for SwiftUI and UIKit. Invoke when building or auditing any user-facing iOS/macOS UI, when asked "make this accessible", or before an App Review submission a11y pass.
+description: Concrete VoiceOver / Dynamic Type / touch-target / Reduce Motion implementation guide for SwiftUI and UIKit. Invoke when adding or auditing VoiceOver labels, Dynamic Type support, touch-target sizing, or Reduce Motion behavior, running a WCAG accessibility audit, when asked "make this accessible", or diagnosing an accessibility-related App Review rejection.
 ---
 
 # iOS Accessibility Engineering

--- a/apple-dev-skills/skills/mise-tool-management/SKILL.md
+++ b/apple-dev-skills/skills/mise-tool-management/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: mise-tool-management
-description: Use mise (mise.jdx.dev) to manage binary CLI / build tools (swiftlint, swiftformat, xcbeautify, gitleaks, lefthook, etc.) on both dev machines and CI, sharing a single `.mise.toml` for version parity. Invoke when starting a new project, choosing a tool version manager (vs asdf / Homebrew / manual), writing `.mise.toml`, or when asked "how do I manage swiftlint / xcbeautify versions".
+description: Use mise (mise.jdx.dev) to manage binary CLI / build tools (swiftlint, swiftformat, xcbeautify, gitleaks, lefthook, etc.) on both dev machines and CI, sharing a single `.mise.toml` for version parity. Invoke when choosing a tool version manager (vs asdf / Homebrew / manual), writing `.mise.toml`, or when asked "how do I manage swiftlint / xcbeautify versions".
 ---
 
 # mise Tool Management

--- a/apple-dev-skills/skills/oslog-logger-defaults/SKILL.md
+++ b/apple-dev-skills/skills/oslog-logger-defaults/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: oslog-logger-defaults
-description: Default logging stack for Apple-platform Swift Apps — Apple's built-in `os.Logger` (no third-party), subsystem = bundle ID, category = module name, all string interpolation defaults to `.private` with explicit `.public` opt-in. Invoke when starting a new project, choosing a logging library, writing the first Logger declaration, deciding privacy interpolation, or when asked "OSLog vs SwiftLog vs CocoaLumberjack, which one".
+description: Default logging stack for Apple-platform Swift Apps — Apple's built-in `os.Logger` (no third-party), subsystem = bundle ID, category = module name, all string interpolation defaults to `.private` with explicit `.public` opt-in. Invoke when choosing a logging library, writing the first Logger declaration, deciding privacy interpolation, or when asked "OSLog vs SwiftLog vs CocoaLumberjack, which one".
 ---
 
 # OSLog / `os.Logger` Defaults

--- a/apple-dev-skills/skills/swift-testing-baseline/SKILL.md
+++ b/apple-dev-skills/skills/swift-testing-baseline/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: swift-testing-baseline
-description: Default testing stack for new Apple-platform Swift projects — swift-testing (no XCTest), pointfreeco/swift-snapshot-testing, protocol-injected fakes for CloudKit / Game Center / network, snapshot images committed to git, CI Xcode version locked to local. Invoke when starting a new project, writing the first test target, choosing a snapshot framework, deciding CloudKit / GameKit test strategy, or when asked "which test framework".
+description: Default testing stack for new Apple-platform Swift projects — swift-testing (no XCTest), pointfreeco/swift-snapshot-testing, protocol-injected fakes for CloudKit / Game Center / network, snapshot images committed to git, CI Xcode version locked to local. Invoke when writing the first test target, choosing a snapshot framework, deciding CloudKit / GameKit test strategy, or when asked "which test framework".
 ---
 
 # Swift Testing Baseline

--- a/apple-dev-skills/skills/swift6-concurrency/SKILL.md
+++ b/apple-dev-skills/skills/swift6-concurrency/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: swift6-concurrency
-description: Default to Swift 6 language mode with complete concurrency checking from the first line of code; treat all in-house types as needing Sendable; isolate third-party deps that lag with @preconcurrency. Invoke when starting a new Swift Apple-platform project, writing Package.swift, picking the Swift language mode in Xcode build settings, or when asked "should I turn on strict concurrency?".
+description: Default to Swift 6 language mode with complete concurrency checking from the first line of code; treat all in-house types as needing Sendable; isolate third-party deps that lag with @preconcurrency. Invoke when writing Package.swift, picking the Swift language mode in Xcode build settings, or when asked "should I turn on strict concurrency?".
 ---
 
 # Swift 6 / Strict Concurrency

--- a/apple-dev-skills/skills/swiftpm-modularization/SKILL.md
+++ b/apple-dev-skills/skills/swiftpm-modularization/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: swiftpm-modularization
-description: Default modularization shape for Apple-platform Swift Apps — single Swift Package, multi-target, thin App target, DI composition root, restricted Apple framework imports, one test target per production target. Invoke when starting a new project, writing Package.swift, deciding how to split modules, planning portability (e.g. Swift on Android), or when asked "single package or multi-package, how should I split modules".
+description: Default modularization shape for Apple-platform Swift Apps — single Swift Package, multi-target, thin App target, DI composition root, restricted Apple framework imports, one test target per production target. Invoke when writing Package.swift, deciding how to split modules, planning portability (e.g. Swift on Android), or when asked "single package or multi-package, how should I split modules".
 ---
 
 # SwiftPM Modularization

--- a/apple-dev-skills/skills/swiftui-interaction-footguns/SKILL.md
+++ b/apple-dev-skills/skills/swiftui-interaction-footguns/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: swiftui-interaction-footguns
-description: Checklist of known SwiftUI interaction bugs that slipped past pure-code review (tap-target shrink, sidebar inert Labels, sizeClass on Mac, .task re-fire, theme tint propagation, NSHostingView env). Invoke automatically during Code Reviewer dispatch on any `.swift` file under your UI target (e.g. `Sources/.../AppUI/`) or any file matching `*View*.swift`, and whenever reviewing new SwiftUI View components, Button / NavigationLink / TabView / Form, or Mac NavigationSplitView variants.
+description: Checklist of known SwiftUI interaction bugs that slipped past pure-code review (tap-target shrink, sidebar inert Labels, sizeClass on Mac, .task re-fire, theme tint propagation, NSHostingView env). Use when reviewing any SwiftUI View file or a PR that adds Button / NavigationLink / TabView / Form / NavigationSplitView.
 ---
 
 # SwiftUI Interaction Footguns

--- a/apple-dev-skills/skills/telemetry-facade-pattern/SKILL.md
+++ b/apple-dev-skills/skills/telemetry-facade-pattern/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: telemetry-facade-pattern
-description: Single `Telemetry` SwiftPM target with a fan-out facade — callers say "what happened" (`telemetry.observe(event)`), facade dispatches to multiple sinks (OSLog / NoOp tracking / MetricKit / Game Center). Invoke when starting a new project that will log + track, deciding logger / tracker coupling, designing telemetry interfaces, or when asked "should Logger and Tracking be one thing".
+description: Single `Telemetry` SwiftPM target with a fan-out facade — callers say "what happened" (`telemetry.observe(event)`), facade dispatches to multiple sinks (OSLog / NoOp tracking / MetricKit / Game Center). Invoke when deciding logger / tracker coupling, designing telemetry interfaces, or when asked "should Logger and Tracking be one thing".
 ---
 
 # Telemetry Facade Pattern

--- a/collaboration-skills/skills/agent-impl-notes-log/SKILL.md
+++ b/collaboration-skills/skills/agent-impl-notes-log/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: agent-impl-notes-log
-description: Maintain a running `meetings/{date}_{topic}.impl-notes.md` *during* subagent task execution to capture in-flight design decisions, intentional deviations from spec, considered alternatives, and open questions for Leader/User. Distinct from the post-hoc phase meeting log; this file is updated incrementally as decisions are made. Invoke at the start of any non-trivial subagent dispatch, when ambiguity is encountered mid-task, or when about to deviate from spec.
+description: Maintain a running `meetings/{date}_{topic}.impl-notes.md` *during* subagent task execution to capture in-flight design decisions, intentional deviations from spec, considered alternatives, and open questions for Leader/User. Distinct from the post-hoc phase meeting log; this file is updated incrementally as decisions are made. Invoke when ambiguity is encountered mid-task, or when about to deviate from spec.
 ---
 
 # Agent Implementation Notes — Running Log

--- a/collaboration-skills/skills/backlog-routing-by-topic/SKILL.md
+++ b/collaboration-skills/skills/backlog-routing-by-topic/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: backlog-routing-by-topic
-description: Route mid-discussion stray ideas to the matching file's §Backlog section by topic — product → design.md; tooling → foundations.md; implementation step → plan.md; collaboration → methodology.md; unclassifiable → today's meeting log §Open questions. Invoke when a stray idea pops up during focused work, when reviewing a meeting log for parking lot items, or when asked "where does this idea go".
+description: For repos using the `spec-phase-orchestration` doc layout (design.md / foundations.md / plan.md / methodology.md), route mid-discussion stray ideas to the matching file's §Backlog section by topic — product → design.md; tooling → foundations.md; implementation step → plan.md; collaboration → methodology.md; unclassifiable → today's meeting log §Open questions. Invoke when a stray idea pops up during focused work, when reviewing a meeting log for parking lot items, or when asked "where does this idea go".
 ---
 
 # Backlog Routing by Topic

--- a/collaboration-skills/skills/spec-phase-orchestration/SKILL.md
+++ b/collaboration-skills/skills/spec-phase-orchestration/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: spec-phase-orchestration
-description: The pre-implementation document pipeline — 5 files + `meetings/` directory (README.md + docs/design.md + docs/foundations.md + docs/plan.md + docs/methodology.md + meetings/), section-by-section approval (§What before §How), prerequisite checklist with Unconfirmed / Resolved gates, "no implementation code before design.md and plan.md approved" rule. Invoke when starting a new project that needs spec-first development, deciding doc structure, or when asked "which documents go in the spec phase".
+description: The pre-implementation document pipeline — 5 files + `meetings/` directory (README.md + docs/design.md + docs/foundations.md + docs/plan.md + docs/methodology.md + meetings/), section-by-section approval (§What before §How), prerequisite checklist with Unconfirmed / Resolved gates, "no implementation code before design.md and plan.md approved" rule. Invoke when deciding doc structure for a spec-first project, or when asked "which documents go in the spec phase".
 ---
 
 # Spec Phase Orchestration
@@ -69,7 +69,7 @@ Any proposal depending on external tools / APIs / third-party packages **must** 
 
 ### Backlog sections
 
-Every living doc carries a §Backlog. Stray ideas are routed by topic: "product → design", "tooling → foundations", "implementation step → plan", "collaboration → methodology", "unclassifiable → meeting log" (see `backlog-routing-by-topic`).
+Every living doc carries a §Backlog; route stray ideas there by topic — see `backlog-routing-by-topic`.
 
 ## Rationale
 


### PR DESCRIPTION
## Summary
- 9 skills shared a generic "starting a new project" description clause (4-way collision at dispatch time, wastes the router's description-length budget). `apple-platform-targets` is now the sole kickoff entry point — its body lists the decision order (platform → swiftpm → swift6 → testing → oslog/telemetry/analytics → mise → xcode-cloud); the other 8 keep only their specific decision-point triggers.
- `agent-impl-notes-log` no longer fires on every subagent dispatch (that's `leader-developer-handoff-contract`'s job).
- `swiftui-interaction-footguns` no longer claims a file-path auto-trigger mechanism Claude Code doesn't have.
- `backlog-routing-by-topic` states its `spec-phase-orchestration` doc-layout precondition up front.
- `ios-accessibility-engineering` narrowed to a11y-specific triggers instead of "any user-facing UI" (was overlapping external swiftui skills).
- `spec-phase-orchestration`'s backlog section points to `backlog-routing-by-topic` instead of restating its table.

Does NOT touch `subagent-conflict-detection`, `subagent-review-cycles`, or `leader-developer-handoff-contract` descriptions (out of scope / already fixed in #47).

## Test plan
- [x] `python3 scripts/check-consistency.py` → `OK — 2 plugins (25/12), catalog + counts + zh-Hant consistent.` exit 0
- [x] All 13 touched descriptions ≤ 800 chars (max 509)
- [x] All 37 `SKILL.md` frontmatter blocks pass `yaml.safe_load`
- [x] `rg -c 'starting a new' */skills/*/SKILL.md` → 9 hits before, 1 hit after (`apple-platform-targets` only)
- [x] Skill directory count unchanged (37); no README/scripts/CONTRIBUTING/plugin.json touched

🤖 Generated with [Claude Code](https://claude.com/claude-code)