### PR TITLE
docs(skills): skill-listing budget + clean dangling methodology.md refs + native-mechanism notes

### DIFF
--- a/collaboration-skills/skills/claude-skill-plugin-packaging/SKILL.md
+++ b/collaboration-skills/skills/claude-skill-plugin-packaging/SKILL.md
@@ -5,6 +5,10 @@ description: How to distribute Claude Code skills for reuse across repos and how
 
 # Claude Code Skill Plugin Packaging
 
+## Native mechanism
+
+[Plugins](https://code.claude.com/docs/en/plugins) and [plugin marketplaces](https://code.claude.com/docs/en/plugin-marketplaces) are Claude Code's own distribution mechanism — a marketplace repo with `.claude-plugin/marketplace.json` gives "centralized discovery, version tracking, automatic updates". What the official docs don't spell out is the depth-1 discovery trap and the three-model install tradeoff below — that's what this skill adds.
+
 ## When to invoke
 
 - You have skills in one repo and want them reusable across other repos/projects.

--- a/collaboration-skills/skills/github-contribution-workflow/SKILL.md
+++ b/collaboration-skills/skills/github-contribution-workflow/SKILL.md
@@ -11,6 +11,10 @@ contribution-flow repo settings. Encodes conventions that keep an agent's
 contributions reviewable and consistent. Tool-agnostic in spirit; concrete
 commands are `gh` + `git`.
 
+## Native mechanism
+
+Claude Code's [Hooks](https://code.claude.com/docs/en/hooks) can intercept and block a tool call before it runs — e.g. a `PreToolUse` hook matching `Bash` can deny a `git push --force` or a bare `rm -rf`. Hooks enforce a hard gate at the tool layer; the `--no-verify` rule and CLEAN-before-merge convention below are conventions this skill asks the agent to follow voluntarily where no hook exists to enforce them.
+
 ## When to invoke
 
 - Opening or merging a PR; opening or commenting on an issue.

--- a/collaboration-skills/skills/leader-developer-handoff-contract/SKILL.md
+++ b/collaboration-skills/skills/leader-developer-handoff-contract/SKILL.md
@@ -5,6 +5,10 @@ description: When the main agent dispatches a sub-agent, the prompt MUST include
 
 # Leader → Developer Handoff Contract
 
+## Native mechanism
+
+Claude Code's [Subagents](https://code.claude.com/docs/en/subagents) feature already gives a dispatched agent "its own context window with a custom system prompt, specific tool access, and independent permissions" — but the platform doesn't require or shape what goes in the dispatch *prompt* itself. This skill is the discipline layer on top: the 5 elements a prompt must contain regardless of how well-configured the subagent's own definition is.
+
 ## When to invoke
 
 - About to dispatch a sub-agent (Developer / Designer / Code Reviewer / drafting agent).

--- a/collaboration-skills/skills/pr-diff-verification/SKILL.md
+++ b/collaboration-skills/skills/pr-diff-verification/SKILL.md
@@ -61,9 +61,9 @@ Discrepancy resolution options:
 - **Lying commit log + invisible diff**: code review reads the message and assumes the code matches. Trust is misplaced; defects ship.
 - **Force-push wrong ref**: `git push origin worktree-agent-X:feat/Y` pushes worktree-agent-X's HEAD to remote feat/Y. If worktree-agent-X doesn't have the commits (because they were committed to a different local branch by the subagent), remote feat/Y gets reset to whatever worktree-agent-X is at — usually main SHA.
 
-## Integration with methodology
+## Integration with commit discipline
 
-`docs/methodology.md §派發契約 §10` requires commit-early discipline. This skill is the POST-commit verification step — confirms the commits that survived actually contain what the message claims.
+Commit-early discipline (commit before push, avoid large uncommitted batches) is covered by `github-contribution-workflow`. This skill is the POST-commit verification step — confirms the commits that survived actually contain what the message claims.
 
 ## Heuristics for "what to check"
 

--- a/collaboration-skills/skills/skill-authoring-patterns/SKILL.md
+++ b/collaboration-skills/skills/skill-authoring-patterns/SKILL.md
@@ -38,6 +38,14 @@ GOOD: description: VoiceOver / Dynamic Type / touch-target implementation for Sw
       Does NOT cover deep Rotor/Focus APIs — see <sibling>.
 ```
 
+## The listing budget is catalog-wide, not per-skill
+
+Claude Code loads a listing of every skill's name + `description` into context on every session so the model knows what's available; the listing's character budget scales at **1% of the model's context window** (raise it with the `skillListingBudgetFraction` setting or the `SLASH_COMMAND_TOOL_CHAR_BUDGET` env var). Each entry's own `description` (+ `when_to_use`, if present — see below) is separately capped at **1,536 characters** regardless of that budget (`skillListingMaxDescChars`). When the total listing overflows the budget, Claude Code truncates descriptions **starting with the skills you invoke least** — your most-used skills keep their full text, your least-used ones lose theirs first. ([Claude Code docs, Skills](https://code.claude.com/docs/en/skills))
+
+The practical implication for this catalog: the scarce resource is not "can my one `description` fit" — this catalog already runs `DESC_MAX = 800` in `scripts/check-consistency.py`, deliberately tighter than the official 1,536-char cap, precisely because 37 skills' descriptions compete for one shared budget every session. Every new skill's `description` is a permanent tax on that shared budget, paid on every session regardless of whether the skill ever fires. So before adding a skill, ask **"is this trigger phrase worth permanently occupying part of every session's listing budget?"** — not just "does this description fit under 800 chars".
+
+`when_to_use` is a real frontmatter field (appended to `description` in the listing and counted toward the same 1,536-char cap) meant for trigger phrases / example requests. None of this catalog's 37 skills currently use it (`grep -rl when_to_use **/SKILL.md` → 0 hits) — this catalog folds trigger phrasing directly into `description` instead (see the router form above). That's a deliberate, not accidental, choice: keeping trigger wording in one field is simpler to audit against `DESC_MAX` than splitting it across two fields that share a cap.
+
 ## Section conventions we standardize
 
 Order the middle by the topic's pedagogy, but keep these conventions:

--- a/collaboration-skills/skills/subagent-conflict-detection/SKILL.md
+++ b/collaboration-skills/skills/subagent-conflict-detection/SKILL.md
@@ -5,6 +5,10 @@ description: 'Use before dispatching a subagent with `isolation:"worktree"`, or 
 
 # Subagent Conflict Detection
 
+## Native mechanism
+
+Claude Code's own isolation primitives are the [Subagents](https://code.claude.com/docs/en/subagents) feature ("each subagent runs in its own context window with a custom system prompt, specific tool access, and independent permissions") and `isolation:"worktree"`'s [base-branch selection](https://code.claude.com/docs/en/worktrees#choose-the-base-branch). Neither one checks whether a NEW dispatch's file scope overlaps an in-flight one, or whether the worktree base is stale — that pre-flight discipline is what this skill adds on top.
+
 ## When to invoke
 
 Before dispatching a new subagent via the Agent tool — especially with `isolation: "worktree"` — if ANY other subagent is currently running or has an active worktree.
@@ -132,9 +136,9 @@ Options:
 - **Lost-work on worktree wipe**: Subagent A's worktree wipes without commit; subagent B's dispatch reuses the path or branch name; A's work is unrecoverable.
 - **Code Reviewer confusion**: CR sees a PR whose diff includes changes from a parallel subagent that's not yet merged; verdict is on wrong baseline.
 
-## Integration with methodology.md
+## Pre-flight discipline this skill adds
 
-This skill operationalizes `docs/methodology.md §派發契約` item 9 (Leader pre-flight). The pre-flight checklist explicitly lists "kill orphan procs" + "rebase WIP onto main" + "mise trust" — this skill adds the conflict-detection step before those. For why `mise trust` is required before `mise install`/`mise exec` take effect in a fresh worktree or CI checkout, see `mise-tool-management`.
+A Leader's pre-dispatch pre-flight typically includes "kill orphan procs", "rebase WIP onto main", and "mise trust" — this skill adds the conflict-detection step before those. For why `mise trust` is required before `mise install`/`mise exec` take effect in a fresh worktree or CI checkout, see `mise-tool-management`.
 
 ## False-positive handling
 


### PR DESCRIPTION
## Summary

- Records the official Claude Code skill-listing character budget in `skill-authoring-patterns/SKILL.md` — the catalog's 37 skills already share one such budget.
- Removes two dangling references to a private `docs/methodology.md §派發契約` that does not exist in this repo (`pr-diff-verification`, `subagent-conflict-detection`).
- Adds short "Native mechanism" notes to 4 skills, each citing the official Claude Code feature the skill layers discipline on top of.

## Official-doc verification (WebFetch, https://code.claude.com/docs/en/skills.md)

Quoted from the doc:

> "Claude Code loads a listing of skill names and descriptions into context so Claude knows what's available. The listing always contains every skill name, but if you have many skills, Claude Code shortens descriptions to fit the listing's character budget... The budget scales at 1% of the model's context window."

> "the combined `description` and `when_to_use` text is truncated at 1,536 characters in the skill listing to reduce context usage."

> "When the listing overflows, Claude Code drops descriptions starting with the skills you invoke least, so the skills you use most keep their full text."

> `when_to_use` frontmatter field: "Additional context for when Claude should invoke the skill, such as trigger phrases or example requests. Appended to `description` in the skill listing and counts toward the 1,536-character cap."

> Settings: `skillListingBudgetFraction` (e.g. `0.02` = 2%), `SLASH_COMMAND_TOOL_CHAR_BUDGET` env var, `skillListingMaxDescChars` for the per-entry cap.

Confirmed via `grep -rl when_to_use **/SKILL.md` → 0 of 37 skills in this catalog currently use `when_to_use`.

Native-mechanism URLs verified individually by WebFetch before citing:
- https://code.claude.com/docs/en/subagents — "Subagents are specialized AI assistants... each subagent runs in its own context window with a custom system prompt, specific tool access, and independent permissions."
- https://code.claude.com/docs/en/plugins — plugin manifest / marketplace mechanics, matches citation in `claude-skill-plugin-packaging`.
- https://code.claude.com/docs/en/plugin-marketplaces — "A plugin marketplace is a catalog that lets you distribute plugins to others, providing centralized discovery, version tracking, automatic updates."
- https://code.claude.com/docs/en/hooks — "Hooks are user-defined shell commands... The `PreToolUse` hook event fires before a tool call executes and can block it."
- https://code.claude.com/docs/en/worktrees#choose-the-base-branch — pre-existing citation in `subagent-conflict-detection`, reused as-is.

## What did NOT change (by design)

- `scripts/check-consistency.py`'s `DESC_MAX = 800` — left untouched (needs a human decision); the new section explains it's a deliberate, tighter-than-official ceiling.
- The 4 skills where `methodology.md` is their own defined doc-layout term (`spec-phase-orchestration`, `methodology-pattern-extractor`, `backlog-routing-by-topic`, `subagent-review-cycles`) — untouched, those are legitimate self-references, not dangling links to a private file.
- No skill directories added/removed (still 37 total: 12 collaboration + 25 apple-dev-skills).
- No README / CONTRIBUTING / scripts / plugin.json / apple-dev-skills/ files touched.

## Test plan

- [x] `python3 scripts/check-consistency.py` → `OK — 2 plugins (25/12), catalog + counts + zh-Hant consistent.` (exit 0)
- [x] `rg -n '§派發契約' collaboration-skills apple-dev-skills` → no hits
- [x] `grep -l 'code\.claude\.com' collaboration-skills/skills/*/SKILL.md | wc -l` → 1 → 5
- [x] Skill dir count unchanged at 37; `git diff --name-only` touches only 6 `collaboration-skills/skills/*/SKILL.md` files
- [x] All 37 SKILL.md frontmatters pass `yaml.safe_load` (verified via script)
- [x] No `description` fields changed (`git diff -U0 | grep -c '^[-+]description:'` → 0)
- [x] `rg -n 'TODO|FIXME|stub|placeholder'` on the diff → no hits

🤖 Generated with [Claude Code](https://claude.com/claude-code)