### PR TITLE
chore(release): 1.7.1 — four-language README, review fixes, apple-skills org move

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -3,7 +3,7 @@
   "owner": { "name": "Wei18" },
   "metadata": {
     "description": "A curated catalog of skills for AI coding agents — first-party Apple/Swift and agent-collaboration skills, plus aggregated best-of-breed external plugins (credited to their authors)",
-    "version": "1.7.0"
+    "version": "1.7.1"
   },
   "plugins": [
     {

--- a/README.ja.md
+++ b/README.ja.md
@@ -156,7 +156,7 @@ UX監査）や`host-driven-xcuitest-e2e`（Tuist scheme配線のXCUITest E2E）�
 {
   "extraKnownMarketplaces": {
     "apple-dev-skills": {
-      "source": { "source": "github", "repo": "wei18/apple-dev-skills", "ref": "v1.7.0" }
+      "source": { "source": "github", "repo": "wei18/apple-dev-skills", "ref": "v1.7.1" }
     }
   },
   "enabledPlugins": {
@@ -206,4 +206,4 @@ scripts/install-flat.sh --dry-run   # preview the `npx skills add` commands
 `docs/superpowers/`にありました——現在は廃止され、git履歴として保存されています。
 `git log -- docs/`で見つけることができます。MIT——[LICENSE](LICENSE)を参照してください。
 
-<!-- src-sha: 8fc1a7010cd5feed7c9962639693a63a1ff0aa55 -->
+<!-- src-sha: 7c20ff7b825eb59f0a020ab728e0b736f548e845 -->

--- a/README.md
+++ b/README.md
@@ -150,7 +150,7 @@ Pin the marketplace to a released tag directly in `.claude/settings.json` — no
 {
   "extraKnownMarketplaces": {
     "apple-dev-skills": {
-      "source": { "source": "github", "repo": "wei18/apple-dev-skills", "ref": "v1.7.0" }
+      "source": { "source": "github", "repo": "wei18/apple-dev-skills", "ref": "v1.7.1" }
     }
   },
   "enabledPlugins": {

--- a/README.zh-Hans.md
+++ b/README.zh-Hans.md
@@ -143,7 +143,7 @@ repo。
 {
   "extraKnownMarketplaces": {
     "apple-dev-skills": {
-      "source": { "source": "github", "repo": "wei18/apple-dev-skills", "ref": "v1.7.0" }
+      "source": { "source": "github", "repo": "wei18/apple-dev-skills", "ref": "v1.7.1" }
     }
   },
   "enabledPlugins": {
@@ -186,4 +186,4 @@ scripts/install-flat.sh --dry-run   # preview the `npx skills add` commands
 此处仅以引用方式呈现。催生本 repo 双 plugin 结构的设计 spec 与计划原本放在 `docs/superpowers/`
 —— 已退役、改由 git 历史保存；用 `git log -- docs/` 可以找回。MIT —— 见 [LICENSE](LICENSE)。
 
-<!-- src-sha: 8fc1a7010cd5feed7c9962639693a63a1ff0aa55 -->
+<!-- src-sha: 7c20ff7b825eb59f0a020ab728e0b736f548e845 -->

--- a/README.zh-Hant.md
+++ b/README.zh-Hant.md
@@ -143,7 +143,7 @@ repo。
 {
   "extraKnownMarketplaces": {
     "apple-dev-skills": {
-      "source": { "source": "github", "repo": "wei18/apple-dev-skills", "ref": "v1.7.0" }
+      "source": { "source": "github", "repo": "wei18/apple-dev-skills", "ref": "v1.7.1" }
     }
   },
   "enabledPlugins": {
@@ -186,4 +186,4 @@ scripts/install-flat.sh --dry-run   # preview the `npx skills add` commands
 此處僅以引用方式呈現。催生本 repo 雙 plugin 結構的設計 spec 與計畫原本放在 `docs/superpowers/`
 —— 已退役、改由 git 歷史保存；用 `git log -- docs/` 可以找回。MIT —— 見 [LICENSE](LICENSE)。
 
-<!-- src-sha: 8fc1a7010cd5feed7c9962639693a63a1ff0aa55 -->
+<!-- src-sha: 7c20ff7b825eb59f0a020ab728e0b736f548e845 -->


### PR DESCRIPTION
marketplace 1.7.0 → 1.7.1. Plugin versions unchanged — nothing under `*/skills/` moved.

What 1.7.1 carries: the Japanese README (#66), the four-language review fixes and Quickstart alignment with the official install flow (#67), and the `apple-skills` move to `Prisma-Labs-Dev` (#67).

Bumped via `mise run bump --marketplace 1.7.1`; the script replaced the `"ref"` pin in all four READMEs and re-stamped the three mirrors' `src-sha`. Gate and `check-externals` green.