### PR TITLE
chore(release): 1.7.0 — 39 first-party skills, 7 externals, drift detection

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -3,14 +3,14 @@
   "owner": { "name": "Wei18" },
   "metadata": {
     "description": "A curated catalog of skills for AI coding agents — first-party Apple/Swift and agent-collaboration skills, plus aggregated best-of-breed external plugins (credited to their authors)",
-    "version": "1.6.0"
+    "version": "1.7.0"
   },
   "plugins": [
     {
       "name": "apple-dev-skills",
       "source": "./apple-dev-skills",
       "description": "27 first-party Apple/Swift skills. Invoke explicitly with /apple-dev-skills:<skill>.",
-      "version": "1.2.0",
+      "version": "1.3.0",
       "author": { "name": "Wei18" },
       "keywords": ["swift", "ios", "macos", "apple-platform", "claude-code", "agent-skills"],
       "category": "workflow"
@@ -19,7 +19,7 @@
       "name": "collaboration-skills",
       "source": "./collaboration-skills",
       "description": "12 first-party AI-agent collaboration & process skills. Invoke explicitly with /collaboration-skills:<skill>.",
-      "version": "1.3.1",
+      "version": "1.4.0",
       "author": { "name": "Wei18" },
       "keywords": ["claude-code", "agent-skills", "ai-agents", "workflow", "collaboration"],
       "category": "workflow"

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ plugins load from the pinned submodule (collaborators are prompted to trust the 
 
 ```bash
 git submodule add https://github.com/wei18/apple-dev-skills.git .claude/skills/apple-dev-skills
-cd .claude/skills/apple-dev-skills && git checkout v1.6.0 && cd -
+cd .claude/skills/apple-dev-skills && git checkout v1.7.0 && cd -
 ```
 
 `.claude/settings.json` (committed):

--- a/README.zh-Hant.md
+++ b/README.zh-Hant.md
@@ -31,7 +31,7 @@
 
 ```bash
 git submodule add https://github.com/wei18/apple-dev-skills.git .claude/skills/apple-dev-skills
-cd .claude/skills/apple-dev-skills && git checkout v1.6.0 && cd -
+cd .claude/skills/apple-dev-skills && git checkout v1.7.0 && cd -
 ```
 
 `.claude/settings.json`（納入版控）：
@@ -170,4 +170,4 @@ OSLog 不用第三方、審查漏掉的執行期 bug）。主題重疊處，兩�
 此處僅以引用方式呈現。催生本 repo 雙 plugin 結構的設計 spec 與計畫原本放在 `docs/superpowers/`，
 現已退役、改由 git 歷史保存；用 `git log -- docs/` 可以找回。MIT —— 見 [LICENSE](LICENSE)。
 
-<!-- src-sha: 15492afaba6d5b24cd21e213f3ec4892a4f40ca0 -->
+<!-- src-sha: 895de96f290994972ddfd2bdab32e3cf5c899032 -->

--- a/apple-dev-skills/.claude-plugin/plugin.json
+++ b/apple-dev-skills/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "apple-dev-skills",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "description": "27 first-party Apple/Swift skills for AI-agent development — Swift 6 / SwiftPM / testing / CI / L10n / telemetry defaults, security & secrets, monetization, StoreKit 2 IAP, App Review, ASC API automation, local archive/export/upload, SwiftUI footguns & navigation, plus accessibility, dependency injection, performance engineering, interactive simulator UX audits, host-driven XCUITest E2E, and CloudKit schema source of truth. Distilled from a real shipping project and public Apple/standards docs.",
   "author": { "name": "Wei18" },
   "homepage": "https://github.com/wei18/apple-dev-skills",

--- a/collaboration-skills/.claude-plugin/plugin.json
+++ b/collaboration-skills/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "collaboration-skills",
-  "version": "1.3.1",
+  "version": "1.4.0",
   "description": "12 first-party AI-agent collaboration & process skills — spec-phase orchestration, Leader/Developer handoff contract, subagent review cycles & conflict detection, impl-notes & meeting logs, methodology extraction, backlog routing, PR-diff verification, Claude Code skill-plugin packaging, skill-authoring patterns, and GitHub contribution workflow. Harness engineering for AI coding agents — tool-agnostic, not Apple-specific.",
   "author": { "name": "Wei18" },
   "homepage": "https://github.com/wei18/apple-dev-skills",


### PR DESCRIPTION
Release bump after the adversarial-review round (#46–#60).

| Plane | From | To | Why |
|---|---|---|---|
| marketplace | 1.6.0 | 1.7.0 | 7th external (`xcode-build-skill`), `check-externals` drift detector, README repositioning + Quickstart, three new gate rules, docs/ retired |
| apple-dev-skills | 1.2.0 | 1.3.0 | +2 skills (`storekit2-iap-defaults`, `local-archive-export-upload`), factual corrections across 15 skills |
| collaboration-skills | 1.3.1 | 1.4.0 | description routing convergence, listing-budget section, worktree-base rewrite, native-mechanism notes |

Bumped via `mise run bump`; gate green (27/12), README pins and zh `src-sha` re-stamped by the script.