### PR TITLE
docs(readme): restructure for clarity, pin marketplace for teams

### DIFF
--- a/.mise.toml
+++ b/.mise.toml
@@ -7,7 +7,7 @@ run = "python3 scripts/check-consistency.py"
 
 [tasks.readme-zh]
 description = "Regenerate README.zh-Hant.md from README.md (needs claude on PATH)"
-run = "scripts/gen-readme-zh.sh"
+run = "scripts/gen-readme-zh.sh zh-Hant"
 
 [tasks.bump]
 description = "Bump release versions on all gate-checked surfaces (e.g. mise run bump -- --marketplace 1.4.0 --collab 1.4.0)"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -13,16 +13,18 @@ mise install && lefthook install
 ## Tasks (always via mise — never call the scripts directly)
 
 - `mise run check` — SSOT consistency gate (run before every PR; CI runs the same).
-- `mise run readme-zh` — regenerate `README.zh-Hant.md` from `README.md` (needs `claude`
-  on PATH; auto-fires in pre-commit when `README.md` changes).
+- `mise run readme-zh` — regenerate each README mirror listed in `scripts/mirrors.py`
+  (currently `README.zh-Hant.md`) from `README.md` (needs `claude` on PATH; auto-fires
+  in pre-commit when `README.md` changes).
 
-### zh-Hant mirror: hand-mirror small diffs, regenerate large ones
+### README mirrors: hand-mirror by default, regenerate only as fallback
 
 Full regeneration is non-deterministic — even for a 2-line content fix it rewrites
-~40 lines of synonym churn, burying the real change in review. So:
+~40 lines of synonym churn (and has previously flipped full-width punctuation to
+half-width), burying the real change in review. So hand-mirroring is the default:
 
-- **≤ 5 changed content lines in `README.md`**: hand-mirror the same lines into
-  `README.zh-Hant.md`, re-stamp its freshness marker, and commit with the regen
+- **Default — any content change**: hand-mirror the same lines into each mirror in
+  `scripts/mirrors.py`, re-stamp its freshness marker, and commit with the regen
   hook excluded (it would otherwise clobber the hand-mirror with a full regen):
 
   ```bash
@@ -30,7 +32,9 @@ Full regeneration is non-deterministic — even for a 2-line content fix it rewr
   git add README.md README.zh-Hant.md
   LEFTHOOK_EXCLUDE=readme-zh git commit -m "..."   # `check` still runs and verifies freshness
   ```
-- **Larger / structural changes**: run `mise run readme-zh` for a full regeneration.
+- **Fallback — large / structural changes**: run `mise run readme-zh` for a full
+  regeneration, then manually re-check punctuation (full-width vs half-width) and
+  wording before committing — regeneration is not a substitute for review.
 
 ## Ways to contribute
 

--- a/README.md
+++ b/README.md
@@ -6,12 +6,12 @@
 > Languages: [English](README.md) · [繁體中文](README.zh-Hant.md)
 
 apple-dev-skills is one **marketplace** for independent developers and small teams
-taking an idea to a shipped App Store release, split into two first-party halves:
-**Apple/Swift** skills for what you are building, and **harness engineering** skills
-for how you drive the agent that builds it — dispatch, review, ship. Quality is held
-up by opinionated defaults, shipped-it war stories, and a consistency gate — plus
-best-of-breed **external** skill plugins aggregated by reference (credited to their
-authors, never copied).
+taking an idea to a shipped App Store release. Its first-party skills come in two halves:
+**Apple/Swift** skills for what you are building, and **harness engineering** skills for
+how you drive the agent that builds it — dispatch, review, ship. Every skill is an
+opinionated default backed by a shipped-it war story and held to a consistency gate;
+alongside them sit best-of-breed **external** skill plugins, aggregated by reference and
+credited to their authors, never copied.
 
 ## Quickstart
 
@@ -97,15 +97,15 @@ Full index in the tables below.
 
 ### Aggregated external (7) — by reference, credited
 
-Listed here but **not authored here** — installed from the authors' own repos (you get
-their latest), credited in full. **Aggregate, don't appropriate**: only MIT-compatible,
-non-duplicate plugins are listed, for genuine gaps only — that check happens once at
+Listed here but **not authored here**: each installs from its author's own repo (you get
+their latest) and is credited in full. **Aggregate, don't appropriate** — only MIT-compatible,
+non-duplicate plugins are listed, and only for genuine gaps. That check happens once, at
 listing time, not on every upstream commit, so an external's scope and licence can drift
-after listing (`caveman` already has). Externals are broad **reference** ("here's the API /
-here's how to build X"); first-party skills sit a layer below as **opinionated defaults and
-shipped-it war stories** (iOS 18, one Package, swift-testing + snapshot, OSLog no-third-party,
-runtime bugs that slipped past review) — where a topic overlaps, they differ by altitude,
-not duplication.
+afterwards (`caveman` already has). Externals are broad **reference** ("here's the API, here's
+how to build X"); first-party skills sit a layer below as **opinionated defaults and shipped-it
+war stories** (iOS 18, one Package, swift-testing + snapshot, OSLog with no third party, runtime
+bugs that slipped past review). Where a topic overlaps, the two differ by altitude, not by
+duplication.
 
 | Plugin | Author | Covers |
 |---|---|---|

--- a/README.md
+++ b/README.md
@@ -1,22 +1,21 @@
 # apple-dev-skills
 
-> A **skill catalog for vibe coding iOS (& Apple Ecosystem) apps with an AI coding agent**
-> ([Claude Code](https://code.claude.com)) — for independent developers and small teams taking
-> an idea to a shipped App Store release. Two first-party halves: **Apple/Swift** skills for what
-> you are building, and **harness engineering** skills for how you drive the agent that builds it —
-> dispatch, review, ship. Both are opinionated defaults and shipped-it war stories, held to a
-> consistency gate. Plus best-of-breed **external** skill plugins aggregated **by reference**
-> (credited to their authors, never copied).
+> Skills for vibe coding iOS & Apple-ecosystem apps with Claude Code — and for driving
+> the agent that builds them.
 >
 > Languages: [English](README.md) · [繁體中文](README.zh-Hant.md)
 
-This repo is one **marketplace** hosting two first-party plugins and several aggregated externals.
+apple-dev-skills is one **marketplace** for independent developers and small teams
+taking an idea to a shipped App Store release, split into two first-party halves:
+**Apple/Swift** skills for what you are building, and **harness engineering** skills
+for how you drive the agent that builds it — dispatch, review, ship. Quality is held
+up by opinionated defaults, shipped-it war stories, and a consistency gate — plus
+best-of-breed **external** skill plugins aggregated by reference (credited to their
+authors, never copied).
 
-## Install
+## Quickstart
 
 > Skills self-trigger from their `description:` — install, then just describe the task.
-
-### A — marketplace (simplest)
 
 ```
 /plugin marketplace add wei18/apple-dev-skills
@@ -26,58 +25,7 @@ This repo is one **marketplace** hosting two first-party plugins and several agg
 
 Install either or both. Externals install the same way, e.g. `/plugin install swiftui-expert@apple-dev-skills`.
 
-### B — repo-level (vendored submodule, pinned)
-
-Vendor + pin into one repo, then register a project-scope local-path marketplace so the
-plugins load from the pinned submodule (collaborators are prompted to trust the workspace):
-
-```bash
-git submodule add https://github.com/wei18/apple-dev-skills.git .claude/skills/apple-dev-skills
-cd .claude/skills/apple-dev-skills && git checkout v1.6.0 && cd -
-```
-
-`.claude/settings.json` (committed):
-
-```json
-{
-  "extraKnownMarketplaces": {
-    "apple-dev-skills": { "source": { "source": "directory", "path": "./.claude/skills/apple-dev-skills" } }
-  },
-  "enabledPlugins": {
-    "apple-dev-skills@apple-dev-skills": true,
-    "collaboration-skills@apple-dev-skills": true
-  }
-}
-```
-
-A bare submodule alone is **not** discovered — the marketplace registration is what loads the skills.
-
-### C — `npx skills` (flat, no plugin)
-
-```bash
-npx skills add wei18/apple-dev-skills --list
-npx skills add wei18/apple-dev-skills --skill swift6-concurrency
-```
-
-> **Path C does not include the aggregated externals.** `npx skills` does read this repo's
-> `marketplace.json` / `plugin.json`, but only follows locally-declared skill paths — it
-> doesn't fetch the externals' remote `github` / `git-subdir` sources, so the commands above
-> reach only the 39 first-party skills; the 7 externals are silently skipped. To flat-install
-> the whole catalog (externals included, pulled from their authors' repos):
-
-```bash
-scripts/install-flat.sh -g          # user-level; drop -g for project-level
-scripts/install-flat.sh --dry-run   # preview the `npx skills add` commands
-```
-
-> Newly installed skills are first in line to lose their descriptions: Claude Code's skill
-> listing has a context budget, and on overflow it drops descriptions starting with the
-> least-invoked skills. Run `/doctor` to check the listing's cost; tune `skillListingBudgetFraction` / `skillOverrides` in settings if it's too tight.
-
-## Quickstart
-
-Install path A, then describe the task — skills route themselves from their `description:`,
-so nothing needs invoking:
+Then just describe the task:
 
 - *"I'm starting a new iOS app"* → `apple-platform-targets` answers the deployment target and
   hands off to the package shape, language mode, and test baseline in order.
@@ -149,25 +97,79 @@ Full index in the tables below.
 
 ### Aggregated external (7) — by reference, credited
 
-Listed here but **not authored here**; they install from their authors' own repos (you get
+Listed here but **not authored here** — installed from the authors' own repos (you get
 their latest), credited in full. **Aggregate, don't appropriate**: only MIT-compatible,
-non-duplicate plugins are listed — first-party skills are written only for genuine gaps.
-That check happens when a plugin is listed, not on every upstream commit: because you install
-the author's latest, an external's scope and licence can move after listing (`caveman` already has).
-The externals are broad **reference** ("here's the API / here's how to build X"); the
-first-party skills sit a layer below as **opinionated defaults and shipped-it war stories**
-(use iOS 18, one Package, swift-testing + snapshot, OSLog no-third-party, runtime bugs that
-slipped past review). Where a topic overlaps, they differ by altitude, not duplication.
+non-duplicate plugins are listed, for genuine gaps only — that check happens once at
+listing time, not on every upstream commit, so an external's scope and licence can drift
+after listing (`caveman` already has). Externals are broad **reference** ("here's the API /
+here's how to build X"); first-party skills sit a layer below as **opinionated defaults and
+shipped-it war stories** (iOS 18, one Package, swift-testing + snapshot, OSLog no-third-party,
+runtime bugs that slipped past review) — where a topic overlaps, they differ by altitude,
+not duplication.
 
 | Plugin | Author | Covers |
 |---|---|---|
 | [`apple-skills`](https://github.com/vabole/apple-skills) | vabole (MIT) | Broad Apple frameworks — SwiftUI, SwiftData, App Intents, WidgetKit, StoreKit, HealthKit … |
 | [`swiftui-expert`](https://github.com/AvdLee/SwiftUI-Agent-Skill) | Antoine van der Lee (MIT) | SwiftUI patterns, Swift Charts, Liquid Glass, Instruments toolchain |
 | [`swiftui-pro`](https://github.com/twostraws/SwiftUI-Agent-Skill) | Paul Hudson (MIT) | SwiftUI pitfalls, deprecated-API watchlist, iOS 26 / Liquid Glass |
-| [`caveman`](https://github.com/JuliusBrussee/caveman) | JuliusBrussee (skills MIT; repo also ships a BSL-1.1 engine) | Ultra-compressed communication mode — cuts ~75% of tokens. Has since grown into a 20-skill suite; 4 of them (`caveman-discover`, `caveman-manage`, `caveman-evidence-review`, `caveman-setup`) document the author's hosted Caveman Cloud commercial service (general agent behavior) |
+| [`caveman`](https://github.com/JuliusBrussee/caveman) | JuliusBrussee (skills MIT; repo also ships a BSL-1.1 engine) | Ultra-compressed communication mode — cuts ~75% of tokens (general agent behavior) |
 | [`ponytail`](https://github.com/DietrichGebert/ponytail) | DietrichGebert (MIT) | "Lazy senior dev" mode — forces the simplest, shortest solution (general agent behavior) |
 | [`i-have-adhd`](https://github.com/ayghri/i-have-adhd) | Ayoub G. (MIT) | Always-on ADHD-friendly output mode — action-first, numbered steps, state restated each turn; vs `caveman` (token compression) and `ponytail` (solution simplicity), this shapes structure (general agent behavior) |
 | [`xcode-build-skill`](https://github.com/pzep1/xcode-build-skill) | pz (MIT) | `xcodebuild`/`xcrun simctl` CLI reference — discover schemes → find simulators → build → install → launch → screenshot; CLI-driven, distinct from `interactive-simulator-ux-audit` (idb-driven interactive UX audit) and `host-driven-xcuitest-e2e` (Tuist-scheme XCUITest E2E) — the three don't overlap |
+
+`caveman` has since grown into a 20-skill suite; 4 of them (`caveman-discover`, `caveman-manage`,
+`caveman-evidence-review`, `caveman-setup`) document the author's hosted Caveman Cloud commercial
+service (general agent behavior).
+
+## Other ways to install
+
+### B — pinned for a team
+
+Pin the marketplace to a released tag directly in `.claude/settings.json` — no submodule needed:
+
+```json
+{
+  "extraKnownMarketplaces": {
+    "apple-dev-skills": {
+      "source": { "source": "github", "repo": "wei18/apple-dev-skills", "ref": "v1.6.0" }
+    }
+  },
+  "enabledPlugins": {
+    "apple-dev-skills@apple-dev-skills": true,
+    "collaboration-skills@apple-dev-skills": true
+  }
+}
+```
+
+Commit it — collaborators get the marketplace automatically once they trust the project
+folder, no separate prompt.
+
+### C — `npx skills` (flat, no plugin)
+
+```bash
+npx skills add wei18/apple-dev-skills --list
+npx skills add wei18/apple-dev-skills --skill swift6-concurrency
+```
+
+> **Path C does not include the aggregated externals.** `npx skills` does read this repo's
+> `marketplace.json` / `plugin.json`, but only follows locally-declared skill paths — it
+> doesn't fetch the externals' remote `github` / `git-subdir` sources, so the commands above
+> reach only the 39 first-party skills; the 7 externals are silently skipped. To flat-install
+> the whole catalog (externals included, pulled from their authors' repos):
+
+```bash
+scripts/install-flat.sh -g          # user-level; drop -g for project-level
+scripts/install-flat.sh --dry-run   # preview the `npx skills add` commands
+```
+
+> Newly installed skills are first in line to lose their descriptions: Claude Code's skill
+> listing has a context budget, and on overflow it drops descriptions starting with the
+> least-invoked skills. Run `/doctor` to check the listing's cost; tune `skillListingBudgetFraction` / `skillOverrides` in settings if it's too tight.
+
+## Contributing
+
+Three ways to help: **aggregate** an external plugin, **add** a first-party skill, or
+**report** a field note — see [CONTRIBUTING.md](CONTRIBUTING.md).
 
 ## Provenance
 
@@ -175,5 +177,5 @@ First-party skills were distilled and genericized from [`wei18/Sudoku`](https://
 `.claude/skills/` — a spec-first, AI-Leader/Developer-built portfolio of shipping Apple-platform
 games — plus original write-ups of public Apple / WCAG / Swift standards. Aggregated externals
 remain their authors' work, surfaced by reference only. The design specs and plans that produced
-this repo's two-plugin shape lived under `docs/superpowers/` until they were retired in favour of
-git history; `git log -- docs/` finds them. MIT — see [LICENSE](LICENSE).
+this repo's two-plugin shape lived under `docs/superpowers/` — retired in favour of git history;
+run `git log -- docs/` to find them. MIT — see [LICENSE](LICENSE).

--- a/README.zh-Hant.md
+++ b/README.zh-Hant.md
@@ -1,20 +1,18 @@
 # apple-dev-skills
 
-> 一份**用 AI coding agent（[Claude Code](https://code.claude.com)）vibe coding iOS（與 Apple 生態系）App 的技能目錄**
-> —— 為獨立開發者與小型團隊而寫，把一個點子帶到 App Store 上架。第一方技能分兩半：**Apple/Swift**
-> 管你在做什麼，**harness engineering** 管你怎麼駕馭那個在做事的 agent —— 派工、審查、出貨。
-> 兩者都是帶立場的預設值與實際上架的戰場故事，並受一道一致性把關。另以**引用方式**彙整
-> 同類最佳的**外部**技能 plugin（完整標註原作者，絕不複製）。
+> 用 Claude Code vibe coding iOS 與 Apple 生態系 App 的技能 —— 以及駕馭那個打造它們的 agent 的技能。
 >
 > 語言：[English](README.md) · [繁體中文](README.zh-Hant.md)
 
-本 repo 是單一 **marketplace**，收錄兩個第一方 plugin 與數個彙整而來的外部 plugin。
+apple-dev-skills 是一個 **marketplace**，為獨立開發者與小型團隊而寫，把一個點子帶到 App Store
+上架，分成兩個第一方半邊：**Apple/Swift** 技能管你在做什麼，**harness engineering** 技能管你
+怎麼駕馭那個在做事的 agent —— 派工、審查、出貨。品質靠帶立場的預設值、實際上架的戰場故事，
+以及一道一致性把關撐住 —— 另以引用方式彙整同類最佳的**外部**技能 plugin（完整標註原作者，
+絕不複製）。
 
-## 安裝
+## 快速開始
 
 > 技能會依其 `description:` 自行觸發——裝好之後，直接描述你的任務即可。
-
-### A —— marketplace（最簡單）
 
 ```
 /plugin marketplace add wei18/apple-dev-skills
@@ -24,56 +22,7 @@
 
 裝其中一個或兩個都裝皆可。外部 plugin 的安裝方式相同，例如 `/plugin install swiftui-expert@apple-dev-skills`。
 
-### B —— repo 層級（vendored submodule，鎖定版本）
-
-在單一 repo 內 vendor 並鎖版，接著註冊一個 project-scope 的 local-path marketplace，
-讓 plugin 從鎖定的 submodule 載入（協作者會被提示信任該 workspace）：
-
-```bash
-git submodule add https://github.com/wei18/apple-dev-skills.git .claude/skills/apple-dev-skills
-cd .claude/skills/apple-dev-skills && git checkout v1.6.0 && cd -
-```
-
-`.claude/settings.json`（納入版控）：
-
-```json
-{
-  "extraKnownMarketplaces": {
-    "apple-dev-skills": { "source": { "source": "directory", "path": "./.claude/skills/apple-dev-skills" } }
-  },
-  "enabledPlugins": {
-    "apple-dev-skills@apple-dev-skills": true,
-    "collaboration-skills@apple-dev-skills": true
-  }
-}
-```
-
-單靠一個 submodule **不會**被探索到——真正載入技能的是 marketplace 註冊。
-
-### C —— `npx skills`（平鋪，不走 plugin）
-
-```bash
-npx skills add wei18/apple-dev-skills --list
-npx skills add wei18/apple-dev-skills --skill swift6-concurrency
-```
-
-> **路徑 C 不包含彙整而來的外部 plugin。** `npx skills` 確實會讀取本 repo 的
-> `marketplace.json` / `plugin.json`，但只跟隨本地宣告的技能路徑——它不會抓取外部
-> plugin 的遠端 `github` / `git-subdir` 來源，因此上述指令只涵蓋 39 個第一方技能；
-> 7 個外部 plugin 會被靜默略過。若要平鋪安裝整份目錄（含外部 plugin，從原作者的 repo 拉取）：
-
-```bash
-scripts/install-flat.sh -g          # user-level; drop -g for project-level
-scripts/install-flat.sh --dry-run   # preview the `npx skills add` commands
-```
-
-> 新安裝的技能最容易第一個失去描述：Claude Code 的技能清單有 context 預算，
-> 溢出時會從最少被呼叫的技能開始丟棄描述。執行 `/doctor` 檢查清單的成本；
-> 若太吃緊，可在 settings 調整 `skillListingBudgetFraction` / `skillOverrides`。
-
-## 快速開始
-
-照路徑 A 安裝，然後直接描述你要做的事 —— 技能會依自己的 `description:` 自動路由，不需要手動呼叫：
+接著直接描述你要做的事：
 
 - *「我要開一個新的 iOS App」* → `apple-platform-targets` 回答最低部署版本，並依序交棒給
   package 結構、語言模式與測試基準。
@@ -144,30 +93,82 @@ scripts/install-flat.sh --dry-run   # preview the `npx skills add` commands
 
 ### 彙整之外部 plugin（7）—— 以引用方式收錄，完整標註
 
-此處僅列出、**並非在此撰寫**；它們會從原作者自己的 repo 安裝（你拿到的是最新版），並完整標註出處。
-**彙整而非佔為己有**：只列出 MIT 相容、不重複的 plugin —— 第一方技能只為真正的空缺而寫。
-這道檢查發生在收錄當下，不是每次上游 commit 都重審：因為你安裝的是原作者的最新版，
-外部 plugin 的範圍與授權在收錄後仍可能變動（`caveman` 就已經變過）。
-外部 plugin 是廣度型的**參考資料**（「這是 API」／「X 要這樣做」）；第一方技能位在下一層，
-是**帶立場的預設值與實際上架的戰場故事**（用 iOS 18、單一 Package、swift-testing + snapshot、
-OSLog 不用第三方、審查漏掉的執行期 bug）。主題重疊處，兩者差在高度，而非重複。
+此處僅列出、**並非在此撰寫** —— 從原作者自己的 repo 安裝（你拿到的是最新版），完整標註出處。
+**彙整而非佔為己有**：只列出 MIT 相容、不重複的 plugin，且只為真正的空缺而收 —— 這道檢查發生
+在收錄當下，不是每次上游 commit 都重審，因此外部 plugin 的範圍與授權在收錄後仍可能變動
+（`caveman` 就已經變過）。外部 plugin 是廣度型的**參考資料**（「這是 API」／「X 要這樣做」）；
+第一方技能位在下一層，是**帶立場的預設值與實際上架的戰場故事**（iOS 18、單一 Package、
+swift-testing + snapshot、OSLog 不用第三方、審查漏掉的執行期 bug）—— 主題重疊處，兩者差在
+高度，而非重複。
 
 | Plugin | 作者 | 涵蓋範圍 |
 |---|---|---|
 | [`apple-skills`](https://github.com/vabole/apple-skills) | vabole (MIT) | 廣泛的 Apple 框架 —— SwiftUI、SwiftData、App Intents、WidgetKit、StoreKit、HealthKit… |
 | [`swiftui-expert`](https://github.com/AvdLee/SwiftUI-Agent-Skill) | Antoine van der Lee (MIT) | SwiftUI 模式、Swift Charts、Liquid Glass、Instruments 工具鏈 |
 | [`swiftui-pro`](https://github.com/twostraws/SwiftUI-Agent-Skill) | Paul Hudson (MIT) | SwiftUI 陷阱、deprecated API 觀察清單、iOS 26 / Liquid Glass |
-| [`caveman`](https://github.com/JuliusBrussee/caveman) | JuliusBrussee（技能為 MIT；該 repo 另含 BSL-1.1 授權的 engine） | 極度壓縮的溝通模式 —— 省下約 75% token。之後已長成 20 個技能的套件；其中 4 個（`caveman-discover`、`caveman-manage`、`caveman-evidence-review`、`caveman-setup`）在講作者自家托管的 Caveman Cloud 商業服務（通用 agent 行為） |
+| [`caveman`](https://github.com/JuliusBrussee/caveman) | JuliusBrussee（技能為 MIT；該 repo 另含 BSL-1.1 授權的 engine） | 極度壓縮的溝通模式 —— 省下約 75% token（通用 agent 行為） |
 | [`ponytail`](https://github.com/DietrichGebert/ponytail) | DietrichGebert (MIT) | 「懶惰資深工程師」模式 —— 逼出最簡單、最短的解法（通用 agent 行為） |
 | [`i-have-adhd`](https://github.com/ayghri/i-have-adhd) | Ayoub G. (MIT) | 常駐的 ADHD 友善輸出模式 —— 行動優先、編號步驟、每一輪重述狀態；相對於 `caveman`（token 壓縮）與 `ponytail`（解法簡化），這個塑形的是結構（通用 agent 行為） |
 | [`xcode-build-skill`](https://github.com/pzep1/xcode-build-skill) | pz (MIT) | `xcodebuild`/`xcrun simctl` CLI 參考 —— 找 scheme → 找模擬器 → build → install → launch → 截圖；CLI 驅動，與 `interactive-simulator-ux-audit`（idb 驅動的互動式 UX 稽核）、`host-driven-xcuitest-e2e`（Tuist scheme 接線的 XCUITest E2E）三者不重疊 |
+
+`caveman` 之後已長成 20 個技能的套件；其中 4 個（`caveman-discover`、`caveman-manage`、
+`caveman-evidence-review`、`caveman-setup`）在講作者自家托管的 Caveman Cloud 商業服務
+（通用 agent 行為）。
+
+## 其他安裝方式
+
+### B —— 團隊固定版本
+
+直接在 `.claude/settings.json` 把 marketplace 鎖定到一個已發佈的 tag —— 不需要 submodule：
+
+```json
+{
+  "extraKnownMarketplaces": {
+    "apple-dev-skills": {
+      "source": { "source": "github", "repo": "wei18/apple-dev-skills", "ref": "v1.6.0" }
+    }
+  },
+  "enabledPlugins": {
+    "apple-dev-skills@apple-dev-skills": true,
+    "collaboration-skills@apple-dev-skills": true
+  }
+}
+```
+
+commit 它 —— 協作者信任該專案資料夾之後就會自動拿到這個 marketplace，不會有額外提示。
+
+### C —— `npx skills`（平鋪，不走 plugin）
+
+```bash
+npx skills add wei18/apple-dev-skills --list
+npx skills add wei18/apple-dev-skills --skill swift6-concurrency
+```
+
+> **路徑 C 不包含彙整而來的外部 plugin。** `npx skills` 確實會讀取本 repo 的
+> `marketplace.json` / `plugin.json`，但只跟隨本地宣告的技能路徑——它不會抓取外部
+> plugin 的遠端 `github` / `git-subdir` 來源，因此上述指令只涵蓋 39 個第一方技能；
+> 7 個外部 plugin 會被靜默略過。若要平鋪安裝整份目錄（含外部 plugin，從原作者的 repo 拉取）：
+
+```bash
+scripts/install-flat.sh -g          # user-level; drop -g for project-level
+scripts/install-flat.sh --dry-run   # preview the `npx skills add` commands
+```
+
+> 新安裝的技能最容易第一個失去描述：Claude Code 的技能清單有 context 預算，
+> 溢出時會從最少被呼叫的技能開始丟棄描述。執行 `/doctor` 檢查清單的成本；
+> 若太吃緊，可在 settings 調整 `skillListingBudgetFraction` / `skillOverrides`。
+
+## 貢獻
+
+三種幫忙方式：**彙整**一個外部 plugin、**新增**一個第一方技能、或**回報**一則現場筆記
+—— 見 [CONTRIBUTING.md](CONTRIBUTING.md)。
 
 ## 出處
 
 第一方技能萃取並去專案化自 [`wei18/Sudoku`](https://github.com/wei18/Sudoku) 的
 `.claude/skills/` —— 一組 spec-first、由 AI Leader/Developer 打造、已上架的 Apple 平台遊戲作品集 ——
 再加上針對公開的 Apple / WCAG / Swift 標準所做的原創整理。彙整之外部 plugin 仍屬其作者的作品，
-此處僅以引用方式呈現。催生本 repo 雙 plugin 結構的設計 spec 與計畫原本放在 `docs/superpowers/`，
-現已退役、改由 git 歷史保存；用 `git log -- docs/` 可以找回。MIT —— 見 [LICENSE](LICENSE)。
+此處僅以引用方式呈現。催生本 repo 雙 plugin 結構的設計 spec 與計畫原本放在 `docs/superpowers/`
+—— 已退役、改由 git 歷史保存；用 `git log -- docs/` 可以找回。MIT —— 見 [LICENSE](LICENSE)。
 
-<!-- src-sha: 15492afaba6d5b24cd21e213f3ec4892a4f40ca0 -->
+<!-- src-sha: df1cfc347ca98c41ad42a2245b2ae9c1234045e1 -->

--- a/README.zh-Hant.md
+++ b/README.zh-Hant.md
@@ -4,11 +4,11 @@
 >
 > 語言：[English](README.md) · [繁體中文](README.zh-Hant.md)
 
-apple-dev-skills 是一個 **marketplace**，為獨立開發者與小型團隊而寫，把一個點子帶到 App Store
-上架，分成兩個第一方半邊：**Apple/Swift** 技能管你在做什麼，**harness engineering** 技能管你
-怎麼駕馭那個在做事的 agent —— 派工、審查、出貨。品質靠帶立場的預設值、實際上架的戰場故事，
-以及一道一致性把關撐住 —— 另以引用方式彙整同類最佳的**外部**技能 plugin（完整標註原作者，
-絕不複製）。
+apple-dev-skills 是一個 **marketplace**，為獨立開發者與小型團隊而寫，陪你把一個點子帶到
+App Store 上架。第一方技能分成兩組：**Apple/Swift** 技能管你在做什麼，**harness engineering**
+技能管你怎麼駕馭那個在做事的 agent —— 派工、審查、出貨。每一支技能都是帶立場的預設值，背後
+有實際上架的戰場故事，並受一道一致性把關；旁邊另以引用方式彙整同類最佳的**外部**技能
+plugin，完整標註原作者，絕不複製。
 
 ## 快速開始
 
@@ -20,7 +20,7 @@ apple-dev-skills 是一個 **marketplace**，為獨立開發者與小型團隊�
 /plugin install collaboration-skills@apple-dev-skills      # 12 agent-collaboration skills
 ```
 
-裝其中一個或兩個都裝皆可。外部 plugin 的安裝方式相同，例如 `/plugin install swiftui-expert@apple-dev-skills`。
+裝一個或兩個都可以。外部 plugin 的安裝方式相同，例如 `/plugin install swiftui-expert@apple-dev-skills`。
 
 接著直接描述你要做的事：
 
@@ -171,4 +171,4 @@ scripts/install-flat.sh --dry-run   # preview the `npx skills add` commands
 此處僅以引用方式呈現。催生本 repo 雙 plugin 結構的設計 spec 與計畫原本放在 `docs/superpowers/`
 —— 已退役、改由 git 歷史保存；用 `git log -- docs/` 可以找回。MIT —— 見 [LICENSE](LICENSE)。
 
-<!-- src-sha: df1cfc347ca98c41ad42a2245b2ae9c1234045e1 -->
+<!-- src-sha: 8f9e00b3a218facc793b00bded93746ca484cc15 -->

--- a/scripts/bump-version.py
+++ b/scripts/bump-version.py
@@ -3,9 +3,10 @@
 
 Surfaces (previously a 4-file manual dance, see v1.3.1 / PR #16):
   --marketplace X.Y.Z  -> marketplace.json metadata.version
-                          + `git checkout vX.Y.Z` pin in README.md AND README.zh-Hant.md
-                          + re-stamp README.zh-Hant.md src-sha (pin line is hand-mirrored;
-                            no full zh regeneration needed for this one-line change)
+                          + `"ref": "vX.Y.Z"` marketplace pin in README.md AND every
+                            mirror in scripts/mirrors.py
+                          + re-stamp each mirror's src-sha (pin line is hand-mirrored;
+                            no full mirror regeneration needed for this one-line change)
   --apple X.Y.Z        -> apple-dev-skills/.claude-plugin/plugin.json version
                           + its marketplace.json plugins[] entry version
   --collab X.Y.Z       -> same pair for collaboration-skills
@@ -20,6 +21,8 @@ Stdlib only.
 from __future__ import annotations
 import argparse, json, re, subprocess, sys
 from pathlib import Path
+
+from mirrors import MIRRORS
 
 ROOT = Path(__file__).resolve().parent.parent
 MP = ROOT / ".claude-plugin" / "marketplace.json"
@@ -50,32 +53,35 @@ def set_plugin_version(plugin_dir: str, version: str):
 
 
 def set_marketplace_version(version: str):
-    # Refuse to bump while the zh mirror is already stale — otherwise the re-stamp
+    # Refuse to bump while any mirror is already stale — otherwise the re-stamp
     # below just re-freshens a src-sha that was never an honest mirror of README.md
-    # (regression: bump-version.py --marketplace silently launders a stale zh mirror
+    # (regression: bump-version.py --marketplace silently launders a stale mirror
     # into a green gate, see check-consistency.py rule 4).
-    zh = ROOT / "README.zh-Hant.md"
     pre_sha = subprocess.run(["git", "hash-object", "README.md"], cwd=ROOT,
                              capture_output=True, text=True, check=True).stdout.strip()
-    m = re.search(r"<!-- src-sha: ([0-9a-f]+) -->", zh.read_text(encoding="utf-8"))
-    if not m or m.group(1) != pre_sha:
-        die("README.zh-Hant.md src-sha is stale vs README.md — run `mise run readme-zh` first, then re-run bump")
+    for mirror_name in MIRRORS:
+        mirror = ROOT / mirror_name
+        m = re.search(r"<!-- src-sha: ([0-9a-f]+) -->", mirror.read_text(encoding="utf-8"))
+        if not m or m.group(1) != pre_sha:
+            die(f"{mirror_name} src-sha is stale vs README.md — run `mise run readme-zh` first, then re-run bump")
 
     MP.write_text(sub_once(MP.read_text(encoding="utf-8"),
                            r'("metadata"\s*:\s*\{[^}]*?"version"\s*:\s*")' + SEMVER + r'(")',
                            rf"\g<1>{version}\g<2>", "marketplace metadata"), encoding="utf-8")
-    for name in ("README.md", "README.zh-Hant.md"):
+    for name in ("README.md", *MIRRORS):
         p = ROOT / name
-        text, n = re.subn(rf"git checkout v{SEMVER}", f"git checkout v{version}",
+        text, n = re.subn(r'"ref":\s*"v' + SEMVER + r'"', f'"ref": "v{version}"',
                           p.read_text(encoding="utf-8"))
-        if n == 0: die(f"no 'git checkout v<semver>' pin in {name}")
+        if n == 0: die(f'no \'"ref": "v<semver>"\' pin in {name}')
         p.write_text(text, encoding="utf-8")
     sha = subprocess.run(["git", "hash-object", "README.md"], cwd=ROOT,
                          capture_output=True, text=True, check=True).stdout.strip()
-    zh.write_text(sub_once(zh.read_text(encoding="utf-8"),
-                           r"(<!-- src-sha: )[0-9a-f]+( -->)", rf"\g<1>{sha}\g<2>",
-                           "zh-Hant src-sha"), encoding="utf-8")
-    print(f"  marketplace metadata + README pins: -> {version} (zh src-sha re-stamped)")
+    for mirror_name in MIRRORS:
+        mirror = ROOT / mirror_name
+        mirror.write_text(sub_once(mirror.read_text(encoding="utf-8"),
+                               r"(<!-- src-sha: )[0-9a-f]+( -->)", rf"\g<1>{sha}\g<2>",
+                               f"{mirror_name} src-sha"), encoding="utf-8")
+    print(f"  marketplace metadata + README pins: -> {version} (mirror src-sha re-stamped)")
 
 
 def main():

--- a/scripts/check-consistency.py
+++ b/scripts/check-consistency.py
@@ -9,18 +9,20 @@ Checks
   3. Counts present: the values 25/12/6 each appear among the Catalog's "(N)" group
      headers (set membership, not per-header association); the Install one-liner
      comments and each plugin.json's "N first-party" are checked exactly.
-  4. README.zh-Hant.md exists and its embedded src-sha == git hash-object README.md.
+  4. Each README mirror (scripts/mirrors.py; currently README.zh-Hant.md) exists and its
+     embedded src-sha == git hash-object README.md.
   5. All plugin/marketplace JSON parse; the two subdir plugin sources resolve to dirs;
      marketplace.json lists exactly the 9 plugins (2 local + 7 externals).
-  6. The `git checkout v<semver>` pin in both READMEs' Install section ==
-     marketplace.json metadata.version (drifted silently before: v1.2.0 → #17).
+  6. The `"ref": "v<semver>"` marketplace pin in README.md and every mirror ==
+     marketplace.json metadata.version (drifted silently before as a
+     `git checkout v<semver>` string: v1.2.0 → #17).
   7. Each SKILL.md frontmatter description <= DESC_MAX chars (descriptions are
      always-on context for every consumer session; keeps Lens-3 compression durable).
   8. Each plugin's `.claude-plugin/plugin.json` "version" == the corresponding
      marketplace.json plugins[] entry "version" (the pair bump-version.py maintains).
-  9. README.zh-Hant.md's `## 目錄` section covers the same first-party skills +
-     externals as README.md's Catalog (mirrors check 2; count regex also accepts
-     full-width parens, since the zh mirror is hand-typed).
+  9. Each README mirror's own Catalog-equivalent section (scripts/mirrors.py) covers
+     the same first-party skills + externals as README.md's Catalog (mirrors check 2;
+     count regex also accepts full-width parens, since mirrors are hand-typed).
   10. Each SKILL.md frontmatter description that is not quoted must not contain
       ": " or start with a YAML indicator character (PR #42: an unquoted value
       containing ": " breaks strict YAML parsers). A block scalar (`description: >`)
@@ -33,6 +35,8 @@ Stdlib only.
 from __future__ import annotations
 import json, re, subprocess, sys
 from pathlib import Path
+
+from mirrors import MIRRORS
 
 ROOT = Path(__file__).resolve().parent.parent
 PLUGINS = {"apple-dev-skills": 27, "collaboration-skills": 12}
@@ -124,23 +128,25 @@ else:
     stale = {t for t in re.findall(r"`([a-z0-9][a-z0-9-]+)`", anchors)} - (all_skills | EXTERNALS)
     if stale: fail(f"[readme] Catalog anchor list names no such skill: {sorted(stale)}")
 
-# 9. README.zh-Hant.md's 目錄 (Catalog) section — same token coverage check as
-# above, mirrored: it's hand-typed so a translator can silently drop/mistype a
-# skill token without English README.md or the src-sha check ever noticing.
-zh_path = ROOT / "README.zh-Hant.md"
-if zh_path.is_file():
-    zh_sec = scoped(zh_path.read_text(encoding="utf-8"), "## 目錄")
-    if not zh_sec:
-        fail("[zh] no '## 目錄' section")
-    else:
-        zh_tokens = set(re.findall(r"`([a-z0-9][a-z0-9-]+)`", zh_sec))
-        zh_missing = (all_skills | EXTERNALS) - zh_tokens
-        if zh_missing: fail(f"[zh] 目錄 missing: {sorted(zh_missing)}")
-        zg = [int(x) for x in re.findall(r"[\(（](\d+)[\)）]", zh_sec)]
-        for required in (*PLUGINS.values(), len(EXTERNALS)):
-            if required not in zg:
-                fail(f"[zh] 目錄 counts {sorted(zg)} must include {sorted((*PLUGINS.values(), len(EXTERNALS)))}")
-                break
+# 9. Each mirror's own Catalog-equivalent section — same token coverage check as
+# above, mirrored: mirrors are hand-typed so a translator can silently drop/mistype
+# a skill token without README.md or the src-sha check (rule 4) ever noticing.
+for mirror_name, heading in MIRRORS.items():
+    mirror_path = ROOT / mirror_name
+    if not mirror_path.is_file():
+        continue  # rule 4 below already flags a missing mirror
+    m_sec = scoped(mirror_path.read_text(encoding="utf-8"), heading)
+    if not m_sec:
+        fail(f"[{mirror_name}] no '{heading}' section")
+        continue
+    m_tokens = set(re.findall(r"`([a-z0-9][a-z0-9-]+)`", m_sec))
+    m_missing = (all_skills | EXTERNALS) - m_tokens
+    if m_missing: fail(f"[{mirror_name}] {heading} missing: {sorted(m_missing)}")
+    mg = [int(x) for x in re.findall(r"[\(（](\d+)[\)）]", m_sec)]
+    for required in (*PLUGINS.values(), len(EXTERNALS)):
+        if required not in mg:
+            fail(f"[{mirror_name}] {heading} counts {sorted(mg)} must include {sorted((*PLUGINS.values(), len(EXTERNALS)))}")
+            break
 
 # plugin.json counts
 plugin_json_versions: dict[str, str] = {}
@@ -157,16 +163,17 @@ for plugin, n in re.findall(r"/plugin install (\S+?)@apple-dev-skills\s+#\s*(\d+
     if plugin in PLUGINS and int(n) != PLUGINS[plugin]:
         fail(f"[readme] Install comment says '{n}' for {plugin}, expected {PLUGINS[plugin]}")
 
-# 4. zh-Hant freshness
-zh = ROOT / "README.zh-Hant.md"
-if not zh.is_file():
-    fail("[zh] README.zh-Hant.md missing — run `mise run readme-zh`")
-else:
-    m = re.search(r"src-sha:\s*([0-9a-f]+)", zh.read_text(encoding="utf-8"))
+# 4. Mirror freshness
+for mirror_name in MIRRORS:
+    mirror = ROOT / mirror_name
+    if not mirror.is_file():
+        fail(f"[{mirror_name}] missing — run `mise run readme-zh`")
+        continue
+    m = re.search(r"src-sha:\s*([0-9a-f]+)", mirror.read_text(encoding="utf-8"))
     cur = subprocess.run(["git", "hash-object", "README.md"], cwd=ROOT,
                          capture_output=True, text=True, check=True).stdout.strip()
-    if not m: fail("[zh] no embedded src-sha")
-    elif m.group(1) != cur: fail("[zh] stale — run `mise run readme-zh` (src-sha != README.md)")
+    if not m: fail(f"[{mirror_name}] no embedded src-sha")
+    elif m.group(1) != cur: fail(f"[{mirror_name}] stale — run `mise run readme-zh` (src-sha != README.md)")
 
 # 5. marketplace JSON + subdir sources
 mp = ROOT / ".claude-plugin" / "marketplace.json"
@@ -188,13 +195,13 @@ try:
             fail(f"[manifest] {plugin} version missing — plugin.json={pj_v!r}, marketplace.json={mp_v!r}")
         elif pj_v != mp_v:
             fail(f"[manifest] {plugin} plugin.json version {pj_v!r} != marketplace.json plugins[].version {mp_v!r} — run `mise run bump`")
-    # 6. README Install pin == marketplace metadata.version
+    # 6. README marketplace-pin == marketplace metadata.version
     mp_version = d.get("metadata", {}).get("version", "")
-    for readme_name in ("README.md", "README.zh-Hant.md"):
+    for readme_name in ("README.md", *MIRRORS):
         text = (ROOT / readme_name).read_text(encoding="utf-8") if (ROOT / readme_name).is_file() else ""
-        pins = re.findall(r"git checkout v(\d+\.\d+\.\d+)", text)
+        pins = re.findall(r'"ref":\s*"v(\d+\.\d+\.\d+)"', text)
         if not pins:
-            fail(f"[readme] {readme_name}: no 'git checkout v<semver>' pin found")
+            fail(f'[readme] {readme_name}: no \'"ref": "v<semver>"\' pin found')
         for pin in pins:
             if pin != mp_version:
                 fail(f"[readme] {readme_name}: Install pin v{pin} != marketplace metadata.version {mp_version} — run `mise run bump`")

--- a/scripts/gen-readme-zh.sh
+++ b/scripts/gen-readme-zh.sh
@@ -1,29 +1,38 @@
 #!/bin/sh
 # C-hybrid: translate when `claude` is available; otherwise verify freshness.
+# Usage: scripts/gen-readme-zh.sh <locale>   (e.g. zh-Hant)
 set -eu
 cd "$(git rev-parse --show-toplevel)"
+
+LOCALE="${1:?usage: gen-readme-zh.sh <locale>, e.g. zh-Hant}"
+case "$LOCALE" in
+  zh-Hant) LANG_NAME="Traditional Chinese (zh-Hant)" ;;
+  *) echo "unsupported locale: $LOCALE (known: zh-Hant)" >&2; exit 1 ;;
+esac
+OUT="README.$LOCALE.md"
+
 SHA="$(git hash-object README.md)"
 
 if command -v claude >/dev/null 2>&1; then
   TMP="$(mktemp)"
   trap 'rm -f "$TMP"' EXIT
-  claude -p "Translate the markdown read from stdin into Traditional Chinese (zh-Hant).
+  claude -p "Translate the markdown read from stdin into $LANG_NAME.
 Preserve structure, code fences, links, table layout, and all identifiers (kebab-case
 skill/plugin names, install commands) verbatim. Translate only prose and table one-liners.
 Output ONLY the translated markdown, nothing else." < README.md > "$TMP"
   if [ ! -s "$TMP" ]; then
-    echo "claude produced empty output; leaving README.zh-Hant.md unchanged" >&2
+    echo "claude produced empty output; leaving $OUT unchanged" >&2
     exit 1
   fi
   printf '\n<!-- src-sha: %s -->\n' "$SHA" >> "$TMP"
-  mv "$TMP" README.zh-Hant.md
-  git add README.zh-Hant.md
-  echo "regenerated README.zh-Hant.md (src-sha $SHA)"
+  mv "$TMP" "$OUT"
+  git add "$OUT"
+  echo "regenerated $OUT (src-sha $SHA)"
 else
-  EMB="$(grep -oE '<!-- src-sha: [0-9a-f]+ -->' README.zh-Hant.md 2>/dev/null | grep -oE '[0-9a-f]{7,}' || true)"
+  EMB="$(grep -oE '<!-- src-sha: [0-9a-f]+ -->' "$OUT" 2>/dev/null | grep -oE '[0-9a-f]{7,}' || true)"
   if [ "$EMB" != "$SHA" ]; then
-    echo "README.zh-Hant.md is stale; run 'mise run readme-zh' where 'claude' is on PATH" >&2
+    echo "$OUT is stale; run 'mise run readme-zh' where 'claude' is on PATH" >&2
     exit 1
   fi
-  echo "README.zh-Hant.md fresh (src-sha $SHA)"
+  echo "$OUT fresh (src-sha $SHA)"
 fi

--- a/scripts/mirrors.py
+++ b/scripts/mirrors.py
@@ -1,0 +1,13 @@
+"""Single source of truth for this repo's README mirrors (SSOT is README.md).
+
+Each entry maps a mirror file to the heading text that opens its localized
+Catalog-equivalent section (used by check-consistency.py rule 9 to scope the
+coverage check, mirroring rule 2's scoping of README.md's own "## Catalog").
+
+Add a locale here — and only here — when a new language mirror lands; both
+check-consistency.py and bump-version.py loop over this mapping instead of
+hardcoding a filename.
+"""
+MIRRORS = {
+    "README.zh-Hant.md": "## 目錄",
+}


### PR DESCRIPTION
## Summary
- Reorder README.md so a first-time reader gets who/what/how-to-start (tagline → 3-sentence intro → Quickstart) before the Catalog, instead of a 7-line quote wall and three install paths (two with long warnings) blocking the way.
- Replace install path B's submodule + `git checkout` + `directory`-source dance with the officially supported form: `extraKnownMarketplaces` pinned to a released tag via `{"source":"github","repo":...,"ref":"vX.Y.Z"}` in `.claude/settings.json` — Claude Code registers it for collaborators automatically once they trust the project folder (per code.claude.com/docs/en/plugin-marketplaces.md).
- Compress the external-plugins intro from 9 dense lines to 3 sentences (keeping all three points: aggregate-don't-appropriate, one-time-verification-drifts-with-upstream, altitude-not-duplication) and shorten the `caveman` table row (its 20-skill / Caveman Cloud detail moved to a footnote below the table, word-for-word, not deleted).
- Hand-mirror README.zh-Hant.md to the same structure (not regenerated — `mise run readme-zh` has previously mistranslated full-width punctuation).
- Generalize the consistency gate and version-bump script from a single hardcoded zh-Hant mirror to a `scripts/mirrors.py` list (`MIRRORS`), so a future third locale is a one-line addition. Rule 6 (marketplace-version pin) now recognizes the new `"ref": "vX.Y.Z"` form instead of the retired `git checkout v<semver>` string.
- `scripts/gen-readme-zh.sh` now takes a locale argument; `.mise.toml`'s `readme-zh` task passes `zh-Hant` through (task name unchanged). `CONTRIBUTING.md`'s zh-Hant-specific mirror section is now a generic "README mirrors" section (hand-mirror by default, full regen as a reviewed fallback).

No technical claims were added beyond what code.claude.com/docs/en/plugin-marketplaces.md states for `extraKnownMarketplaces` + `ref`; no technical claims were removed (only reordered/compressed). No SKILL.md, marketplace.json, or plugin.json files were touched. No third locale file was added.

## Test plan
- [x] `python3 scripts/check-consistency.py` → exit 0
- [x] 5 negative tests (each reverted after): corrupted zh skill token → red with filename; zh `（27）`→`（26）` → red; polluted README.md without re-stamping mirror → red stale; Quickstart `# 27` → `# 26` → red (rule 3b still fires after the section move); README path B `"ref": "v1.6.0"`→`"v1.5.0"` → red (rule 6 recognizes new pin form)
- [x] `git stash`-protected trial of `python3 scripts/bump-version.py --marketplace 1.7.0` → both README pins replaced, src-sha re-stamped, gate green, then `git checkout -- .` to discard the bump (not part of this PR)
- [x] Path B's JSON snippet validated with `python3 -c "import json,sys; json.load(sys.stdin)"`
- [x] `rg -n 'TODO|FIXME|stub|placeholder'` — no hits in the diff

🤖 Generated with [Claude Code](https://claude.com/claude-code)