### PR TITLE
docs(readme): add Simplified Chinese mirror

### DIFF
--- a/.mise.toml
+++ b/.mise.toml
@@ -9,6 +9,10 @@ run = "python3 scripts/check-consistency.py"
 description = "Regenerate README.zh-Hant.md from README.md (needs claude on PATH)"
 run = "scripts/gen-readme-zh.sh zh-Hant"
 
+[tasks.readme-zh-hans]
+description = "Regenerate README.zh-Hans.md from README.md (needs claude on PATH)"
+run = "scripts/gen-readme-zh.sh zh-Hans"
+
 [tasks.bump]
 description = "Bump release versions on all gate-checked surfaces (e.g. mise run bump -- --marketplace 1.4.0 --collab 1.4.0)"
 run = "python3 scripts/bump-version.py"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -13,9 +13,11 @@ mise install && lefthook install
 ## Tasks (always via mise — never call the scripts directly)
 
 - `mise run check` — SSOT consistency gate (run before every PR; CI runs the same).
-- `mise run readme-zh` — regenerate each README mirror listed in `scripts/mirrors.py`
-  (currently `README.zh-Hant.md`) from `README.md` (needs `claude` on PATH; auto-fires
-  in pre-commit when `README.md` changes).
+- `mise run readme-zh` — regenerate `README.zh-Hant.md` (Catalog heading `## 目錄`) from
+  `README.md` (needs `claude` on PATH; auto-fires in pre-commit when `README.md` changes).
+- `mise run readme-zh-hans` — same, for `README.zh-Hans.md` (Catalog heading `## 目录`).
+  Every mirror listed in `scripts/mirrors.py` has its own task and its own pre-commit
+  trigger; add both when a mirror is added.
 
 ### README mirrors: hand-mirror by default, regenerate only as fallback
 
@@ -24,13 +26,16 @@ Full regeneration is non-deterministic — even for a 2-line content fix it rewr
 half-width), burying the real change in review. So hand-mirroring is the default:
 
 - **Default — any content change**: hand-mirror the same lines into each mirror in
-  `scripts/mirrors.py`, re-stamp its freshness marker, and commit with the regen
-  hook excluded (it would otherwise clobber the hand-mirror with a full regen):
+  `scripts/mirrors.py` (currently `README.zh-Hant.md`, `## 目錄`; `README.zh-Hans.md`,
+  `## 目录`), re-stamp each one's freshness marker, and commit with the regen hooks
+  excluded (they would otherwise clobber the hand-mirror with a full regen):
 
   ```bash
-  sed -i '' "s/src-sha: [0-9a-f]*/src-sha: $(git hash-object README.md)/" README.zh-Hant.md
-  git add README.md README.zh-Hant.md
-  LEFTHOOK_EXCLUDE=readme-zh git commit -m "..."   # `check` still runs and verifies freshness
+  for f in README.zh-Hant.md README.zh-Hans.md; do
+    sed -i '' "s/src-sha: [0-9a-f]*/src-sha: $(git hash-object README.md)/" "$f"
+  done
+  git add README.md README.zh-Hant.md README.zh-Hans.md
+  LEFTHOOK_EXCLUDE=readme-zh,readme-zh-hans git commit -m "..."   # `check` still runs and verifies freshness
   ```
 - **Fallback — large / structural changes**: run `mise run readme-zh` for a full
   regeneration, then manually re-check punctuation (full-width vs half-width) and

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 > Skills for vibe coding iOS & Apple-ecosystem apps with Claude Code — and for driving
 > the agent that builds them.
 >
-> Languages: [English](README.md) · [繁體中文](README.zh-Hant.md)
+> Languages: [English](README.md) · [繁體中文](README.zh-Hant.md) · [简体中文](README.zh-Hans.md)
 
 apple-dev-skills is one **marketplace** for independent developers and small teams
 taking an idea to a shipped App Store release. Its first-party skills come in two halves:

--- a/README.zh-Hans.md
+++ b/README.zh-Hans.md
@@ -1,0 +1,174 @@
+# apple-dev-skills
+
+> 用 Claude Code vibe coding iOS 与 Apple 生态系统 App 的技能——以及驾驭那个打造它们的 agent 的技能。
+>
+> 语言：[English](README.md) · [繁體中文](README.zh-Hant.md) · [简体中文](README.zh-Hans.md)
+
+apple-dev-skills 是一个 **marketplace**，为独立开发者与小型团队而写，陪你把一个点子带到
+App Store 上架。第一方技能分成两组：**Apple/Swift** 技能管你在做什么，**harness engineering**
+技能管你怎么驾驭那个做事的 agent——调度、审查、交付。每一支技能都是带立场的默认值，背后
+有实际上线的实战故事，并受一道一致性把关；旁边另以引用方式汇总同类最佳的**外部**技能
+plugin，完整标注原作者，绝不复制。
+
+## 快速开始
+
+> 技能会依其 `description:` 自行触发——装好之后，直接描述你的任务即可。
+
+```
+/plugin marketplace add wei18/apple-dev-skills
+/plugin install apple-dev-skills@apple-dev-skills          # 27 Apple/Swift skills
+/plugin install collaboration-skills@apple-dev-skills      # 12 agent-collaboration skills
+```
+
+装一个或两个都可以。外部 plugin 的安装方式相同，例如 `/plugin install swiftui-expert@apple-dev-skills`。
+
+接着直接描述你要做的事：
+
+- *“我要开一个新的 iOS App”* → `apple-platform-targets` 回答最低部署版本，并依次移交给
+  package 结构、语言模式与测试基准。
+- *“App Review 以 guideline 5.1.2 退回”* → `app-store-review-rejections` 把该条款对应到修复方案。
+
+要指定某一个，用它的 slash command：`/apple-dev-skills:swift6-concurrency`。`/skills` 会列出
+已安装的全部技能，以及每一个来自哪个 plugin。
+
+## 目录
+
+- **Spec** 流程 → `spec-phase-orchestration`
+- **Bootstrap** 项目 → `apple-platform-targets`
+- **Build** UI → `swiftui-navigation-architecture`
+- **Test** 测试 → `swift-testing-baseline`
+- **Ship** 上架 → `asc-api-automation`
+- **Operate** 运营 → `apple-three-piece-analytics`
+
+完整索引见下方表格。
+
+### apple-dev-skills（27）—— Apple/Swift
+
+| Skill | 一句话说明 |
+|---|---|
+| `swift6-concurrency` | Swift 6 语言模式 + 完整 concurrency 检查；默认 Sendable |
+| `apple-platform-targets` | 默认 iOS 18 / macOS 15、Xcode 16+；只有为了 latest-OS-only API 才升到 26 |
+| `swiftpm-modularization` | 单一 Package、多 target、薄 App、DI composition root、测试一对一 |
+| `swift-testing-baseline` | swift-testing + pointfreeco snapshot；protocol fake；严格/宽松 snapshot 把关 |
+| `xcode-cloud-single-track-ci` | 单轨 Xcode Cloud；PR / Main / Release / Periodic；merge 前的 PR CI |
+| `local-archive-export-upload` | Xcode Cloud 不可用时的本机 `xcodebuild archive` → export → `altool` 上传 TestFlight |
+| `mise-tool-management` | 以 mise 管理二进制 CLI 工具；开发与 CI 共用 `.mise.toml`；macOS-only `os` guard |
+| `oslog-logger-defaults` | `os.Logger`（不用第三方）；subsystem = bundle ID；默认 `.private` |
+| `apple-three-piece-analytics` | ASC Analytics + MetricKit + Game Center；不用第三方追踪；PrivacyInfo 必备 |
+| `telemetry-facade-pattern` | 单一 `Telemetry` target、fan-out facade；OSLog / NoOp / MetricKit / GameCenter sink |
+| `ai-translated-localization` | 默认 7 个语言；AI 翻译流程；`Localizable.xcstrings`；完整度把关 |
+| `ios-accessibility-engineering` | SwiftUI 与 UIKit 的 VoiceOver / Dynamic Type / 触控目标 / Reduce Motion；WCAG 2.2 |
+| `swift-dependency-injection` | Protocol 注入 + composition root；environment vs constructor；`@TaskLocal`；Sendable |
+| `ios-performance-engineering` | Instruments / xctrace / hang-hitch 预算 / 启动 / 内存 / 二进制大小 / MetricKit |
+| `apple-public-repo-security` | 公开 iOS/macOS repo 的三道防线 + rotate-first 泄漏处理 SOP |
+| `build-time-secret-injection` | xcconfig + Info.plist `$()` + `Bundle.main`，让标识符进得了二进制、出不了 diff |
+| `storekit2-iap-defaults` | StoreKit 2 非消耗型 IAP 默认值：bridge protocol 测试接缝、entitlements、restore |
+| `monetization-sdk-integration` | 新增／升级／审计变现 SDK；把 `import` 隔离在单一 bridge 文件 |
+| `app-store-review-rejections` | 诊断并预先化解 free + 广告 + IAP + CloudKit + GC 的 App Review 退回类型 |
+| `asc-api-automation` | 用 `.p8` 生成 ES256 JWT + curl 打 ASC REST API —— TestFlight、metadata、送审、报表；不用 fastlane |
+| `swiftui-interaction-footguns` | 纯代码审查抓不到的已知 SwiftUI 互动 bug |
+| `swiftui-navigation-architecture` | 类型化 `Route` enum + `@Observable` router；value-based `NavigationStack`；逐转场的呈现语义与 macOS 退路；deep link；每个 tab 各自的 path |
+| `app-icon-rasterize` | 以 `qlmanage` 把 1024 SVG 图标栅格化成 asset catalog PNG —— 免 Homebrew |
+| `ios-design-mockup` | 从 spec 生成单文件 HTML iOS 设计 mockup —— iPhone 外框 + tokens |
+| `interactive-simulator-ux-audit` | 用 `idb`（tap/describe/screenshot）驱动已启动的 Simulator，抓 snapshot 抓不到的导航／modal／safe-area bug |
+| `host-driven-xcuitest-e2e` | 通过 Tuist 启动 App 跑 XCUITest E2E —— 专用 scheme 接线 + macOS 窗口坐标点击驱动 |
+| `cloudkit-schema-source-of-truth` | 纳入版控的 `.ckdb` + `cktool` 导出／验证／部署到 Development；Production 是用户自持、仅限 Console 的关卡 |
+
+### collaboration-skills（12）—— harness engineering：调度、审查、交付
+
+| Skill | 一句话说明 |
+|---|---|
+| `spec-phase-orchestration` | 实现前的文档流水线；逐节核准 |
+| `subagent-review-cycles` | Leader / Developer / Code-Reviewer 三角；第一轮外观问题直接 inline；limit(N) |
+| `leader-developer-handoff-contract` | 调度 sub-agent 时必备的 5 个元素 |
+| `agent-impl-notes-log` | Sub-agent 任务进行中的即时 impl-notes —— 决策、偏离、未决问题 |
+| `subagent-conflict-detection` | 检查新 sub-agent 的目标不与进行中的 worktree 重叠 |
+| `methodology-pattern-extractor` | 从会议记录中提取重复出现 ≥3 次的模式 |
+| `session-to-meeting-log` | 把一场 Claude Code session 整合成会议记录；是摘要，不是逐字稿 |
+| `pr-diff-verification` | Push／开 PR 前，确认 `git show --stat HEAD` 与 commit 宣称的内容相符 |
+| `backlog-routing-by-topic` | 依主题把零散点子路由到对应 spec 文件的 §Backlog |
+| `claude-skill-plugin-packaging` | 发布／安装 Claude Code 技能 —— depth-1 规则、plugin + marketplace、汇总 |
+| `skill-authoring-patterns` | 叠在 `superpowers:writing-skills` 之上的 Apple/Swift 目录层 —— router 描述、bookend 段落、两层式 references、证据导向 CR |
+| `github-contribution-workflow` | gh-CLI 贡献循环 —— PR、issue、GitHub 文件操作、secrets、贡献流程的 repo 设置；惯例 + merge 前 CLEAN |
+
+### 汇总的外部 plugin（7）—— 以引用方式收录，完整标注
+
+此处仅列出、**并非在此撰写** —— 从原作者自己的 repo 安装（你拿到的是最新版），完整标注出处。
+**汇总而非据为己有**：只列出 MIT 兼容、不重复的 plugin，且只为真正的空缺而收 —— 这道检查发生
+在收录当下，不是每次上游 commit 都重审，因此外部 plugin 的范围与授权在收录后仍可能变动
+（`caveman` 就已经变过）。外部 plugin 是广度型的**参考资料**（“这是 API”／“X 要这样做”）；
+第一方技能位于下一层，是**带立场的默认值与实际上线的实战故事**（iOS 18、单一 Package、
+swift-testing + snapshot、OSLog 不用第三方、审查漏掉的运行时 bug）—— 主题重叠处，两者差在
+高度，而非重复。
+
+| Plugin | 作者 | 涵盖范围 |
+|---|---|---|
+| [`apple-skills`](https://github.com/vabole/apple-skills) | vabole (MIT) | 广泛的 Apple 框架 —— SwiftUI、SwiftData、App Intents、WidgetKit、StoreKit、HealthKit… |
+| [`swiftui-expert`](https://github.com/AvdLee/SwiftUI-Agent-Skill) | Antoine van der Lee (MIT) | SwiftUI 模式、Swift Charts、Liquid Glass、Instruments 工具链 |
+| [`swiftui-pro`](https://github.com/twostraws/SwiftUI-Agent-Skill) | Paul Hudson (MIT) | SwiftUI 陷阱、deprecated API 观察清单、iOS 26 / Liquid Glass |
+| [`caveman`](https://github.com/JuliusBrussee/caveman) | JuliusBrussee（技能为 MIT；该 repo 另含 BSL-1.1 授权的 engine） | 极度压缩的沟通模式 —— 省下约 75% token（通用 agent 行为） |
+| [`ponytail`](https://github.com/DietrichGebert/ponytail) | DietrichGebert (MIT) | “懒惰资深工程师”模式 —— 逼出最简单、最短的解法（通用 agent 行为） |
+| [`i-have-adhd`](https://github.com/ayghri/i-have-adhd) | Ayoub G. (MIT) | 常驻的 ADHD 友好输出模式 —— 行动优先、编号步骤、每一轮重述状态；相对于 `caveman`（token 压缩）与 `ponytail`（解法简化），这个塑形的是结构（通用 agent 行为） |
+| [`xcode-build-skill`](https://github.com/pzep1/xcode-build-skill) | pz (MIT) | `xcodebuild`/`xcrun simctl` CLI 参考 —— 找 scheme → 找模拟器 → build → install → launch → 截图；CLI 驱动，与 `interactive-simulator-ux-audit`（idb 驱动的交互式 UX 审计）、`host-driven-xcuitest-e2e`（Tuist scheme 接线的 XCUITest E2E）三者不重叠 |
+
+`caveman` 之后已长成 20 个技能的套件；其中 4 个（`caveman-discover`、`caveman-manage`、
+`caveman-evidence-review`、`caveman-setup`）在讲作者自家托管的 Caveman Cloud 商业服务
+（通用 agent 行为）。
+
+## 其他安装方式
+
+### B —— 团队固定版本
+
+直接在 `.claude/settings.json` 把 marketplace 锁定到一个已发布的 tag —— 不需要 submodule：
+
+```json
+{
+  "extraKnownMarketplaces": {
+    "apple-dev-skills": {
+      "source": { "source": "github", "repo": "wei18/apple-dev-skills", "ref": "v1.6.0" }
+    }
+  },
+  "enabledPlugins": {
+    "apple-dev-skills@apple-dev-skills": true,
+    "collaboration-skills@apple-dev-skills": true
+  }
+}
+```
+
+commit 它 —— 协作者信任该项目文件夹之后就会自动拿到这个 marketplace，不会有额外提示。
+
+### C —— `npx skills`（平铺，不走 plugin）
+
+```bash
+npx skills add wei18/apple-dev-skills --list
+npx skills add wei18/apple-dev-skills --skill swift6-concurrency
+```
+
+> **路径 C 不包含汇总而来的外部 plugin。** `npx skills` 确实会读取本 repo 的
+> `marketplace.json` / `plugin.json`，但只跟随本地声明的技能路径——它不会抓取外部
+> plugin 的远端 `github` / `git-subdir` 来源，因此上述指令只涵盖 39 个第一方技能；
+> 7 个外部 plugin 会被静默跳过。若要平铺安装整份目录（含外部 plugin，从原作者的 repo 拉取）：
+
+```bash
+scripts/install-flat.sh -g          # user-level; drop -g for project-level
+scripts/install-flat.sh --dry-run   # preview the `npx skills add` commands
+```
+
+> 新安装的技能最容易第一个失去描述：Claude Code 的技能清单有 context 预算，
+> 溢出时会从最少被调用的技能开始丢弃描述。执行 `/doctor` 检查清单的成本；
+> 若太吃紧，可在 settings 调整 `skillListingBudgetFraction` / `skillOverrides`。
+
+## 贡献
+
+三种帮忙方式：**汇总**一个外部 plugin、**新增**一个第一方技能、或**反馈**一则现场笔记
+—— 见 [CONTRIBUTING.md](CONTRIBUTING.md)。
+
+## 出处
+
+第一方技能提取并去项目化自 [`wei18/Sudoku`](https://github.com/wei18/Sudoku) 的
+`.claude/skills/` —— 一组 spec-first、由 AI Leader/Developer 打造、已上架的 Apple 平台游戏作品集 ——
+再加上针对公开的 Apple / WCAG / Swift 标准所做的原创整理。汇总的外部 plugin 仍属其作者的作品，
+此处仅以引用方式呈现。催生本 repo 双 plugin 结构的设计 spec 与计划原本放在 `docs/superpowers/`
+—— 已退役、改由 git 历史保存；用 `git log -- docs/` 可以找回。MIT —— 见 [LICENSE](LICENSE)。
+
+<!-- src-sha: da96d1ff6df67b1dd6e5e2a91efd8cfe4eb0f734 -->

--- a/README.zh-Hant.md
+++ b/README.zh-Hant.md
@@ -2,7 +2,7 @@
 
 > 用 Claude Code vibe coding iOS 與 Apple 生態系 App 的技能 —— 以及駕馭那個打造它們的 agent 的技能。
 >
-> 語言：[English](README.md) · [繁體中文](README.zh-Hant.md)
+> 語言：[English](README.md) · [繁體中文](README.zh-Hant.md) · [简体中文](README.zh-Hans.md)
 
 apple-dev-skills 是一個 **marketplace**，為獨立開發者與小型團隊而寫，陪你把一個點子帶到
 App Store 上架。第一方技能分成兩組：**Apple/Swift** 技能管你在做什麼，**harness engineering**
@@ -171,4 +171,4 @@ scripts/install-flat.sh --dry-run   # preview the `npx skills add` commands
 此處僅以引用方式呈現。催生本 repo 雙 plugin 結構的設計 spec 與計畫原本放在 `docs/superpowers/`
 —— 已退役、改由 git 歷史保存；用 `git log -- docs/` 可以找回。MIT —— 見 [LICENSE](LICENSE)。
 
-<!-- src-sha: 8f9e00b3a218facc793b00bded93746ca484cc15 -->
+<!-- src-sha: da96d1ff6df67b1dd6e5e2a91efd8cfe4eb0f734 -->

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -4,5 +4,8 @@ pre-commit:
     readme-zh:
       glob: "README.md"
       run: mise run readme-zh
+    readme-zh-hans:
+      glob: "README.md"
+      run: mise run readme-zh-hans
     check:
       run: mise run check

--- a/scripts/check-consistency.py
+++ b/scripts/check-consistency.py
@@ -9,8 +9,8 @@ Checks
   3. Counts present: the values 25/12/6 each appear among the Catalog's "(N)" group
      headers (set membership, not per-header association); the Install one-liner
      comments and each plugin.json's "N first-party" are checked exactly.
-  4. Each README mirror (scripts/mirrors.py; currently README.zh-Hant.md) exists and its
-     embedded src-sha == git hash-object README.md.
+  4. Each README mirror (scripts/mirrors.py; currently README.zh-Hant.md, README.zh-Hans.md)
+     exists and its embedded src-sha == git hash-object README.md.
   5. All plugin/marketplace JSON parse; the two subdir plugin sources resolve to dirs;
      marketplace.json lists exactly the 9 plugins (2 local + 7 externals).
   6. The `"ref": "v<semver>"` marketplace pin in README.md and every mirror ==
@@ -212,4 +212,5 @@ if errors:
     print(f"FAIL — {len(errors)} error(s):", file=sys.stderr)
     for e in errors: print(f"  - {e}", file=sys.stderr)
     sys.exit(1)
-print(f"OK — 2 plugins ({'/'.join(map(str, PLUGINS.values()))}), catalog + counts + zh-Hant consistent.")
+print(f"OK — 2 plugins ({'/'.join(map(str, PLUGINS.values()))}), catalog + counts + "
+      f"{len(MIRRORS)} README mirror(s) ({'/'.join(MIRRORS)}) consistent.")

--- a/scripts/gen-readme-zh.sh
+++ b/scripts/gen-readme-zh.sh
@@ -7,7 +7,8 @@ cd "$(git rev-parse --show-toplevel)"
 LOCALE="${1:?usage: gen-readme-zh.sh <locale>, e.g. zh-Hant}"
 case "$LOCALE" in
   zh-Hant) LANG_NAME="Traditional Chinese (zh-Hant)" ;;
-  *) echo "unsupported locale: $LOCALE (known: zh-Hant)" >&2; exit 1 ;;
+  zh-Hans) LANG_NAME="Simplified Chinese (zh-Hans), using mainland-China terminology and simplified characters throughout" ;;
+  *) echo "unsupported locale: $LOCALE (known: zh-Hant, zh-Hans)" >&2; exit 1 ;;
 esac
 OUT="README.$LOCALE.md"
 

--- a/scripts/mirrors.py
+++ b/scripts/mirrors.py
@@ -10,4 +10,5 @@ hardcoding a filename.
 """
 MIRRORS = {
     "README.zh-Hant.md": "## 目錄",
+    "README.zh-Hans.md": "## 目录",
 }


### PR DESCRIPTION
## Summary
- Add `README.zh-Hans.md` — a hand-localized Simplified Chinese mirror of `README.md` for mainland iOS developers, using genuine mainland terminology (檔案→文件, 資料→数据, 網路→网络, 介面→界面, 程式碼→代码, etc.), not a script-converted Traditional→Simplified pass.
- Add the zh-Hans link to the Languages row in `README.md` and `README.zh-Hant.md`; re-stamp both mirrors' `src-sha`.
- Wire the new mirror into the existing mechanism: `scripts/mirrors.py` entry (`"## 目录"`), `scripts/gen-readme-zh.sh` accepts `zh-Hans`, `.mise.toml` gets a `readme-zh-hans` task, `lefthook.yml` triggers it on the same `README.md` glob, `CONTRIBUTING.md` documents both mirrors.
- Generalized `check-consistency.py`'s final OK message off a hardcoded "zh-Hant" mention now that there are two mirrors (rules 4/6/9 already looped over `scripts/mirrors.py` generically, no other gate code changes needed).

## Test plan
- [x] `python3 scripts/check-consistency.py` — green, exit 0, message reflects both mirrors.
- [x] 4 negative tests (each restored after): (a) corrupt a zh-Hans skill token → red, message names `README.zh-Hans.md`; (b) `（27）`→`（26）` in zh-Hans → red; (c) pollute `README.md` without re-stamping → both mirrors report stale; (d) zh-Hans path-B `"ref"` → `v1.5.0` → red.
- [x] `bump-version.py --marketplace 1.7.0` trial (protected via `git stash`, reverted via `git checkout -- .`): all three READMEs' pins updated, both mirrors' `src-sha` re-stamped, gate green.
- [x] Traditional-character residual scan on `README.zh-Hans.md` — only hit is the proper-noun link label "繁體中文" (the zh-Hant filename's display name), expected.
- [x] `grep -n '^## '` and punctuation-count parity checks between `README.zh-Hans.md` and `README.zh-Hant.md`.
- [x] All three READMEs carry the 3-link Languages/語言/语言 row.
- [x] `rg -n 'TODO|FIXME|stub|placeholder'` — no hits in the diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)