### PR TITLE
docs: add a Quickstart, and fix the invocation form in the plugin descriptions

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,7 +9,7 @@
     {
       "name": "apple-dev-skills",
       "source": "./apple-dev-skills",
-      "description": "25 first-party Apple/Swift skills. Namespaced apple-dev-skills:<skill>.",
+      "description": "25 first-party Apple/Swift skills. Invoke explicitly with /apple-dev-skills:<skill>.",
       "version": "1.2.0",
       "author": { "name": "Wei18" },
       "keywords": ["swift", "ios", "macos", "apple-platform", "claude-code", "agent-skills"],
@@ -18,7 +18,7 @@
     {
       "name": "collaboration-skills",
       "source": "./collaboration-skills",
-      "description": "12 first-party AI-agent collaboration & process skills. Namespaced collaboration-skills:<skill>.",
+      "description": "12 first-party AI-agent collaboration & process skills. Invoke explicitly with /collaboration-skills:<skill>.",
       "version": "1.3.1",
       "author": { "name": "Wei18" },
       "keywords": ["claude-code", "agent-skills", "ai-agents", "workflow", "collaboration"],

--- a/README.md
+++ b/README.md
@@ -74,6 +74,19 @@ scripts/install-flat.sh --dry-run   # preview the `npx skills add` commands
 > listing has a context budget, and on overflow it drops descriptions starting with the
 > least-invoked skills. Run `/doctor` to check the listing's cost; tune `skillListingBudgetFraction` / `skillOverrides` in settings if it's too tight.
 
+## Quickstart
+
+Install path A, then describe the task — skills route themselves from their `description:`,
+so nothing needs invoking:
+
+- *"I'm starting a new iOS app"* → `apple-platform-targets` answers the deployment target and
+  hands off to the package shape, language mode, and test baseline in order.
+- *"App Review bounced this on guideline 5.1.2"* → `app-store-review-rejections` maps the
+  guideline to the fix.
+
+To force one, use its slash command: `/apple-dev-skills:swift6-concurrency`. `/skills` lists
+what is installed and which plugin each skill came from.
+
 ## Catalog
 
 - **Spec** the flow → `spec-phase-orchestration`

--- a/README.zh-Hant.md
+++ b/README.zh-Hant.md
@@ -71,6 +71,17 @@ scripts/install-flat.sh --dry-run   # preview the `npx skills add` commands
 > 溢出時會從最少被呼叫的技能開始丟棄描述。執行 `/doctor` 檢查清單的成本；
 > 若太吃緊，可在 settings 調整 `skillListingBudgetFraction` / `skillOverrides`。
 
+## 快速開始
+
+照路徑 A 安裝，然後直接描述你要做的事 —— 技能會依自己的 `description:` 自動路由，不需要手動呼叫：
+
+- *「我要開一個新的 iOS App」* → `apple-platform-targets` 回答最低部署版本，並依序交棒給
+  package 結構、語言模式與測試基準。
+- *「App Review 以 guideline 5.1.2 退件」* → `app-store-review-rejections` 把該條款對應到修法。
+
+要指定某一支，用它的 slash command：`/apple-dev-skills:swift6-concurrency`。`/skills` 會列出
+已安裝的全部技能，以及每一支來自哪個 plugin。
+
 ## 目錄
 
 - **Spec** 流程 → `spec-phase-orchestration`
@@ -156,4 +167,4 @@ OSLog 不用第三方、審查漏掉的執行期 bug）。主題重疊處，兩�
 此處僅以引用方式呈現。催生本 repo 雙 plugin 結構的設計 spec 與計畫原本放在 `docs/superpowers/`，
 現已退役、改由 git 歷史保存；用 `git log -- docs/` 可以找回。MIT —— 見 [LICENSE](LICENSE)。
 
-<!-- src-sha: fd9e946885542b0acccc57ec1b94e93b2cc4e697 -->
+<!-- src-sha: 2e8a7a67a1b1051b9c55e192227a97757f63e63d -->


### PR DESCRIPTION
Decision on the last of the four open items: yes, the README gets a Quickstart.

Installing told a reader nothing about what to do next. The Install note added in #49 says skills self-trigger from their `description:`, which is true but abstract — a first-time reader has no idea what a prompt that triggers one looks like, and the README never showed the explicit invocation form at all. That gap hits hardest on exactly the reader this catalog is for: someone who wants to describe a task, not learn a routing system.

Eight lines, placed above `## Catalog` so the consistency gate's Catalog scoping is untouched.

Both examples were checked against the actual frontmatter rather than invented:

- `apple-platform-targets` carries "Invoke when starting a new Apple-platform project", and #48 made it the single kickoff entry point that hands off in order.
- `app-store-review-rejections` carries "diagnosing an App Review rejection / Resolution Center message" and names guideline 5.1.2 explicitly.

## The invocation form was wrong

Both plugin descriptions in `marketplace.json` said "Namespaced apple-dev-skills:<skill>". Per the official skills documentation, a plugin skill is invoked as a slash command, `/plugin-name:skill-name` — so the leading slash was missing, and "namespaced" on its own never told anyone it was invocable. Both descriptions now show the real form, and the Quickstart names `/skills` for listing what is installed.

## Verification

- `mise run check` green, exit 0 — including the Catalog token and count rules, which the new section sits above.
- `marketplace.json` parses.
- zh-Hant hand-written to match and `src-sha` re-stamped, rather than regenerated.