### PR TITLE
docs(readme): apply four-language review findings; fix apple-skills org move

### DIFF
--- a/.claude-plugin/externals-snapshot.json
+++ b/.claude-plugin/externals-snapshot.json
@@ -4,7 +4,7 @@
     "license": "MIT",
     "manifest_present": true,
     "path": null,
-    "repo": "vabole/apple-skills",
+    "repo": "Prisma-Labs-Dev/apple-skills",
     "skill_count": 33
   },
   "caveman": {

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -26,9 +26,9 @@
     },
     {
       "name": "apple-skills",
-      "source": { "source": "github", "repo": "vabole/apple-skills" },
-      "description": "Aggregated (not authored here). Broad Apple-framework skills — SwiftUI, UIKit, Swift Testing, Concurrency, SwiftData, App Intents, WidgetKit, StoreKit, HealthKit, MapKit, TipKit, and more. By vabole, MIT.",
-      "author": { "name": "vabole" },
+      "source": { "source": "github", "repo": "Prisma-Labs-Dev/apple-skills" },
+      "description": "Aggregated (not authored here). Broad Apple-framework skills — SwiftUI, UIKit, Swift Testing, Concurrency, SwiftData, App Intents, WidgetKit, StoreKit, HealthKit, MapKit, TipKit, and more. By Prisma Labs (vabole), MIT.",
+      "author": { "name": "Prisma Labs (vabole)" },
       "category": "workflow"
     },
     {

--- a/README.ja.md
+++ b/README.ja.md
@@ -5,24 +5,29 @@
 >
 > 言語：[English](README.md) · [繁體中文](README.zh-Hant.md) · [简体中文](README.zh-Hans.md) · [日本語](README.ja.md)
 
-apple-dev-skillsは、個人開発者や小規模チームがアイデアをApp Storeへのリリースまで導くための
+apple-dev-skillsは、アイデアをApp Storeへのリリースまで導く個人開発者や小規模チームのための
 **マーケットプレイス**です。ファーストパーティのスキルは大きく二つに分かれています。作って
-いるものそのものを担う**Apple/Swift**スキルと、それを作り上げるagentの操り方——ディスパッチ、
-レビュー、リリース——を担う**harness engineering**スキルです。どのスキルも実際にリリースまで
-漕ぎ着けた実戦のエピソードに裏打ちされた、立場のある既定値であり、一貫性ゲートによって
-守られています。あわせて、他に類を見ない**外部**スキルプラグインを参照という形で集約し、
-著者を明記した上で——決してコピーはせずに——並べています。
+いるものそのものを担う**Apple/Swift**スキルと、Claude Code自体の操り方——計画、レビュー、
+リリース——を担う**harness engineering**スキルです。どのスキルも実際にリリースまで漕ぎ着けた
+実戦のエピソードに裏打ちされた、立場のある既定値であり、一貫性ゲートによって守られています。
+あわせて、他に類を見ない**外部**スキルプラグインを**参照という形で集約**し——ここでは書かず、
+リンクと著者クレジットのみで——決してコピーせずに並べています。
 
 ## クイックスタート
 
-> スキルは`description:`から自動的にトリガーされます——インストールしたら、あとはタスクを
+> スキルは頼んだ内容から自動的にトリガーされます——インストールしたら、あとはタスクを
 > 説明するだけです。
+
+Claude Codeのsession内で実行します。
 
 ```
 /plugin marketplace add wei18/apple-dev-skills
 /plugin install apple-dev-skills@apple-dev-skills          # 27 Apple/Swift skills
 /plugin install collaboration-skills@apple-dev-skills      # 12 agent-collaboration skills
 ```
+
+インストール結果に`Run /reload-plugins to activate.`と表示されたら実行してください——古い
+クライアントでは常に必要な手順です。
 
 どちらか一方でも両方でもインストール可能です。外部プラグインも同じ方法でインストールできます。
 例：`/plugin install swiftui-expert@apple-dev-skills`。
@@ -37,6 +42,10 @@ apple-dev-skillsは、個人開発者や小規模チームがアイデアをApp 
 特定のスキルを強制的に呼び出すにはスラッシュコマンドを使います：
 `/apple-dev-skills:swift6-concurrency`。`/skills`でインストール済みのスキル一覧と、それぞれが
 どのプラグイン由来かを確認できます。
+
+> 新しくインストールされたスキルは、Claude Codeのスキル一覧のcontext予算が溢れたときに
+> 最初に説明文を失います。`/doctor`で一覧のコストを確認してください。厳しい場合はsettingsで
+> `skillListingBudgetFraction` / `skillOverrides`を調整してください。
 
 ## カタログ
 
@@ -59,22 +68,22 @@ apple-dev-skillsは、個人開発者や小規模チームがアイデアをApp 
 | `swift-testing-baseline` | swift-testing + pointfreeco snapshot；protocol fake；厳格/寛容なsnapshotゲート |
 | `xcode-cloud-single-track-ci` | シングルトラックのXcode Cloud；PR / Main / Release / Periodic；merge前のPR CI |
 | `local-archive-export-upload` | Xcode Cloudが使えない場合のローカル`xcodebuild archive` → export → `altool`によるTestFlightアップロード |
-| `mise-tool-management` | miseでバイナリCLIツールを管理；開発とCIで`.mise.toml`を共有；macOS専用の`os`ガード |
-| `oslog-logger-defaults` | `os.Logger`（サードパーティ不使用）；subsystem = bundle ID；デフォルトは`.private` |
-| `apple-three-piece-analytics` | ASC Analytics + MetricKit + Game Center；サードパーティトラッキング不使用；PrivacyInfoは必須 |
-| `telemetry-facade-pattern` | 単一の`Telemetry`target、fan-out facade；OSLog / NoOp / MetricKit / GameCenterのsink |
+| `mise-tool-management` | miseでCLIツールのバージョンを固定（swiftlint、xcbeautify…）——ローカル開発とCIで同じバージョンを使う |
+| `oslog-logger-defaults` | デフォルトのlogging設定：Apple純正の`os.Logger`、サードパーティ不使用、opt-inしない限りログ値はprivate |
+| `apple-three-piece-analytics` | App Store Connect (ASC) Analytics + MetricKit + Game Center；サードパーティトラッキング不使用；PrivacyInfoは必須 |
+| `telemetry-facade-pattern` | logging呼び出しは1つ、OSLog / MetricKit / Game Centerへルーティング——呼び出し側を変えずに送り先を差し替えられる |
 | `ai-translated-localization` | デフォルトで7言語；AI翻訳フロー；`Localizable.xcstrings`；網羅性ゲート |
 | `ios-accessibility-engineering` | SwiftUIとUIKitにおけるVoiceOver / Dynamic Type / タップ領域 / Reduce Motion；WCAG 2.2 |
-| `swift-dependency-injection` | Protocol注入 + composition root；environment vs constructor；`@TaskLocal`；Sendable |
+| `swift-dependency-injection` | テストのためにサービスを差し替え可能にする——protocol注入 + composition root（environment vs constructor、`@TaskLocal`、Sendable） |
 | `ios-performance-engineering` | Instruments / xctrace / hang-hitch予算 / 起動 / メモリ / バイナリサイズ / MetricKit |
 | `apple-public-repo-security` | 公開iOS/macOS repoのための三重防御 + rotate-firstな漏洩対応SOP |
 | `build-time-secret-injection` | xcconfig + Info.plist `$()` + `Bundle.main`——バイナリには含めつつdiffには出さないID管理 |
 | `storekit2-iap-defaults` | StoreKit 2の非消耗型IAPデフォルト；bridge protocolのテストシーム、entitlements、restore |
 | `monetization-sdk-integration` | マネタイズSDKの追加／アップグレード／監査；`import`を単一のbridgeファイルに隔離 |
-| `app-store-review-rejections` | 無料 + 広告 + IAP + CloudKit + GCにおけるApp Review却下パターンの診断と事前対策 |
+| `app-store-review-rejections` | 無料 + 広告 + IAP + CloudKit + Game Center (GC)におけるApp Review却下パターンの診断と事前対策 |
 | `asc-api-automation` | `.p8`からES256 JWTを生成 + curlでASC REST APIを叩く——TestFlight、metadata、審査提出、レポート；fastlane不使用 |
 | `swiftui-interaction-footguns` | 純粋なコードレビューでは見逃されがちな既知のSwiftUIインタラクションバグ |
-| `swiftui-navigation-architecture` | 型付き`Route`enum + `@Observable`router；value-basedな`NavigationStack`；遷移ごとの表示セマンティクスとmacOSフォールバック；ディープリンク；tabごとのpath |
+| `swiftui-navigation-architecture` | SwiftUI向けの型付きルートナビゲーション——`@Observable`router一つ、`NavigationStack`、ディープリンク、macOSフォールバックも対応済み |
 | `app-icon-rasterize` | `qlmanage`で1024のSVGアイコンをasset catalog用PNGにラスタライズ——Homebrew不要 |
 | `ios-design-mockup` | specから単一HTMLファイルのiOSデザインモックアップを生成——iPhoneフレーム + トークン |
 | `interactive-simulator-ux-audit` | `idb`（tap/describe/screenshot）で起動中のSimulatorを操作し、スナップショットでは見つからないナビゲーション／モーダル／safe-areaのバグを検出 |
@@ -105,25 +114,36 @@ apple-dev-skillsは、個人開発者や小規模チームがアイデアをApp 
 我が物にすることではありません**：MIT互換で重複のないプラグインのみを、本当にギャップがある
 場合に限って掲載します——このチェックは掲載する時点で一度だけ行われ、上流のcommitのたびに
 再審査するわけではないため、外部プラグインの範囲やライセンスは掲載後に変わることがあります
-（`caveman`はすでに変わっています）。外部プラグインは幅広い**リファレンス**（「これがAPIです」
-「Xはこう作ります」）であり、ファーストパーティのスキルはその一段下のレイヤーに位置する、
-**立場のあるデフォルト値と実際にリリースした実戦のエピソード**（iOS 18、単一Package、
-swift-testing + snapshot、サードパーティなしのOSLog、レビューをすり抜けた実行時バグ）です
-——トピックが重なる箇所では、両者の違いは高度であって重複ではありません。
+（`caveman`はすでに変わっています）。外部プラグインは幅広い**リファレンス**です——「これが
+APIです、Xはこう作ります」。ファーストパーティのスキルはより狭く、トピックごとに立場のある
+デフォルト値が一つだけあります（iOS 18を下限に、単一Package、swift-testing + snapshot、
+OSLogのみ、避けるべき既知の実行時バグ）。トピックが重なる箇所でも、両者は重複ではなく、
+答える詳細度のレベルが違うだけです。
 
 | Plugin | Author | Covers |
 |---|---|---|
-| [`apple-skills`](https://github.com/vabole/apple-skills) | vabole (MIT) | 幅広いAppleフレームワーク——SwiftUI、SwiftData、App Intents、WidgetKit、StoreKit、HealthKit… |
+| [`apple-skills`](https://github.com/Prisma-Labs-Dev/apple-skills) | Prisma Labs (vabole), MIT | 幅広いAppleフレームワーク——SwiftUI、SwiftData、App Intents、WidgetKit、StoreKit、HealthKit… |
 | [`swiftui-expert`](https://github.com/AvdLee/SwiftUI-Agent-Skill) | Antoine van der Lee (MIT) | SwiftUIパターン、Swift Charts、Liquid Glass、Instrumentsツールチェーン |
 | [`swiftui-pro`](https://github.com/twostraws/SwiftUI-Agent-Skill) | Paul Hudson (MIT) | SwiftUIの落とし穴、非推奨APIのウォッチリスト、iOS 26 / Liquid Glass |
-| [`caveman`](https://github.com/JuliusBrussee/caveman) | JuliusBrussee（skillsはMIT；repoにはBSL-1.1ライセンスのengineも含まれる） | 超圧縮されたコミュニケーションモード——トークンを約75%削減（汎用的なagentの振る舞い） |
+| [`caveman`](https://github.com/JuliusBrussee/caveman) | JuliusBrussee (MIT) | 超圧縮されたコミュニケーションモード——トークンを約75%削減（汎用的なagentの振る舞い） |
 | [`ponytail`](https://github.com/DietrichGebert/ponytail) | DietrichGebert (MIT) | 「怠け者のシニア開発者」モード——最もシンプルで最短の解法を強制する（汎用的なagentの振る舞い） |
-| [`i-have-adhd`](https://github.com/ayghri/i-have-adhd) | Ayoub G. (MIT) | 常時ONのADHDフレンドリーな出力モード——行動優先、番号付きステップ、毎ターン状態を再掲示；`caveman`（トークン圧縮）や`ponytail`（解法の単純化）とは異なり、こちらは構造を形作る（汎用的なagentの振る舞い） |
-| [`xcode-build-skill`](https://github.com/pzep1/xcode-build-skill) | pz (MIT) | `xcodebuild`/`xcrun simctl` CLIリファレンス——scheme探索 → simulator検索 → build → install → launch → screenshot；CLI駆動で、`interactive-simulator-ux-audit`（idb駆動のインタラクティブUX監査）や`host-driven-xcuitest-e2e`（Tuist scheme配線のXCUITest E2E）とは重複しない |
+| [`i-have-adhd`](https://github.com/ayghri/i-have-adhd) | Ayoub G. (MIT) | 常時ONのADHDフレンドリーな出力モード——番号付きステップ、毎ターン状態を再掲示（汎用的なagentの振る舞い） |
+| [`xcode-build-skill`](https://github.com/pzep1/xcode-build-skill) | pz (MIT) | `xcodebuild`/`xcrun simctl` CLIチートシート——scheme → simulator → build → install → launch → screenshot |
 
+`caveman`のライセンス：skills自体はMIT、repoにはBSL-1.1ライセンスのengineも含まれています。
 `caveman`はその後20スキルからなるスイートへと成長しました。そのうち4つ（`caveman-discover`、
 `caveman-manage`、`caveman-evidence-review`、`caveman-setup`）は、著者自身がホストする商用
 サービスCaveman Cloudについて説明したものです（汎用的なagentの振る舞い）。
+
+`i-have-adhd`は`caveman`（トークン圧縮）や`ponytail`（解法の単純化）とは異なり、構造を
+形作ります。
+
+`xcode-build-skill`はCLI駆動で、`interactive-simulator-ux-audit`（idb駆動のインタラクティブ
+UX監査）や`host-driven-xcuitest-e2e`（Tuist scheme配線のXCUITest E2E）とは別物です——三者は
+重複しません。
+
+`apple-skills`は`vabole`の個人アカウントから`Prisma-Labs-Dev`organizationへ移管されました。
+この表には移管後のrepoを掲載しています。
 
 ## 他のインストール方法
 
@@ -147,7 +167,8 @@ swift-testing + snapshot、サードパーティなしのOSLog、レビューを
 ```
 
 これをcommitしておけば、コラボレーターがそのプロジェクトフォルダを信頼した時点で、追加の
-確認なしに自動的にこのmarketplaceが使えるようになります。
+確認なしに自動的にこのmarketplaceが使えるようになります。それでもClaude Codeがあるプラグイン
+を未インストールと報告する場合は、表示された`/plugin install`コマンドを一度実行してください。
 
 ### C —— `npx skills`（フラット、プラグイン不使用）
 
@@ -157,9 +178,9 @@ npx skills add wei18/apple-dev-skills --skill swift6-concurrency
 ```
 
 > **経路Cには集約された外部プラグインは含まれません。** `npx skills`はこのrepoの
-> `marketplace.json` / `plugin.json`を読み込みはしますが、ローカルで宣言されたスキルの
-> パスしか辿りません——外部プラグインのリモートの`github` / `git-subdir`ソースは取得
-> しないため、上記のコマンドは39のファーストパーティスキルにしか届かず、7つの外部
+> `marketplace.json` / `plugin.json`を読み込みますが、ローカルで宣言されたスキルのパスしか
+> 辿りません。外部プラグインのリモートの`github` / `git-subdir`ソースは取得しません。その
+> ため上記のコマンドは39のファーストパーティスキルしかインストールしません——7つの外部
 > プラグインは黙って読み飛ばされます。カタログ全体（外部プラグインを含め、著者のrepoから
 > 取得）をフラットにインストールするには：
 
@@ -167,11 +188,6 @@ npx skills add wei18/apple-dev-skills --skill swift6-concurrency
 scripts/install-flat.sh -g          # user-level; drop -g for project-level
 scripts/install-flat.sh --dry-run   # preview the `npx skills add` commands
 ```
-
-> 新しくインストールされたスキルは、説明文を最初に失いやすい存在です。Claude Codeのスキル
-> 一覧にはcontext予算があり、溢れると呼び出し頻度の低いスキルから順に説明文が削られます。
-> `/doctor`を実行して一覧のコストを確認してください。厳しい場合はsettingsで
-> `skillListingBudgetFraction` / `skillOverrides`を調整してください。
 
 ## コントリビューション
 
@@ -190,4 +206,4 @@ scripts/install-flat.sh --dry-run   # preview the `npx skills add` commands
 `docs/superpowers/`にありました——現在は廃止され、git履歴として保存されています。
 `git log -- docs/`で見つけることができます。MIT——[LICENSE](LICENSE)を参照してください。
 
-<!-- src-sha: c65fc1aab4f4d04aefe8d22f290fc6dae4c7f1d2 -->
+<!-- src-sha: 8fc1a7010cd5feed7c9962639693a63a1ff0aa55 -->

--- a/README.md
+++ b/README.md
@@ -8,20 +8,24 @@
 apple-dev-skills is one **marketplace** for independent developers and small teams
 taking an idea to a shipped App Store release. Its first-party skills come in two halves:
 **Apple/Swift** skills for what you are building, and **harness engineering** skills for
-how you drive the agent that builds it — dispatch, review, ship. Every skill is an
-opinionated default backed by a shipped-it war story and held to a consistency gate;
-alongside them sit best-of-breed **external** skill plugins, aggregated by reference and
-credited to their authors, never copied.
+how you direct Claude Code itself — planning, reviewing, and shipping the work. Every
+skill is an opinionated default backed by a shipped-it war story and held to a consistency
+gate. Alongside them sit best-of-breed **external** skill plugins, **aggregated by
+reference** — not written here, linked and credited to their authors, never copied.
 
 ## Quickstart
 
-> Skills self-trigger from their `description:` — install, then just describe the task.
+> Skills trigger automatically from what you ask for — install, then just describe the task.
+
+Inside a Claude Code session, run:
 
 ```
 /plugin marketplace add wei18/apple-dev-skills
 /plugin install apple-dev-skills@apple-dev-skills          # 27 Apple/Swift skills
 /plugin install collaboration-skills@apple-dev-skills      # 12 agent-collaboration skills
 ```
+
+If the install summary says `Run /reload-plugins to activate.`, run it — older clients always need it.
 
 Install either or both. Externals install the same way, e.g. `/plugin install swiftui-expert@apple-dev-skills`.
 
@@ -34,6 +38,10 @@ Then just describe the task:
 
 To force one, use its slash command: `/apple-dev-skills:swift6-concurrency`. `/skills` lists
 what is installed and which plugin each skill came from.
+
+> Newly installed skills are first to lose their descriptions if Claude Code's skill-listing
+> context budget overflows. Run `/doctor` to check the listing's cost; tune
+> `skillListingBudgetFraction` / `skillOverrides` in settings if it's too tight.
 
 ## Catalog
 
@@ -56,22 +64,22 @@ Full index in the tables below.
 | `swift-testing-baseline` | swift-testing + pointfreeco snapshot; protocol fakes; strict/tolerant snapshot gate |
 | `xcode-cloud-single-track-ci` | Single-track Xcode Cloud; PR / Main / Release / Periodic; pre-merge PR CI |
 | `local-archive-export-upload` | Local `xcodebuild archive` → export → `altool` upload to TestFlight when Xcode Cloud can't run |
-| `mise-tool-management` | mise manages binary CLI tools; dev + CI share `.mise.toml`; macOS-only `os` guard |
-| `oslog-logger-defaults` | `os.Logger` (no third-party); subsystem = bundle ID; `.private` default |
-| `apple-three-piece-analytics` | ASC Analytics + MetricKit + Game Center; no third-party tracking; PrivacyInfo mandatory |
-| `telemetry-facade-pattern` | One `Telemetry` target, fan-out facade; OSLog / NoOp / MetricKit / GameCenter sinks |
+| `mise-tool-management` | Pin CLI tool versions (swiftlint, xcbeautify…) with mise, so local dev and CI use the exact same ones |
+| `oslog-logger-defaults` | Default logging setup: Apple's own `os.Logger`, no third-party library, log values private unless you opt in |
+| `apple-three-piece-analytics` | App Store Connect (ASC) Analytics + MetricKit + Game Center; no third-party tracking; PrivacyInfo mandatory |
+| `telemetry-facade-pattern` | One logging call, routed to OSLog / MetricKit / Game Center — swap where events go without touching call sites |
 | `ai-translated-localization` | Default 7 locales; AI translation flow; `Localizable.xcstrings`; completeness gates |
 | `ios-accessibility-engineering` | VoiceOver / Dynamic Type / touch-target / Reduce Motion for SwiftUI & UIKit; WCAG 2.2 |
-| `swift-dependency-injection` | Protocol injection + composition root; environment vs constructor; `@TaskLocal`; Sendable |
+| `swift-dependency-injection` | Make services swappable for tests — protocol injection + a composition root (environment vs constructor, `@TaskLocal`, Sendable) |
 | `ios-performance-engineering` | Instruments / xctrace / hang-hitch budgets / launch / memory / binary size / MetricKit |
 | `apple-public-repo-security` | Three lines of defence for public iOS/macOS repos + rotate-first leak SOP |
 | `build-time-secret-injection` | xcconfig + Info.plist `$()` + `Bundle.main` for ship-in-binary-but-out-of-diff IDs |
 | `storekit2-iap-defaults` | StoreKit 2 non-consumable IAP defaults; bridge-protocol test seam, entitlements, restore |
 | `monetization-sdk-integration` | Add/upgrade/audit a monetization SDK; isolate `import` to one bridge file |
-| `app-store-review-rejections` | Diagnose & pre-empt App Review rejection classes for free + ads + IAP + CloudKit + GC |
+| `app-store-review-rejections` | Diagnose & pre-empt App Review rejection classes for free + ads + IAP + CloudKit + Game Center (GC) |
 | `asc-api-automation` | ES256 JWT from the `.p8` + curl against the ASC REST API — TestFlight, metadata, submission, reports; no fastlane |
 | `swiftui-interaction-footguns` | Known SwiftUI interaction bugs that slip past pure-code review |
-| `swiftui-navigation-architecture` | Typed `Route` enum + `@Observable` router; value-based `NavigationStack`; per-transition presentation semantics with macOS fallbacks; deep links; per-tab paths |
+| `swiftui-navigation-architecture` | Typed-route navigation for SwiftUI — one `@Observable` router, `NavigationStack`, deep links, macOS fallbacks handled |
 | `app-icon-rasterize` | Rasterize a 1024 SVG icon to asset-catalog PNG via `qlmanage` — no Homebrew |
 | `ios-design-mockup` | Single-file HTML iOS design mockup from a spec — iPhone frames + tokens |
 | `interactive-simulator-ux-audit` | Drive a booted Simulator with `idb` (tap/describe/screenshot) to catch nav/modal/safe-area bugs snapshots can't |
@@ -101,25 +109,36 @@ Listed here but **not authored here**: each installs from its author's own repo 
 their latest) and is credited in full. **Aggregate, don't appropriate** — only MIT-compatible,
 non-duplicate plugins are listed, and only for genuine gaps. That check happens once, at
 listing time, not on every upstream commit, so an external's scope and licence can drift
-afterwards (`caveman` already has). Externals are broad **reference** ("here's the API, here's
-how to build X"); first-party skills sit a layer below as **opinionated defaults and shipped-it
-war stories** (iOS 18, one Package, swift-testing + snapshot, OSLog with no third party, runtime
-bugs that slipped past review). Where a topic overlaps, the two differ by altitude, not by
-duplication.
+afterwards (`caveman` already has). Externals are broad **reference** — "here's the API,
+here's how to build X." First-party skills are narrower: one opinionated default per topic
+(iOS 18 as the floor, one Package, swift-testing + snapshot, OSLog only, known runtime bugs
+to avoid). Where a topic overlaps, the two aren't duplicates — they answer at a different
+level of detail.
 
 | Plugin | Author | Covers |
 |---|---|---|
-| [`apple-skills`](https://github.com/vabole/apple-skills) | vabole (MIT) | Broad Apple frameworks — SwiftUI, SwiftData, App Intents, WidgetKit, StoreKit, HealthKit … |
+| [`apple-skills`](https://github.com/Prisma-Labs-Dev/apple-skills) | Prisma Labs (vabole), MIT | Broad Apple frameworks — SwiftUI, SwiftData, App Intents, WidgetKit, StoreKit, HealthKit … |
 | [`swiftui-expert`](https://github.com/AvdLee/SwiftUI-Agent-Skill) | Antoine van der Lee (MIT) | SwiftUI patterns, Swift Charts, Liquid Glass, Instruments toolchain |
 | [`swiftui-pro`](https://github.com/twostraws/SwiftUI-Agent-Skill) | Paul Hudson (MIT) | SwiftUI pitfalls, deprecated-API watchlist, iOS 26 / Liquid Glass |
-| [`caveman`](https://github.com/JuliusBrussee/caveman) | JuliusBrussee (skills MIT; repo also ships a BSL-1.1 engine) | Ultra-compressed communication mode — cuts ~75% of tokens (general agent behavior) |
+| [`caveman`](https://github.com/JuliusBrussee/caveman) | JuliusBrussee (MIT) | Ultra-compressed communication mode — cuts ~75% of tokens (general agent behavior) |
 | [`ponytail`](https://github.com/DietrichGebert/ponytail) | DietrichGebert (MIT) | "Lazy senior dev" mode — forces the simplest, shortest solution (general agent behavior) |
-| [`i-have-adhd`](https://github.com/ayghri/i-have-adhd) | Ayoub G. (MIT) | Always-on ADHD-friendly output mode — action-first, numbered steps, state restated each turn; vs `caveman` (token compression) and `ponytail` (solution simplicity), this shapes structure (general agent behavior) |
-| [`xcode-build-skill`](https://github.com/pzep1/xcode-build-skill) | pz (MIT) | `xcodebuild`/`xcrun simctl` CLI reference — discover schemes → find simulators → build → install → launch → screenshot; CLI-driven, distinct from `interactive-simulator-ux-audit` (idb-driven interactive UX audit) and `host-driven-xcuitest-e2e` (Tuist-scheme XCUITest E2E) — the three don't overlap |
+| [`i-have-adhd`](https://github.com/ayghri/i-have-adhd) | Ayoub G. (MIT) | Always-on ADHD-friendly output mode — numbered steps, state restated each turn (general agent behavior) |
+| [`xcode-build-skill`](https://github.com/pzep1/xcode-build-skill) | pz (MIT) | `xcodebuild`/`xcrun simctl` CLI cheatsheet — schemes → simulators → build → install → launch → screenshot |
 
-`caveman` has since grown into a 20-skill suite; 4 of them (`caveman-discover`, `caveman-manage`,
+`caveman`'s license: skills MIT; repo also ships a BSL-1.1 engine. `caveman` has since grown
+into a 20-skill suite; 4 of them (`caveman-discover`, `caveman-manage`,
 `caveman-evidence-review`, `caveman-setup`) document the author's hosted Caveman Cloud commercial
 service (general agent behavior).
+
+`i-have-adhd` vs `caveman` (token compression) and `ponytail` (solution simplicity), this shapes
+structure.
+
+`xcode-build-skill` is CLI-driven, distinct from `interactive-simulator-ux-audit` (idb-driven
+interactive UX audit) and `host-driven-xcuitest-e2e` (Tuist-scheme XCUITest E2E) — the three
+don't overlap.
+
+`apple-skills` moved from the `vabole` personal account to the `Prisma-Labs-Dev` organization;
+this table lists the org's repo.
 
 ## Other ways to install
 
@@ -142,7 +161,8 @@ Pin the marketplace to a released tag directly in `.claude/settings.json` — no
 ```
 
 Commit it — collaborators get the marketplace automatically once they trust the project
-folder, no separate prompt.
+folder, no separate prompt. If Claude Code still reports a plugin as not installed, run the
+`/plugin install` command it shows once.
 
 ### C — `npx skills` (flat, no plugin)
 
@@ -151,20 +171,16 @@ npx skills add wei18/apple-dev-skills --list
 npx skills add wei18/apple-dev-skills --skill swift6-concurrency
 ```
 
-> **Path C does not include the aggregated externals.** `npx skills` does read this repo's
-> `marketplace.json` / `plugin.json`, but only follows locally-declared skill paths — it
-> doesn't fetch the externals' remote `github` / `git-subdir` sources, so the commands above
-> reach only the 39 first-party skills; the 7 externals are silently skipped. To flat-install
-> the whole catalog (externals included, pulled from their authors' repos):
+> **Path C does not include the aggregated externals.** `npx skills` reads this repo's
+> `marketplace.json` / `plugin.json`, but it only follows locally-declared skill paths. It
+> does not fetch the externals' remote `github` / `git-subdir` sources. So the commands above
+> install only the 39 first-party skills — the 7 externals are silently skipped. To
+> flat-install the whole catalog (externals included, pulled from their authors' repos):
 
 ```bash
 scripts/install-flat.sh -g          # user-level; drop -g for project-level
 scripts/install-flat.sh --dry-run   # preview the `npx skills add` commands
 ```
-
-> Newly installed skills are first in line to lose their descriptions: Claude Code's skill
-> listing has a context budget, and on overflow it drops descriptions starting with the
-> least-invoked skills. Run `/doctor` to check the listing's cost; tune `skillListingBudgetFraction` / `skillOverrides` in settings if it's too tight.
 
 ## Contributing
 

--- a/README.zh-Hans.md
+++ b/README.zh-Hans.md
@@ -1,18 +1,20 @@
 # apple-dev-skills
 
-> 用 Claude Code vibe coding iOS 与 Apple 生态系统 App 的技能——以及驾驭那个打造它们的 agent 的技能。
+> 用 Claude Code vibe coding iOS 与 Apple 生态系统 App 的技能 —— 以及驾驭那个打造它们的 agent 的技能。
 >
 > 语言：[English](README.md) · [繁體中文](README.zh-Hant.md) · [简体中文](README.zh-Hans.md) · [日本語](README.ja.md)
 
-apple-dev-skills 是一个 **marketplace**，为独立开发者与小型团队而写，陪你把一个点子带到
-App Store 上架。第一方技能分成两组：**Apple/Swift** 技能管你在做什么，**harness engineering**
-技能管你怎么驾驭那个做事的 agent——调度、审查、交付。每一支技能都是带立场的默认值，背后
-有实际上线的实战故事，并受一道一致性把关；旁边另以引用方式汇总同类最佳的**外部**技能
-plugin，完整标注原作者，绝不复制。
+apple-dev-skills 是一个 **marketplace**，服务对象是正在把一个点子做到 App Store 上架的
+独立开发者与小型团队。第一方技能分成两组：**Apple/Swift** 技能对应你正在打造的东西，
+**harness engineering** 技能对应你怎么驾驭 Claude Code 本身 —— 规划、审查、交付。每一支
+技能都是带立场的默认值，背后有实际上架的实战故事，并受一道一致性把关。旁边另以引用方式
+汇总同类最佳的**外部**技能 plugin —— 并非在此撰写，仅链接并标注原作者，绝不复制。
 
 ## 快速开始
 
-> 技能会依其 `description:` 自行触发——装好之后，直接描述你的任务即可。
+> 技能会依你描述的任务自动触发 —— 装好之后，直接描述你的任务即可。
+
+在 Claude Code session 里执行：
 
 ```
 /plugin marketplace add wei18/apple-dev-skills
@@ -20,16 +22,23 @@ plugin，完整标注原作者，绝不复制。
 /plugin install collaboration-skills@apple-dev-skills      # 12 agent-collaboration skills
 ```
 
+若安装摘要显示 `Run /reload-plugins to activate.`，就执行它 —— 较旧版的 client 一定需要这步。
+
 装一个或两个都可以。外部 plugin 的安装方式相同，例如 `/plugin install swiftui-expert@apple-dev-skills`。
 
 接着直接描述你要做的事：
 
 - *“我要开一个新的 iOS App”* → `apple-platform-targets` 回答最低部署版本，并依次移交给
   package 结构、语言模式与测试基准。
-- *“App Review 以 guideline 5.1.2 退回”* → `app-store-review-rejections` 把该条款对应到修复方案。
+- *“App Review 以 guideline 5.1.2 退回”* → `app-store-review-rejections` 把该条款对应到
+  修复方案。
 
 要指定某一个，用它的 slash command：`/apple-dev-skills:swift6-concurrency`。`/skills` 会列出
 已安装的全部技能，以及每一个来自哪个 plugin。
+
+> 新安装的技能最容易在 Claude Code 的技能清单 context 预算超支时第一个失去描述。执行
+> `/doctor` 检查清单的成本；若太吃紧，可在 settings 调整 `skillListingBudgetFraction` /
+> `skillOverrides`。
 
 ## 目录
 
@@ -52,22 +61,22 @@ plugin，完整标注原作者，绝不复制。
 | `swift-testing-baseline` | swift-testing + pointfreeco snapshot；protocol fake；严格/宽松 snapshot 把关 |
 | `xcode-cloud-single-track-ci` | 单轨 Xcode Cloud；PR / Main / Release / Periodic；merge 前的 PR CI |
 | `local-archive-export-upload` | Xcode Cloud 不可用时的本机 `xcodebuild archive` → export → `altool` 上传 TestFlight |
-| `mise-tool-management` | 以 mise 管理二进制 CLI 工具；开发与 CI 共用 `.mise.toml`；macOS-only `os` guard |
-| `oslog-logger-defaults` | `os.Logger`（不用第三方）；subsystem = bundle ID；默认 `.private` |
-| `apple-three-piece-analytics` | ASC Analytics + MetricKit + Game Center；不用第三方追踪；PrivacyInfo 必备 |
-| `telemetry-facade-pattern` | 单一 `Telemetry` target、fan-out facade；OSLog / NoOp / MetricKit / GameCenter sink |
+| `mise-tool-management` | 用 mise 钉住 CLI 工具版本（swiftlint、xcbeautify…），让本机开发与 CI 用同一个版本 |
+| `oslog-logger-defaults` | 默认的 logging 设置：Apple 自家 `os.Logger`，不用第三方库，log 值默认 private，除非你自己 opt-in |
+| `apple-three-piece-analytics` | App Store Connect (ASC) Analytics + MetricKit + Game Center；不用第三方追踪；PrivacyInfo 必备 |
+| `telemetry-facade-pattern` | 一次 logging 调用，路由到 OSLog / MetricKit / Game Center —— 换目的地不用动调用点 |
 | `ai-translated-localization` | 默认 7 个语言；AI 翻译流程；`Localizable.xcstrings`；完整度把关 |
 | `ios-accessibility-engineering` | SwiftUI 与 UIKit 的 VoiceOver / Dynamic Type / 触控目标 / Reduce Motion；WCAG 2.2 |
-| `swift-dependency-injection` | Protocol 注入 + composition root；environment vs constructor；`@TaskLocal`；Sendable |
+| `swift-dependency-injection` | 让服务可以为了测试替换 —— protocol 注入 + composition root（environment vs constructor、`@TaskLocal`、Sendable） |
 | `ios-performance-engineering` | Instruments / xctrace / hang-hitch 预算 / 启动 / 内存 / 二进制大小 / MetricKit |
 | `apple-public-repo-security` | 公开 iOS/macOS repo 的三道防线 + rotate-first 泄漏处理 SOP |
 | `build-time-secret-injection` | xcconfig + Info.plist `$()` + `Bundle.main`，让标识符进得了二进制、出不了 diff |
 | `storekit2-iap-defaults` | StoreKit 2 非消耗型 IAP 默认值：bridge protocol 测试接缝、entitlements、restore |
 | `monetization-sdk-integration` | 新增／升级／审计变现 SDK；把 `import` 隔离在单一 bridge 文件 |
-| `app-store-review-rejections` | 诊断并预先化解 free + 广告 + IAP + CloudKit + GC 的 App Review 退回类型 |
+| `app-store-review-rejections` | 诊断并预先化解 free + 广告 + IAP + CloudKit + Game Center (GC) 的 App Review 退回类型 |
 | `asc-api-automation` | 用 `.p8` 生成 ES256 JWT + curl 打 ASC REST API —— TestFlight、metadata、送审、报表；不用 fastlane |
 | `swiftui-interaction-footguns` | 纯代码审查抓不到的已知 SwiftUI 互动 bug |
-| `swiftui-navigation-architecture` | 类型化 `Route` enum + `@Observable` router；value-based `NavigationStack`；逐转场的呈现语义与 macOS 退路；deep link；每个 tab 各自的 path |
+| `swiftui-navigation-architecture` | SwiftUI 的类型化路由导航 —— 一个 `@Observable` router、`NavigationStack`、deep link、处理好 macOS 退路 |
 | `app-icon-rasterize` | 以 `qlmanage` 把 1024 SVG 图标栅格化成 asset catalog PNG —— 免 Homebrew |
 | `ios-design-mockup` | 从 spec 生成单文件 HTML iOS 设计 mockup —— iPhone 外框 + tokens |
 | `interactive-simulator-ux-audit` | 用 `idb`（tap/describe/screenshot）驱动已启动的 Simulator，抓 snapshot 抓不到的导航／modal／safe-area bug |
@@ -93,27 +102,36 @@ plugin，完整标注原作者，绝不复制。
 
 ### 汇总的外部 plugin（7）—— 以引用方式收录，完整标注
 
-此处仅列出、**并非在此撰写** —— 从原作者自己的 repo 安装（你拿到的是最新版），完整标注出处。
+此处仅列出，**并非在此撰写** —— 从原作者自己的 repo 安装（你拿到的是最新版），完整标注出处。
 **汇总而非据为己有**：只列出 MIT 兼容、不重复的 plugin，且只为真正的空缺而收 —— 这道检查发生
 在收录当下，不是每次上游 commit 都重审，因此外部 plugin 的范围与授权在收录后仍可能变动
-（`caveman` 就已经变过）。外部 plugin 是广度型的**参考资料**（“这是 API”／“X 要这样做”）；
-第一方技能位于下一层，是**带立场的默认值与实际上线的实战故事**（iOS 18、单一 Package、
-swift-testing + snapshot、OSLog 不用第三方、审查漏掉的运行时 bug）—— 主题重叠处，两者差在
-高度，而非重复。
+（`caveman` 就已经变过）。外部 plugin 是广度型的**参考资料** —— “这是 API，这是怎么做 X 的
+方法”。第一方技能更窄：每个主题一个带立场的默认值（iOS 18 是底线、单一 Package、
+swift-testing + snapshot、只用 OSLog、已知的运行时 bug 要避开）。主题重叠处，两者不是重复，
+而是回答的细节层级不同。
 
 | Plugin | 作者 | 涵盖范围 |
 |---|---|---|
-| [`apple-skills`](https://github.com/vabole/apple-skills) | vabole (MIT) | 广泛的 Apple 框架 —— SwiftUI、SwiftData、App Intents、WidgetKit、StoreKit、HealthKit… |
+| [`apple-skills`](https://github.com/Prisma-Labs-Dev/apple-skills) | Prisma Labs (vabole), MIT | 广泛的 Apple 框架 —— SwiftUI、SwiftData、App Intents、WidgetKit、StoreKit、HealthKit… |
 | [`swiftui-expert`](https://github.com/AvdLee/SwiftUI-Agent-Skill) | Antoine van der Lee (MIT) | SwiftUI 模式、Swift Charts、Liquid Glass、Instruments 工具链 |
 | [`swiftui-pro`](https://github.com/twostraws/SwiftUI-Agent-Skill) | Paul Hudson (MIT) | SwiftUI 陷阱、deprecated API 观察清单、iOS 26 / Liquid Glass |
-| [`caveman`](https://github.com/JuliusBrussee/caveman) | JuliusBrussee（技能为 MIT；该 repo 另含 BSL-1.1 授权的 engine） | 极度压缩的沟通模式 —— 省下约 75% token（通用 agent 行为） |
+| [`caveman`](https://github.com/JuliusBrussee/caveman) | JuliusBrussee (MIT) | 极度压缩的沟通模式 —— 省下约 75% token（通用 agent 行为） |
 | [`ponytail`](https://github.com/DietrichGebert/ponytail) | DietrichGebert (MIT) | “懒惰资深工程师”模式 —— 逼出最简单、最短的解法（通用 agent 行为） |
-| [`i-have-adhd`](https://github.com/ayghri/i-have-adhd) | Ayoub G. (MIT) | 常驻的 ADHD 友好输出模式 —— 行动优先、编号步骤、每一轮重述状态；相对于 `caveman`（token 压缩）与 `ponytail`（解法简化），这个塑形的是结构（通用 agent 行为） |
-| [`xcode-build-skill`](https://github.com/pzep1/xcode-build-skill) | pz (MIT) | `xcodebuild`/`xcrun simctl` CLI 参考 —— 找 scheme → 找模拟器 → build → install → launch → 截图；CLI 驱动，与 `interactive-simulator-ux-audit`（idb 驱动的交互式 UX 审计）、`host-driven-xcuitest-e2e`（Tuist scheme 接线的 XCUITest E2E）三者不重叠 |
+| [`i-have-adhd`](https://github.com/ayghri/i-have-adhd) | Ayoub G. (MIT) | 常驻的 ADHD 友好输出模式 —— 编号步骤、每一轮重述状态（通用 agent 行为） |
+| [`xcode-build-skill`](https://github.com/pzep1/xcode-build-skill) | pz (MIT) | `xcodebuild`/`xcrun simctl` CLI 小抄 —— scheme → 模拟器 → build → install → launch → 截图 |
 
-`caveman` 之后已长成 20 个技能的套件；其中 4 个（`caveman-discover`、`caveman-manage`、
+`caveman` 的授权：技能本身 MIT；repo 另外还有一个 BSL-1.1 授权的 engine。`caveman` 之后已
+长成 20 个技能的套件；其中 4 个（`caveman-discover`、`caveman-manage`、
 `caveman-evidence-review`、`caveman-setup`）在讲作者自家托管的 Caveman Cloud 商业服务
 （通用 agent 行为）。
+
+`i-have-adhd` 相对于 `caveman`（token 压缩）与 `ponytail`（解法简化），这个塑形的是结构。
+
+`xcode-build-skill` 是 CLI 驱动的，与 `interactive-simulator-ux-audit`（idb 驱动的交互式 UX
+审计）、`host-driven-xcuitest-e2e`（Tuist scheme 接线的 XCUITest E2E）不同 —— 三者不重叠。
+
+`apple-skills` 已从 `vabole` 的个人账号迁移到 `Prisma-Labs-Dev` 组织；此表列出的是组织版
+repo。
 
 ## 其他安装方式
 
@@ -135,7 +153,8 @@ swift-testing + snapshot、OSLog 不用第三方、审查漏掉的运行时 bug�
 }
 ```
 
-commit 它 —— 协作者信任该项目文件夹之后就会自动拿到这个 marketplace，不会有额外提示。
+commit 它 —— 协作者信任该项目文件夹之后就会自动拿到这个 marketplace，不会有额外提示。若
+Claude Code 仍报告某个 plugin 未安装，照它显示的 `/plugin install` 命令跑一次即可。
 
 ### C —— `npx skills`（平铺，不走 plugin）
 
@@ -144,19 +163,15 @@ npx skills add wei18/apple-dev-skills --list
 npx skills add wei18/apple-dev-skills --skill swift6-concurrency
 ```
 
-> **路径 C 不包含汇总而来的外部 plugin。** `npx skills` 确实会读取本 repo 的
-> `marketplace.json` / `plugin.json`，但只跟随本地声明的技能路径——它不会抓取外部
-> plugin 的远端 `github` / `git-subdir` 来源，因此上述指令只涵盖 39 个第一方技能；
+> **路径 C 不包含汇总而来的外部 plugin。** `npx skills` 会读取本 repo 的
+> `marketplace.json` / `plugin.json`，但只跟随本地声明的技能路径。它不会抓取外部
+> plugin 的远端 `github` / `git-subdir` 来源。所以上述指令只会安装 39 个第一方技能 ——
 > 7 个外部 plugin 会被静默跳过。若要平铺安装整份目录（含外部 plugin，从原作者的 repo 拉取）：
 
 ```bash
 scripts/install-flat.sh -g          # user-level; drop -g for project-level
 scripts/install-flat.sh --dry-run   # preview the `npx skills add` commands
 ```
-
-> 新安装的技能最容易第一个失去描述：Claude Code 的技能清单有 context 预算，
-> 溢出时会从最少被调用的技能开始丢弃描述。执行 `/doctor` 检查清单的成本；
-> 若太吃紧，可在 settings 调整 `skillListingBudgetFraction` / `skillOverrides`。
 
 ## 贡献
 
@@ -171,4 +186,4 @@ scripts/install-flat.sh --dry-run   # preview the `npx skills add` commands
 此处仅以引用方式呈现。催生本 repo 双 plugin 结构的设计 spec 与计划原本放在 `docs/superpowers/`
 —— 已退役、改由 git 历史保存；用 `git log -- docs/` 可以找回。MIT —— 见 [LICENSE](LICENSE)。
 
-<!-- src-sha: c65fc1aab4f4d04aefe8d22f290fc6dae4c7f1d2 -->
+<!-- src-sha: 8fc1a7010cd5feed7c9962639693a63a1ff0aa55 -->

--- a/README.zh-Hant.md
+++ b/README.zh-Hant.md
@@ -4,15 +4,17 @@
 >
 > 語言：[English](README.md) · [繁體中文](README.zh-Hant.md) · [简体中文](README.zh-Hans.md) · [日本語](README.ja.md)
 
-apple-dev-skills 是一個 **marketplace**，為獨立開發者與小型團隊而寫，陪你把一個點子帶到
-App Store 上架。第一方技能分成兩組：**Apple/Swift** 技能管你在做什麼，**harness engineering**
-技能管你怎麼駕馭那個在做事的 agent —— 派工、審查、出貨。每一支技能都是帶立場的預設值，背後
-有實際上架的戰場故事，並受一道一致性把關；旁邊另以引用方式彙整同類最佳的**外部**技能
-plugin，完整標註原作者，絕不複製。
+apple-dev-skills 是一個 **marketplace**，服務對象是正在把一個點子做到 App Store 上架的
+獨立開發者與小型團隊。第一方技能分成兩組：**Apple/Swift** 技能對應你正在打造的東西，
+**harness engineering** 技能對應你怎麼駕馭 Claude Code 本身 —— 規劃、審查、出貨。每一支
+技能都是帶立場的預設值，背後有實際上架的戰場故事，並受一道一致性把關。旁邊另以引用方式
+彙整同類最佳的**外部**技能 plugin —— 並非在此撰寫，僅連結並標註原作者，絕不複製。
 
 ## 快速開始
 
-> 技能會依其 `description:` 自行觸發——裝好之後，直接描述你的任務即可。
+> 技能會依你描述的任務自動觸發 —— 裝好之後，直接描述你的任務即可。
+
+在 Claude Code session 裡執行：
 
 ```
 /plugin marketplace add wei18/apple-dev-skills
@@ -20,16 +22,23 @@ plugin，完整標註原作者，絕不複製。
 /plugin install collaboration-skills@apple-dev-skills      # 12 agent-collaboration skills
 ```
 
+若安裝摘要顯示 `Run /reload-plugins to activate.`，就執行它 —— 較舊版的 client 一定需要這步。
+
 裝一個或兩個都可以。外部 plugin 的安裝方式相同，例如 `/plugin install swiftui-expert@apple-dev-skills`。
 
 接著直接描述你要做的事：
 
 - *「我要開一個新的 iOS App」* → `apple-platform-targets` 回答最低部署版本，並依序交棒給
   package 結構、語言模式與測試基準。
-- *「App Review 以 guideline 5.1.2 退件」* → `app-store-review-rejections` 把該條款對應到修法。
+- *「App Review 以 guideline 5.1.2 退件」* → `app-store-review-rejections` 把該條款對應到
+  修復方式。
 
 要指定某一支，用它的 slash command：`/apple-dev-skills:swift6-concurrency`。`/skills` 會列出
 已安裝的全部技能，以及每一支來自哪個 plugin。
+
+> 新安裝的技能最容易在 Claude Code 的技能清單 context 預算爆量時第一個失去描述。執行
+> `/doctor` 檢查清單的成本；若太吃緊，可在 settings 調整 `skillListingBudgetFraction` /
+> `skillOverrides`。
 
 ## 目錄
 
@@ -52,22 +61,22 @@ plugin，完整標註原作者，絕不複製。
 | `swift-testing-baseline` | swift-testing + pointfreeco snapshot；protocol fake；嚴格/寬鬆 snapshot 把關 |
 | `xcode-cloud-single-track-ci` | 單軌 Xcode Cloud；PR / Main / Release / Periodic；merge 前的 PR CI |
 | `local-archive-export-upload` | Xcode Cloud 不可用時的本機 `xcodebuild archive` → export → `altool` 上傳 TestFlight |
-| `mise-tool-management` | 以 mise 管理二進位 CLI 工具；開發與 CI 共用 `.mise.toml`；macOS-only `os` guard |
-| `oslog-logger-defaults` | `os.Logger`（不用第三方）；subsystem = bundle ID；預設 `.private` |
-| `apple-three-piece-analytics` | ASC Analytics + MetricKit + Game Center；不用第三方追蹤；PrivacyInfo 必備 |
-| `telemetry-facade-pattern` | 單一 `Telemetry` target、fan-out facade；OSLog / NoOp / MetricKit / GameCenter sink |
+| `mise-tool-management` | 用 mise 釘住 CLI 工具版本（swiftlint、xcbeautify…），讓本機開發與 CI 用同一個版本 |
+| `oslog-logger-defaults` | 預設的 logging 設定：Apple 自家 `os.Logger`，不用第三方函式庫，log 值預設 private，除非你自己 opt-in |
+| `apple-three-piece-analytics` | App Store Connect (ASC) Analytics + MetricKit + Game Center；不用第三方追蹤；PrivacyInfo 必備 |
+| `telemetry-facade-pattern` | 一次 logging 呼叫，路由到 OSLog / MetricKit / Game Center —— 換目的地不必動呼叫端 |
 | `ai-translated-localization` | 預設 7 個語系；AI 翻譯流程；`Localizable.xcstrings`；完整度把關 |
 | `ios-accessibility-engineering` | SwiftUI 與 UIKit 的 VoiceOver / Dynamic Type / 觸控目標 / Reduce Motion；WCAG 2.2 |
-| `swift-dependency-injection` | Protocol 注入 + composition root；environment vs constructor；`@TaskLocal`；Sendable |
+| `swift-dependency-injection` | 讓服務可以為了測試替換 —— protocol 注入 + composition root（environment vs constructor、`@TaskLocal`、Sendable） |
 | `ios-performance-engineering` | Instruments / xctrace / hang-hitch 預算 / 啟動 / 記憶體 / 二進位大小 / MetricKit |
 | `apple-public-repo-security` | 公開 iOS/macOS repo 的三道防線 + rotate-first 洩漏處理 SOP |
 | `build-time-secret-injection` | xcconfig + Info.plist `$()` + `Bundle.main`，讓識別碼進得了二進位、出不了 diff |
 | `storekit2-iap-defaults` | StoreKit 2 非消耗型 IAP 預設：bridge protocol 測試接縫、entitlements、restore |
 | `monetization-sdk-integration` | 新增／升級／稽核變現 SDK；把 `import` 隔離在單一 bridge 檔 |
-| `app-store-review-rejections` | 診斷並預先化解 free + 廣告 + IAP + CloudKit + GC 的 App Review 退件類型 |
+| `app-store-review-rejections` | 診斷並預先化解 free + 廣告 + IAP + CloudKit + Game Center (GC) 的 App Review 退件類型 |
 | `asc-api-automation` | 用 `.p8` 產 ES256 JWT + curl 打 ASC REST API —— TestFlight、metadata、送審、報表；不用 fastlane |
 | `swiftui-interaction-footguns` | 純程式碼審查抓不到的已知 SwiftUI 互動 bug |
-| `swiftui-navigation-architecture` | 型別化 `Route` enum + `@Observable` router；value-based `NavigationStack`；逐轉場的呈現語意與 macOS 退路；deep link；每個 tab 各自的 path |
+| `swiftui-navigation-architecture` | SwiftUI 的型別化路由導航 —— 一個 `@Observable` router、`NavigationStack`、deep link、處理好 macOS 退路 |
 | `app-icon-rasterize` | 以 `qlmanage` 把 1024 SVG 圖示點陣化成 asset catalog PNG —— 免 Homebrew |
 | `ios-design-mockup` | 從 spec 產出單檔 HTML iOS 設計 mockup —— iPhone 外框 + tokens |
 | `interactive-simulator-ux-audit` | 用 `idb`（tap/describe/screenshot）驅動已開機的 Simulator，抓 snapshot 抓不到的導航／modal／safe-area bug |
@@ -93,27 +102,36 @@ plugin，完整標註原作者，絕不複製。
 
 ### 彙整之外部 plugin（7）—— 以引用方式收錄，完整標註
 
-此處僅列出、**並非在此撰寫** —— 從原作者自己的 repo 安裝（你拿到的是最新版），完整標註出處。
+此處僅列出，**並非在此撰寫** —— 從原作者自己的 repo 安裝（你拿到的是最新版），完整標註出處。
 **彙整而非佔為己有**：只列出 MIT 相容、不重複的 plugin，且只為真正的空缺而收 —— 這道檢查發生
 在收錄當下，不是每次上游 commit 都重審，因此外部 plugin 的範圍與授權在收錄後仍可能變動
-（`caveman` 就已經變過）。外部 plugin 是廣度型的**參考資料**（「這是 API」／「X 要這樣做」）；
-第一方技能位在下一層，是**帶立場的預設值與實際上架的戰場故事**（iOS 18、單一 Package、
-swift-testing + snapshot、OSLog 不用第三方、審查漏掉的執行期 bug）—— 主題重疊處，兩者差在
-高度，而非重複。
+（`caveman` 就已經變過）。外部 plugin 是廣度型的**參考資料** —— 「這是 API，這是怎麼做 X 的
+方法」。第一方技能比較窄：每個主題一個帶立場的預設值（iOS 18 是底線、單一 Package、
+swift-testing + snapshot、只用 OSLog、已知的執行期 bug 要避開）。主題重疊處，兩者不是重複，
+而是回答的細節層級不同。
 
 | Plugin | 作者 | 涵蓋範圍 |
 |---|---|---|
-| [`apple-skills`](https://github.com/vabole/apple-skills) | vabole (MIT) | 廣泛的 Apple 框架 —— SwiftUI、SwiftData、App Intents、WidgetKit、StoreKit、HealthKit… |
+| [`apple-skills`](https://github.com/Prisma-Labs-Dev/apple-skills) | Prisma Labs (vabole), MIT | 廣泛的 Apple 框架 —— SwiftUI、SwiftData、App Intents、WidgetKit、StoreKit、HealthKit… |
 | [`swiftui-expert`](https://github.com/AvdLee/SwiftUI-Agent-Skill) | Antoine van der Lee (MIT) | SwiftUI 模式、Swift Charts、Liquid Glass、Instruments 工具鏈 |
 | [`swiftui-pro`](https://github.com/twostraws/SwiftUI-Agent-Skill) | Paul Hudson (MIT) | SwiftUI 陷阱、deprecated API 觀察清單、iOS 26 / Liquid Glass |
-| [`caveman`](https://github.com/JuliusBrussee/caveman) | JuliusBrussee（技能為 MIT；該 repo 另含 BSL-1.1 授權的 engine） | 極度壓縮的溝通模式 —— 省下約 75% token（通用 agent 行為） |
+| [`caveman`](https://github.com/JuliusBrussee/caveman) | JuliusBrussee (MIT) | 極度壓縮的溝通模式 —— 省下約 75% token（通用 agent 行為） |
 | [`ponytail`](https://github.com/DietrichGebert/ponytail) | DietrichGebert (MIT) | 「懶惰資深工程師」模式 —— 逼出最簡單、最短的解法（通用 agent 行為） |
-| [`i-have-adhd`](https://github.com/ayghri/i-have-adhd) | Ayoub G. (MIT) | 常駐的 ADHD 友善輸出模式 —— 行動優先、編號步驟、每一輪重述狀態；相對於 `caveman`（token 壓縮）與 `ponytail`（解法簡化），這個塑形的是結構（通用 agent 行為） |
-| [`xcode-build-skill`](https://github.com/pzep1/xcode-build-skill) | pz (MIT) | `xcodebuild`/`xcrun simctl` CLI 參考 —— 找 scheme → 找模擬器 → build → install → launch → 截圖；CLI 驅動，與 `interactive-simulator-ux-audit`（idb 驅動的互動式 UX 稽核）、`host-driven-xcuitest-e2e`（Tuist scheme 接線的 XCUITest E2E）三者不重疊 |
+| [`i-have-adhd`](https://github.com/ayghri/i-have-adhd) | Ayoub G. (MIT) | 常駐的 ADHD 友善輸出模式 —— 編號步驟、每一輪重述狀態（通用 agent 行為） |
+| [`xcode-build-skill`](https://github.com/pzep1/xcode-build-skill) | pz (MIT) | `xcodebuild`/`xcrun simctl` CLI 小抄 —— scheme → 模擬器 → build → install → launch → 截圖 |
 
-`caveman` 之後已長成 20 個技能的套件；其中 4 個（`caveman-discover`、`caveman-manage`、
+`caveman` 的授權：技能本身 MIT；repo 另外還有一個 BSL-1.1 授權的 engine。`caveman` 之後已
+長成 20 個技能的套件；其中 4 個（`caveman-discover`、`caveman-manage`、
 `caveman-evidence-review`、`caveman-setup`）在講作者自家托管的 Caveman Cloud 商業服務
 （通用 agent 行為）。
+
+`i-have-adhd` 相對於 `caveman`（token 壓縮）與 `ponytail`（解法簡化），這個塑形的是結構。
+
+`xcode-build-skill` 是 CLI 驅動的，與 `interactive-simulator-ux-audit`（idb 驅動的互動式 UX
+稽核）、`host-driven-xcuitest-e2e`（Tuist scheme 接線的 XCUITest E2E）不同 —— 三者不重疊。
+
+`apple-skills` 已從 `vabole` 的個人帳號移轉到 `Prisma-Labs-Dev` 組織；此表列出的是組織版
+repo。
 
 ## 其他安裝方式
 
@@ -135,7 +153,8 @@ swift-testing + snapshot、OSLog 不用第三方、審查漏掉的執行期 bug�
 }
 ```
 
-commit 它 —— 協作者信任該專案資料夾之後就會自動拿到這個 marketplace，不會有額外提示。
+commit 它 —— 協作者信任該專案資料夾之後就會自動拿到這個 marketplace，不會有額外提示。若
+Claude Code 仍回報某個 plugin 未安裝，照它顯示的 `/plugin install` 指令跑一次即可。
 
 ### C —— `npx skills`（平鋪，不走 plugin）
 
@@ -144,19 +163,15 @@ npx skills add wei18/apple-dev-skills --list
 npx skills add wei18/apple-dev-skills --skill swift6-concurrency
 ```
 
-> **路徑 C 不包含彙整而來的外部 plugin。** `npx skills` 確實會讀取本 repo 的
-> `marketplace.json` / `plugin.json`，但只跟隨本地宣告的技能路徑——它不會抓取外部
-> plugin 的遠端 `github` / `git-subdir` 來源，因此上述指令只涵蓋 39 個第一方技能；
+> **路徑 C 不包含彙整而來的外部 plugin。** `npx skills` 會讀取本 repo 的
+> `marketplace.json` / `plugin.json`，但只跟隨本地宣告的技能路徑。它不會抓取外部
+> plugin 的遠端 `github` / `git-subdir` 來源。所以上述指令只會安裝 39 個第一方技能 ——
 > 7 個外部 plugin 會被靜默略過。若要平鋪安裝整份目錄（含外部 plugin，從原作者的 repo 拉取）：
 
 ```bash
 scripts/install-flat.sh -g          # user-level; drop -g for project-level
 scripts/install-flat.sh --dry-run   # preview the `npx skills add` commands
 ```
-
-> 新安裝的技能最容易第一個失去描述：Claude Code 的技能清單有 context 預算，
-> 溢出時會從最少被呼叫的技能開始丟棄描述。執行 `/doctor` 檢查清單的成本；
-> 若太吃緊，可在 settings 調整 `skillListingBudgetFraction` / `skillOverrides`。
 
 ## 貢獻
 
@@ -171,4 +186,4 @@ scripts/install-flat.sh --dry-run   # preview the `npx skills add` commands
 此處僅以引用方式呈現。催生本 repo 雙 plugin 結構的設計 spec 與計畫原本放在 `docs/superpowers/`
 —— 已退役、改由 git 歷史保存；用 `git log -- docs/` 可以找回。MIT —— 見 [LICENSE](LICENSE)。
 
-<!-- src-sha: c65fc1aab4f4d04aefe8d22f290fc6dae4c7f1d2 -->
+<!-- src-sha: 8fc1a7010cd5feed7c9962639693a63a1ff0aa55 -->


### PR DESCRIPTION
## Summary

- Fixes from a four-way adversarial README review (readability, structure, official-docs accuracy, locale-native-speaker review): split the dense intro and two long run-on sentences, add the missing "run inside a session" / `/reload-plugins` Quickstart steps (per official `discover-plugins.md`), move the context-budget warning from Path C into Quickstart where it actually applies, rewrite five noun-soup catalog one-liners, expand `ASC`/`GC` on first use, and shrink three oversized external-plugin table cells (`caveman`, `i-have-adhd`, `xcode-build-skill`) with the dropped comparison/license detail moved to footnotes.
- The `zh-Hant`/`zh-Hans` mirrors also drop translationese (personifying "陪你", vague "管你", legal-register "修法", an inconsistent "上线"/"上架" split) and fix unspaced em dashes. All three mirrors (`zh-Hant`, `zh-Hans`, `ja`) are hand-mirrored to the new English content.
- `vabole/apple-skills` now resolves (301) to the `Prisma-Labs-Dev` GitHub org — confirmed live via `gh api`. Updated `marketplace.json`'s source/author, `externals-snapshot.json`'s baseline (via `mise run check-externals -- --update`), and all four README's link/attribution/footnote.

## Test plan

- [x] `python3 scripts/check-consistency.py` — OK, all 3 mirrors consistent
- [x] `mise run check-externals` — OK, 7 externals match snapshot (only `apple-skills.repo` drifted, now re-baselined)
- [x] `grep -c 'skillListingBudgetFraction' README.md` = 1, inside the Quickstart section
- [x] `## ` heading order identical across all four READMEs; Catalog backtick-token sets identical across all four
- [x] `reload-plugins` present in all four READMEs; `Prisma-Labs-Dev` present in all READMEs + `.claude-plugin/`; `vabole/apple-skills` count is 0 everywhere
- [x] zh-Hans has zero `上线`; zh-Hant has zero `修法`; both have zero `陪你` / `管你`
- [x] `caveman`/`i-have-adhd`/`xcode-build-skill` table cells all ≤120 bytes
- [x] `.claude-plugin/marketplace.json` parses as valid JSON

🤖 Generated with [Claude Code](https://claude.com/claude-code)