### PR TITLE
feat(marketplace): aggregate xcode-build-skill as 7th external; add opt-in check-externals

### DIFF
--- a/.claude-plugin/externals-snapshot.json
+++ b/.claude-plugin/externals-snapshot.json
@@ -1,0 +1,58 @@
+{
+  "apple-skills": {
+    "archived": false,
+    "license": "MIT",
+    "manifest_present": true,
+    "path": null,
+    "repo": "vabole/apple-skills",
+    "skill_count": 33
+  },
+  "caveman": {
+    "archived": false,
+    "license": "NOASSERTION",
+    "manifest_present": true,
+    "path": null,
+    "repo": "JuliusBrussee/caveman",
+    "skill_count": 20
+  },
+  "i-have-adhd": {
+    "archived": false,
+    "license": "MIT",
+    "manifest_present": true,
+    "path": null,
+    "repo": "ayghri/i-have-adhd",
+    "skill_count": 1
+  },
+  "ponytail": {
+    "archived": false,
+    "license": "MIT",
+    "manifest_present": true,
+    "path": null,
+    "repo": "DietrichGebert/ponytail",
+    "skill_count": 6
+  },
+  "swiftui-expert": {
+    "archived": false,
+    "license": "MIT",
+    "manifest_present": true,
+    "path": null,
+    "repo": "AvdLee/SwiftUI-Agent-Skill",
+    "skill_count": 1
+  },
+  "swiftui-pro": {
+    "archived": false,
+    "license": "MIT",
+    "manifest_present": true,
+    "path": "swiftui-pro",
+    "repo": "twostraws/SwiftUI-Agent-Skill",
+    "skill_count": 1
+  },
+  "xcode-build-skill": {
+    "archived": false,
+    "license": "MIT",
+    "manifest_present": true,
+    "path": null,
+    "repo": "pzep1/xcode-build-skill",
+    "skill_count": 1
+  }
+}

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -48,7 +48,7 @@
     {
       "name": "caveman",
       "source": { "source": "github", "repo": "JuliusBrussee/caveman" },
-      "description": "Aggregated (not authored here). Ultra-compressed communication mode that cuts ~75% of tokens, now grown into a ~20-skill suite (commit discipline, review, refactor verbs, plus skills for the author's hosted Caveman Cloud). General agent behavior. By JuliusBrussee; skills are MIT, the repo also ships a Business Source License 1.1 engine.",
+      "description": "Aggregated (not authored here). Ultra-compressed communication mode that cuts ~75% of tokens, now grown into a 20-skill suite (commit discipline, review, refactor verbs, plus 4 skills — caveman-discover, caveman-manage, caveman-evidence-review, caveman-setup — for the author's hosted Caveman Cloud commercial service). General agent behavior. By JuliusBrussee; skills are MIT, the repo also ships a Business Source License 1.1 engine.",
       "author": { "name": "JuliusBrussee" },
       "category": "workflow"
     },
@@ -64,6 +64,13 @@
       "source": { "source": "github", "repo": "ayghri/i-have-adhd" },
       "description": "Aggregated (not authored here). ADHD-friendly output mode — leads with the next action, numbers steps, restates state each turn, makes wins visible. General agent-behavior skill. By Ayoub G. (ayghri), MIT.",
       "author": { "name": "Ayoub G. (ayghri)" },
+      "category": "workflow"
+    },
+    {
+      "name": "xcode-build-skill",
+      "source": { "source": "github", "repo": "pzep1/xcode-build-skill" },
+      "description": "Aggregated (not authored here). `xcodebuild` / `xcrun simctl` CLI reference — discover schemes, find simulators, build, install, launch, and screenshot in a loop. The CLI-driven counterpart to this catalog's idb-driven `interactive-simulator-ux-audit` and Tuist-scheme `host-driven-xcuitest-e2e`. By pz, MIT.",
+      "author": { "name": "pz" },
       "category": "workflow"
     }
   ]

--- a/.mise.toml
+++ b/.mise.toml
@@ -12,3 +12,7 @@ run = "scripts/gen-readme-zh.sh"
 [tasks.bump]
 description = "Bump release versions on all gate-checked surfaces (e.g. mise run bump -- --marketplace 1.4.0 --collab 1.4.0)"
 run = "python3 scripts/bump-version.py"
+
+[tasks.check-externals]
+description = "Opt-in: re-verify aggregated externals still meet listing conditions (needs gh + network — not in pre-commit/CI; mise run check-externals -- --update to accept a reviewed change)"
+run = "python3 scripts/check-externals.py"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -42,6 +42,20 @@ re-implement. Open an [aggregation issue](.github/ISSUE_TEMPLATE/aggregate-a-plu
 Requirements: MIT-compatible license; a real `.claude-plugin/plugin.json` (root → `source: github`,
 subdir → `git-subdir`); no overlap with an existing skill.
 
+`git-subdir` only works when the upstream repo ships a `.claude-plugin/plugin.json`
+*inside that subdirectory itself* — e.g. `swiftui-pro/.claude-plugin/plugin.json` in
+`twostraws/SwiftUI-Agent-Skill` — so a subdir source can point at it. Aggregating just
+one skill folder out of a repo whose only manifest sits at the repo root (e.g.
+`caveman`, which has no `skills/<name>/.claude-plugin/plugin.json`) isn't possible
+without upstream adding one; it's all-or-nothing via `source: github` there.
+
+That MIT/no-overlap check happens once, at listing time — not on every upstream
+commit — so an already-listed external's license, archive status, or skill count
+can drift afterward. Run `mise run check-externals` to re-verify every listed
+external still meets the aggregation requirements above; after a deliberate,
+reviewed change (including right after adding a new one), accept the new baseline
+with `mise run check-externals -- --update` and commit the updated snapshot.
+
 ### 2. Add a first-party skill (only for genuine gaps)
 
 Pick the plugin: Apple/Swift → `apple-dev-skills/skills/`, generic agent process →

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ npx skills add wei18/apple-dev-skills --skill swift6-concurrency
 > **Path C does not include the aggregated externals.** `npx skills` does read this repo's
 > `marketplace.json` / `plugin.json`, but only follows locally-declared skill paths — it
 > doesn't fetch the externals' remote `github` / `git-subdir` sources, so the commands above
-> reach only the 37 first-party skills; the 6 externals are silently skipped. To flat-install
+> reach only the 37 first-party skills; the 7 externals are silently skipped. To flat-install
 > the whole catalog (externals included, pulled from their authors' repos):
 
 ```bash
@@ -145,7 +145,7 @@ Full index in the tables below.
 | `skill-authoring-patterns` | Apple/Swift catalog layer over `superpowers:writing-skills` — router descriptions, bookend sections, two-tier references, evidence-based CR |
 | `github-contribution-workflow` | gh-CLI contribution loop — PRs, issues, GitHub file ops, secrets, contribution-flow repo settings; conventions + CLEAN-before-merge |
 
-### Aggregated external (6) — by reference, credited
+### Aggregated external (7) — by reference, credited
 
 Listed here but **not authored here**; they install from their authors' own repos (you get
 their latest), credited in full. **Aggregate, don't appropriate**: only MIT-compatible,
@@ -162,9 +162,10 @@ slipped past review). Where a topic overlaps, they differ by altitude, not dupli
 | [`apple-skills`](https://github.com/vabole/apple-skills) | vabole (MIT) | Broad Apple frameworks — SwiftUI, SwiftData, App Intents, WidgetKit, StoreKit, HealthKit … |
 | [`swiftui-expert`](https://github.com/AvdLee/SwiftUI-Agent-Skill) | Antoine van der Lee (MIT) | SwiftUI patterns, Swift Charts, Liquid Glass, Instruments toolchain |
 | [`swiftui-pro`](https://github.com/twostraws/SwiftUI-Agent-Skill) | Paul Hudson (MIT) | SwiftUI pitfalls, deprecated-API watchlist, iOS 26 / Liquid Glass |
-| [`caveman`](https://github.com/JuliusBrussee/caveman) | JuliusBrussee (skills MIT; repo also ships a BSL-1.1 engine) | Ultra-compressed communication mode — cuts ~75% of tokens. Has since grown into a ~20-skill suite, some of it about the author's hosted Caveman Cloud (general agent behavior) |
+| [`caveman`](https://github.com/JuliusBrussee/caveman) | JuliusBrussee (skills MIT; repo also ships a BSL-1.1 engine) | Ultra-compressed communication mode — cuts ~75% of tokens. Has since grown into a 20-skill suite; 4 of them (`caveman-discover`, `caveman-manage`, `caveman-evidence-review`, `caveman-setup`) document the author's hosted Caveman Cloud commercial service (general agent behavior) |
 | [`ponytail`](https://github.com/DietrichGebert/ponytail) | DietrichGebert (MIT) | "Lazy senior dev" mode — forces the simplest, shortest solution (general agent behavior) |
 | [`i-have-adhd`](https://github.com/ayghri/i-have-adhd) | Ayoub G. (MIT) | Always-on ADHD-friendly output mode — action-first, numbered steps, state restated each turn; vs `caveman` (token compression) and `ponytail` (solution simplicity), this shapes structure (general agent behavior) |
+| [`xcode-build-skill`](https://github.com/pzep1/xcode-build-skill) | pz (MIT) | `xcodebuild`/`xcrun simctl` CLI reference — discover schemes → find simulators → build → install → launch → screenshot; CLI-driven, distinct from `interactive-simulator-ux-audit` (idb-driven interactive UX audit) and `host-driven-xcuitest-e2e` (Tuist-scheme XCUITest E2E) — the three don't overlap |
 
 ## Provenance
 

--- a/README.zh-Hant.md
+++ b/README.zh-Hant.md
@@ -60,7 +60,7 @@ npx skills add wei18/apple-dev-skills --skill swift6-concurrency
 > **路徑 C 不包含彙整而來的外部 plugin。** `npx skills` 確實會讀取本 repo 的
 > `marketplace.json` / `plugin.json`，但只跟隨本地宣告的技能路徑——它不會抓取外部
 > plugin 的遠端 `github` / `git-subdir` 來源，因此上述指令只涵蓋 37 個第一方技能；
-> 6 個外部 plugin 會被靜默略過。若要平鋪安裝整份目錄（含外部 plugin，從原作者的 repo 拉取）：
+> 7 個外部 plugin 會被靜默略過。若要平鋪安裝整份目錄（含外部 plugin，從原作者的 repo 拉取）：
 
 ```bash
 scripts/install-flat.sh -g          # user-level; drop -g for project-level
@@ -140,7 +140,7 @@ scripts/install-flat.sh --dry-run   # preview the `npx skills add` commands
 | `skill-authoring-patterns` | 疊在 `superpowers:writing-skills` 之上的 Apple/Swift 目錄層 —— router 描述、bookend 段落、兩層式 references、證據導向 CR |
 | `github-contribution-workflow` | gh-CLI 貢獻循環 —— PR、issue、GitHub 檔案操作、secrets、貢獻流程的 repo 設定；慣例 + merge 前 CLEAN |
 
-### 彙整之外部 plugin（6）—— 以引用方式收錄，完整標註
+### 彙整之外部 plugin（7）—— 以引用方式收錄，完整標註
 
 此處僅列出、**並非在此撰寫**；它們會從原作者自己的 repo 安裝（你拿到的是最新版），並完整標註出處。
 **彙整而非佔為己有**：只列出 MIT 相容、不重複的 plugin —— 第一方技能只為真正的空缺而寫。
@@ -155,9 +155,10 @@ OSLog 不用第三方、審查漏掉的執行期 bug）。主題重疊處，兩�
 | [`apple-skills`](https://github.com/vabole/apple-skills) | vabole (MIT) | 廣泛的 Apple 框架 —— SwiftUI、SwiftData、App Intents、WidgetKit、StoreKit、HealthKit… |
 | [`swiftui-expert`](https://github.com/AvdLee/SwiftUI-Agent-Skill) | Antoine van der Lee (MIT) | SwiftUI 模式、Swift Charts、Liquid Glass、Instruments 工具鏈 |
 | [`swiftui-pro`](https://github.com/twostraws/SwiftUI-Agent-Skill) | Paul Hudson (MIT) | SwiftUI 陷阱、deprecated API 觀察清單、iOS 26 / Liquid Glass |
-| [`caveman`](https://github.com/JuliusBrussee/caveman) | JuliusBrussee（技能為 MIT；該 repo 另含 BSL-1.1 授權的 engine） | 極度壓縮的溝通模式 —— 省下約 75% token。之後已長成約 20 個技能的套件，其中部分在講作者自家的 Caveman Cloud 服務（通用 agent 行為） |
+| [`caveman`](https://github.com/JuliusBrussee/caveman) | JuliusBrussee（技能為 MIT；該 repo 另含 BSL-1.1 授權的 engine） | 極度壓縮的溝通模式 —— 省下約 75% token。之後已長成 20 個技能的套件；其中 4 個（`caveman-discover`、`caveman-manage`、`caveman-evidence-review`、`caveman-setup`）在講作者自家托管的 Caveman Cloud 商業服務（通用 agent 行為） |
 | [`ponytail`](https://github.com/DietrichGebert/ponytail) | DietrichGebert (MIT) | 「懶惰資深工程師」模式 —— 逼出最簡單、最短的解法（通用 agent 行為） |
 | [`i-have-adhd`](https://github.com/ayghri/i-have-adhd) | Ayoub G. (MIT) | 常駐的 ADHD 友善輸出模式 —— 行動優先、編號步驟、每一輪重述狀態；相對於 `caveman`（token 壓縮）與 `ponytail`（解法簡化），這個塑形的是結構（通用 agent 行為） |
+| [`xcode-build-skill`](https://github.com/pzep1/xcode-build-skill) | pz (MIT) | `xcodebuild`/`xcrun simctl` CLI 參考 —— 找 scheme → 找模擬器 → build → install → launch → 截圖；CLI 驅動，與 `interactive-simulator-ux-audit`（idb 驅動的互動式 UX 稽核）、`host-driven-xcuitest-e2e`（Tuist scheme 接線的 XCUITest E2E）三者不重疊 |
 
 ## 出處
 
@@ -167,4 +168,4 @@ OSLog 不用第三方、審查漏掉的執行期 bug）。主題重疊處，兩�
 此處僅以引用方式呈現。催生本 repo 雙 plugin 結構的設計 spec 與計畫原本放在 `docs/superpowers/`，
 現已退役、改由 git 歷史保存；用 `git log -- docs/` 可以找回。MIT —— 見 [LICENSE](LICENSE)。
 
-<!-- src-sha: 2e8a7a67a1b1051b9c55e192227a97757f63e63d -->
+<!-- src-sha: cb94661e7b508a9836d35fdeac9a7e84e97da823 -->

--- a/scripts/check-consistency.py
+++ b/scripts/check-consistency.py
@@ -11,7 +11,7 @@ Checks
      comments and each plugin.json's "N first-party" are checked exactly.
   4. README.zh-Hant.md exists and its embedded src-sha == git hash-object README.md.
   5. All plugin/marketplace JSON parse; the two subdir plugin sources resolve to dirs;
-     marketplace.json lists exactly the 8 plugins (2 local + 6 externals).
+     marketplace.json lists exactly the 9 plugins (2 local + 7 externals).
   6. The `git checkout v<semver>` pin in both READMEs' Install section ==
      marketplace.json metadata.version (drifted silently before: v1.2.0 → #17).
   7. Each SKILL.md frontmatter description <= DESC_MAX chars (descriptions are
@@ -36,7 +36,7 @@ from pathlib import Path
 
 ROOT = Path(__file__).resolve().parent.parent
 PLUGINS = {"apple-dev-skills": 25, "collaboration-skills": 12}
-EXTERNALS = {"apple-skills", "swiftui-expert", "swiftui-pro", "caveman", "ponytail", "i-have-adhd"}
+EXTERNALS = {"apple-skills", "swiftui-expert", "swiftui-pro", "caveman", "ponytail", "i-have-adhd", "xcode-build-skill"}
 DESC_MAX = 800  # ceiling on frontmatter description length; which skill is currently
                 # longest shifts as skills are added — don't hardcode a name here
 errors: list[str] = []

--- a/scripts/check-externals.py
+++ b/scripts/check-externals.py
@@ -1,0 +1,160 @@
+#!/usr/bin/env python3
+"""Opt-in drift detector for aggregated externals.
+
+`check-consistency.py` only checks that this repo's own JSON/README stay
+internally consistent — it never looks upstream. But this catalog installs
+each external at *the author's latest*, and the MIT/no-overlap check that
+qualified it happens once, at listing time (see CONTRIBUTING.md #1). An
+external's license, archive status, manifest, or skill count can all move
+after that (`caveman` already grew from 1 skill to 20 and split its license
+per-directory — a human happened to notice on a later read-through).
+
+This script makes "does the listing condition still hold" a command instead
+of something that only gets checked when someone happens to look:
+
+  1. Read every aggregated external out of `.claude-plugin/marketplace.json`.
+  2. For each, ask GitHub (via `gh api`) whether the repo still exists /
+     is archived, its repo-level license SPDX id, whether its
+     `.claude-plugin/plugin.json` manifest still exists, and how many
+     `SKILL.md` files its plugin provides (scoped to the git-subdir `path`
+     for a subdir source).
+  3. Diff that against the committed snapshot (`.claude-plugin/externals-snapshot.json`).
+     Any field that changed is printed and the script exits 1. A clean match
+     exits 0.
+  4. `--update` writes the freshly probed data as the new snapshot instead of
+     diffing — run it after a reviewed, deliberate change (including right
+     after adding a new external, so its baseline gets recorded).
+
+This needs `gh` + network, so it is deliberately NOT wired into lefthook's
+pre-commit or the consistency GitHub Actions workflow — both must work
+offline. Run it by hand: `mise run check-externals` (or `-- --update`).
+
+Stdlib only.
+"""
+from __future__ import annotations
+import argparse, json, re, shutil, subprocess, sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+MARKETPLACE = ROOT / ".claude-plugin" / "marketplace.json"
+SNAPSHOT = ROOT / ".claude-plugin" / "externals-snapshot.json"
+FIELDS = ("repo", "path", "archived", "license", "manifest_present", "skill_count")
+AUTH_HINTS = ("not logged into", "auth login", "authentication required")
+
+
+def die(msg: str, code: int = 1):
+    print(msg, file=sys.stderr)
+    sys.exit(code)
+
+
+def gh_json(*args: str):
+    try:
+        r = subprocess.run(["gh", *args], capture_output=True, text=True, timeout=30)
+    except FileNotFoundError:
+        die("gh CLI not found on PATH — install it (https://cli.github.com) to run check-externals.")
+    if r.returncode != 0:
+        stderr = r.stderr.strip()
+        if any(h in stderr.lower() for h in AUTH_HINTS):
+            die("gh is not authenticated — run `gh auth login` first, then re-run check-externals.")
+        die(f"gh call failed: gh {' '.join(args)}\n{stderr}")
+    try:
+        return json.loads(r.stdout)
+    except json.JSONDecodeError:
+        die(f"gh returned non-JSON output for: gh {' '.join(args)}\n{r.stdout[:500]}")
+
+
+def parse_repo_url(url: str) -> str:
+    m = re.search(r"github\.com/([^/]+/[^/]+?)(?:\.git)?/?$", url)
+    if not m:
+        die(f"[check-externals] cannot parse owner/repo from url: {url}")
+    return m.group(1)
+
+
+def external_entries(mp: dict) -> list[tuple[str, str, str | None]]:
+    """(plugin name, owner/repo, git-subdir path or None) for every aggregated
+    external — a first-party plugin's source is a plain './...' string, so it's
+    skipped here."""
+    out = []
+    for p in mp.get("plugins", []):
+        src = p.get("source")
+        if not isinstance(src, dict):
+            continue
+        kind = src.get("source")
+        if kind == "github":
+            out.append((p["name"], src["repo"], None))
+        elif kind == "git-subdir":
+            out.append((p["name"], parse_repo_url(src["url"]), src.get("path")))
+        else:
+            die(f"[check-externals] {p.get('name')}: unrecognized source shape {src!r}")
+    return out
+
+
+def probe(repo: str, path: str | None) -> dict:
+    info = gh_json("api", f"repos/{repo}", "--jq", "{archived: .archived, license: .license.spdx_id}")
+    tree = gh_json("api", f"repos/{repo}/git/trees/HEAD?recursive=1", "--jq", "[.tree[].path]")
+    prefix = f"{path}/" if path else ""
+    manifest_present = f"{prefix}.claude-plugin/plugin.json" in tree
+    skills_prefix = f"{prefix}skills/"
+    skill_count = sum(1 for t in tree if t.startswith(skills_prefix) and t.endswith("/SKILL.md"))
+    return {
+        "repo": repo,
+        "path": path,
+        "archived": info.get("archived"),
+        "license": info.get("license"),
+        "manifest_present": manifest_present,
+        "skill_count": skill_count,
+    }
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    ap.add_argument("--update", action="store_true",
+                     help="write freshly probed data as the new snapshot instead of diffing")
+    args = ap.parse_args()
+
+    if shutil.which("gh") is None:
+        die("gh CLI not found on PATH — install it (https://cli.github.com) to run check-externals. "
+            "This check needs network + gh and is intentionally not run in pre-commit or CI.")
+
+    mp = json.loads(MARKETPLACE.read_text(encoding="utf-8"))
+    entries = external_entries(mp)
+
+    current = {}
+    for name, repo, path in entries:
+        loc = f"{repo}/{path}" if path else repo
+        print(f"probing {name} ({loc}) ...", file=sys.stderr)
+        current[name] = probe(repo, path)
+
+    if args.update:
+        SNAPSHOT.write_text(json.dumps(current, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+        print(f"OK — snapshot updated: {SNAPSHOT.relative_to(ROOT)} — review the diff and commit it.")
+        return
+
+    snapshot = json.loads(SNAPSHOT.read_text(encoding="utf-8")) if SNAPSHOT.is_file() else {}
+    diffs: list[str] = []
+    for name, data in current.items():
+        if name not in snapshot:
+            diffs.append(f"{name}: not in snapshot (new external) — run `mise run check-externals -- --update`")
+            continue
+        old = snapshot[name]
+        for field in FIELDS:
+            if old.get(field) != data.get(field):
+                diffs.append(f"{name}.{field}: snapshot={old.get(field)!r} -> current={data.get(field)!r}")
+    for name in snapshot:
+        if name not in current:
+            diffs.append(f"{name}: in snapshot but no longer listed in marketplace.json")
+
+    if diffs:
+        print(f"DRIFT — {len(diffs)} change(s) since the snapshot was taken:", file=sys.stderr)
+        for d in diffs:
+            print(f"  - {d}", file=sys.stderr)
+        print("Review each change against CONTRIBUTING.md's aggregation requirements; if it's still "
+              "acceptable, accept the new baseline with `mise run check-externals -- --update`.",
+              file=sys.stderr)
+        sys.exit(1)
+
+    print(f"OK — {len(current)} aggregated externals match the recorded snapshot.")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

- Aggregates [`pzep1/xcode-build-skill`](https://github.com/pzep1/xcode-build-skill) as the 7th external (MIT, unarchived, 137 stars, root `.claude-plugin/plugin.json` — verified via `gh api`). It's an `xcodebuild`/`xcrun simctl` **CLI reference**: discover schemes → find simulators → build → install → launch → screenshot.
- **Boundary vs. existing first-party skills** (verified by reading both SKILL.md files before writing the README row): `interactive-simulator-ux-audit` is `idb`-driven interactive UX audit against a booted Simulator; `host-driven-xcuitest-e2e` is Tuist-scheme-wired, CI-runnable XCUITest E2E. `xcode-build-skill` is neither — it's the raw CLI loop underneath both. No overlap.
- Adds `scripts/check-externals.py` + `mise run check-externals`: an **opt-in** drift detector. The catalog calls itself curated, but the MIT/no-overlap check that qualifies an external only runs once, at listing time — you install the author's *latest*, so license, archive status, manifest, and skill count can all drift afterward. `caveman` already grew from 1 skill to 20 and split its license per-directory, and that was only caught because a human happened to do a full review. This script makes "does the listing condition still hold" a command: it probes every external via `gh api` and diffs against a committed snapshot (`.claude-plugin/externals-snapshot.json`); `--update` accepts a reviewed change as the new baseline.
- **Why it's not in CI or pre-commit**: it needs `gh` + live network (GitHub repo/tree queries per external). `lefthook` pre-commit and the `consistency` GitHub Actions workflow must both keep working offline / without a `gh`-authenticated network call on every commit — mixing in a live upstream check would make local commits and CI flaky on rate limits or transient network issues, for a check that only matters occasionally (after adding an external, or periodically). It's a manual/human-triggered gate, not a machine gate.
- Also corrects the `caveman` disclosure to the actual verified numbers: 20 skills total, and (re-verified independently via `gh api`, not copied from a prior review's guess) exactly 4 of them — `caveman-discover`, `caveman-manage`, `caveman-evidence-review`, `caveman-setup` — document the author's hosted Caveman Cloud commercial service. (`caveman-optimize` does not mention "Cloud" and is not one of the four.)
- `CONTRIBUTING.md` documents a verified technical constraint: `git-subdir` only works when the upstream repo ships a `.claude-plugin/plugin.json` *inside the target subdirectory* (confirmed present at `twostraws/SwiftUI-Agent-Skill/swiftui-pro/.claude-plugin/plugin.json`, confirmed absent anywhere but the root in `JuliusBrussee/caveman`) — so "aggregate just one skill folder" from a single-manifest repo like caveman isn't possible without upstream adding a manifest there.

## Test plan

- [x] `mise run check` — green (SSOT consistency gate)
- [x] `mise run check-externals` — green on a clean tree (7/7 externals match snapshot)
- [x] Negative test: tampered `caveman`'s snapshot license/skill_count → `check-externals` exited 1 and named exactly the changed fields; restored via `--update` against real upstream state
- [x] Negative test: `gh` hidden from `PATH` → prints a human sentence and exits 1, no traceback
- [x] `grep -n 'check-externals' lefthook.yml .github/workflows/*.yml` — no hits (opt-in only)
- [x] README.md / README.zh-Hant.md external counts both read 7; `marketplace.json` parses and lists exactly 9 plugins

🤖 Generated with [Claude Code](https://claude.com/claude-code)