### PR TITLE
chore(release): 1.7.0 — 39 first-party skills, 7 externals, three READMEs

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -3,14 +3,14 @@
   "owner": { "name": "Wei18" },
   "metadata": {
     "description": "A curated catalog of skills for AI coding agents — first-party Apple/Swift and agent-collaboration skills, plus aggregated best-of-breed external plugins (credited to their authors)",
-    "version": "1.6.0"
+    "version": "1.7.0"
   },
   "plugins": [
     {
       "name": "apple-dev-skills",
       "source": "./apple-dev-skills",
       "description": "27 first-party Apple/Swift skills. Invoke explicitly with /apple-dev-skills:<skill>.",
-      "version": "1.2.0",
+      "version": "1.3.0",
       "author": { "name": "Wei18" },
       "keywords": ["swift", "ios", "macos", "apple-platform", "claude-code", "agent-skills"],
       "category": "workflow"
@@ -19,7 +19,7 @@
       "name": "collaboration-skills",
       "source": "./collaboration-skills",
       "description": "12 first-party AI-agent collaboration & process skills. Invoke explicitly with /collaboration-skills:<skill>.",
-      "version": "1.3.1",
+      "version": "1.4.0",
       "author": { "name": "Wei18" },
       "keywords": ["claude-code", "agent-skills", "ai-agents", "workflow", "collaboration"],
       "category": "workflow"

--- a/README.md
+++ b/README.md
@@ -131,7 +131,7 @@ Pin the marketplace to a released tag directly in `.claude/settings.json` — no
 {
   "extraKnownMarketplaces": {
     "apple-dev-skills": {
-      "source": { "source": "github", "repo": "wei18/apple-dev-skills", "ref": "v1.6.0" }
+      "source": { "source": "github", "repo": "wei18/apple-dev-skills", "ref": "v1.7.0" }
     }
   },
   "enabledPlugins": {

--- a/README.zh-Hans.md
+++ b/README.zh-Hans.md
@@ -125,7 +125,7 @@ swift-testing + snapshot、OSLog 不用第三方、审查漏掉的运行时 bug�
 {
   "extraKnownMarketplaces": {
     "apple-dev-skills": {
-      "source": { "source": "github", "repo": "wei18/apple-dev-skills", "ref": "v1.6.0" }
+      "source": { "source": "github", "repo": "wei18/apple-dev-skills", "ref": "v1.7.0" }
     }
   },
   "enabledPlugins": {
@@ -171,4 +171,4 @@ scripts/install-flat.sh --dry-run   # preview the `npx skills add` commands
 此处仅以引用方式呈现。催生本 repo 双 plugin 结构的设计 spec 与计划原本放在 `docs/superpowers/`
 —— 已退役、改由 git 历史保存；用 `git log -- docs/` 可以找回。MIT —— 见 [LICENSE](LICENSE)。
 
-<!-- src-sha: da96d1ff6df67b1dd6e5e2a91efd8cfe4eb0f734 -->
+<!-- src-sha: fd7cc386adec78f5bf329db7857b0b9855658d43 -->

--- a/README.zh-Hant.md
+++ b/README.zh-Hant.md
@@ -125,7 +125,7 @@ swift-testing + snapshot、OSLog 不用第三方、審查漏掉的執行期 bug�
 {
   "extraKnownMarketplaces": {
     "apple-dev-skills": {
-      "source": { "source": "github", "repo": "wei18/apple-dev-skills", "ref": "v1.6.0" }
+      "source": { "source": "github", "repo": "wei18/apple-dev-skills", "ref": "v1.7.0" }
     }
   },
   "enabledPlugins": {
@@ -171,4 +171,4 @@ scripts/install-flat.sh --dry-run   # preview the `npx skills add` commands
 此處僅以引用方式呈現。催生本 repo 雙 plugin 結構的設計 spec 與計畫原本放在 `docs/superpowers/`
 —— 已退役、改由 git 歷史保存；用 `git log -- docs/` 可以找回。MIT —— 見 [LICENSE](LICENSE)。
 
-<!-- src-sha: da96d1ff6df67b1dd6e5e2a91efd8cfe4eb0f734 -->
+<!-- src-sha: fd7cc386adec78f5bf329db7857b0b9855658d43 -->

--- a/apple-dev-skills/.claude-plugin/plugin.json
+++ b/apple-dev-skills/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "apple-dev-skills",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "description": "27 first-party Apple/Swift skills for AI-agent development — Swift 6 / SwiftPM / testing / CI / L10n / telemetry defaults, security & secrets, monetization, StoreKit 2 IAP, App Review, ASC API automation, local archive/export/upload, SwiftUI footguns & navigation, plus accessibility, dependency injection, performance engineering, interactive simulator UX audits, host-driven XCUITest E2E, and CloudKit schema source of truth. Distilled from a real shipping project and public Apple/standards docs.",
   "author": { "name": "Wei18" },
   "homepage": "https://github.com/wei18/apple-dev-skills",

--- a/collaboration-skills/.claude-plugin/plugin.json
+++ b/collaboration-skills/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "collaboration-skills",
-  "version": "1.3.1",
+  "version": "1.4.0",
   "description": "12 first-party AI-agent collaboration & process skills — spec-phase orchestration, Leader/Developer handoff contract, subagent review cycles & conflict detection, impl-notes & meeting logs, methodology extraction, backlog routing, PR-diff verification, Claude Code skill-plugin packaging, skill-authoring patterns, and GitHub contribution workflow. Harness engineering for AI coding agents — tool-agnostic, not Apple-specific.",
   "author": { "name": "Wei18" },
   "homepage": "https://github.com/wei18/apple-dev-skills",


### PR DESCRIPTION
| Plane | From | To | Why |
|---|---|---|---|
| marketplace | 1.6.0 | 1.7.0 | 7th external, `check-externals` drift detector, README restructure + Quickstart + Simplified Chinese, official pinned-marketplace install path, three new gate rules, docs/ retired |
| apple-dev-skills | 1.2.0 | 1.3.0 | +2 skills (`storekit2-iap-defaults`, `local-archive-export-upload`), factual corrections across 15 skills |
| collaboration-skills | 1.3.1 | 1.4.0 | description routing convergence, listing-budget section, worktree-base rewrite, native-mechanism notes |

Bumped via `mise run bump`; the script replaced the `"ref"` pin in all three READMEs and re-stamped both mirrors' `src-sha`. Gate green.