### PR TITLE
docs(apple-dev-skills): rewrite 22 skill descriptions per phase-2 audit

### DIFF
--- a/apple-dev-skills/skills/ai-translated-localization/SKILL.md
+++ b/apple-dev-skills/skills/ai-translated-localization/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: ai-translated-localization
-description: Default localization scope AND execution playbook for Apple-platform Apps — 7 locales (en, zh-Hant, zh-Hans, ja, ko, es, th) translated via AI agent flow using `Localizable.xcstrings`. Source = en, primary = zh-Hant. Minimum set zh-Hant + en. Invoke when (1) deciding L10n scope / catalog format / translation flow at project setup, OR (2) actually executing a translation pass to add or refresh strings.
+description: 'Localization scope and AI-translation execution for Apple-platform Apps on `Localizable.xcstrings` — default locale set, source / primary language rule, per-locale review gotchas, completeness gates. Use when deciding which locales to ship at project setup; when adding or refreshing user-facing strings (UI keys, Game Center, App Store metadata) in non-source locales; when `extractionState: stale` entries or untranslated placeholder markers appear; or when asked "how many locales", "how do translations enter git". Does NOT cover RTL layout or ASC upload mechanics → asc-api-automation.'
 ---
 
 # AI-Translated Localization

--- a/apple-dev-skills/skills/app-store-review-rejections/SKILL.md
+++ b/apple-dev-skills/skills/app-store-review-rejections/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: app-store-review-rejections
-description: Use when preparing an App Store submission, diagnosing an App Review rejection / Resolution Center message, or hardening a free game/app with ads + Remove-Ads IAP + CloudKit + Game Center against the rejection classes it realistically hits. Covers guideline 2.1 / 2.3.x (incl. 2.3.6 age rating) / 3.1.1 / 4.0 / 4.2 / 4.3 / 5.1.1 / 5.1.2 plus ASC export compliance, the ATT-vs-AdMob trap, privacy-label parity, and a pre-submit checklist.
+description: 'Use when preparing an App Store submission, reading an App Review rejection or Resolution Center message citing a guideline number (2.1, 2.3.x, 3.1.1, 4.3, 5.1.1, 5.1.2), or auditing an ads + Remove-Ads IAP + CloudKit + Game Center app for the rejection classes it realistically hits: the ATT-vs-AdMob trap, privacy-label parity with `PrivacyInfo.xcprivacy`, Restore Purchases, screenshot metadata, export compliance. Maps each class to a pre-submit fix. Not the submission mechanics (asc-api-automation) nor StoreKit implementation (storekit2-iap-defaults).'
 ---
 
 # App Store Review Rejections

--- a/apple-dev-skills/skills/apple-public-repo-security/SKILL.md
+++ b/apple-dev-skills/skills/apple-public-repo-security/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: apple-public-repo-security
-description: Security baseline for public iOS / macOS repos — secret classification (CloudKit PEM, ASC API key, APNs key, signing cert, provisioning profiles), `.gitignore` baseline, three lines of defence (mise gitleaks + lefthook pre-commit · Xcode Cloud `ci_post_clone.sh` · GitHub Secret Scanning), rotate-first leak SOP (`git filter-repo`, fork persistence), Apple upstream telemetry disclosure (MetricKit / Game Center / sysdiagnose). Invoke when a repo goes public, an existing repo open-sources, a secret enters the build pipeline, or asked "how to prevent secret leaks in a public repo". Repo-hygiene baseline; for ship-in-binary identifiers (AdMob ID via xcconfig `$()`) see build-time-secret-injection.
+description: Use when a repo goes public or open-sources, when a CloudKit server-to-server PEM, ASC API `.p8`, APNs key, signing `.p12`, or provisioning profile first enters the pipeline, or when asked how to prevent or respond to a secret leak (gitleaks, lefthook, GitHub Secret Scanning, `git filter-repo`, rotate-first). Also for Apple upstream telemetry disclosure (MetricKit, Game Center, sysdiagnose). Repo-hygiene baseline only; ship-in-binary identifiers (AdMob IDs via xcconfig) and CLI keys in `secrets/.env` are build-time-secret-injection; ASC API usage is asc-api-automation.
 ---
 
 # Apple Public Repo Security

--- a/apple-dev-skills/skills/apple-three-piece-analytics/SKILL.md
+++ b/apple-dev-skills/skills/apple-three-piece-analytics/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: apple-three-piece-analytics
-description: Default analytics stack for solo / small Apple-platform Apps — App Store Connect Analytics + MetricKit + Game Center (for games), no third-party tracking SDK by default, PrivacyInfo.xcprivacy mandatory. Invoke when deciding analytics SDK (vs Firebase / TelemetryDeck / Amplitude), writing PrivacyInfo, or when asked "should I integrate Firebase / Mixpanel / TelemetryDeck".
+description: 'Choose analytics and metrics sources for a solo / small-team Apple app and decide whether a third-party tracking SDK is justified. Use when picking an analytics SDK; when asked "should I add Firebase / Mixpanel / Amplitude / TelemetryDeck"; when asked what App Store Connect Analytics, MetricKit (`MXMetricPayload`) or Game Center can measure without an SDK; when the analytics choice drives `PrivacyInfo.xcprivacy` or ATT. Does NOT own MetricKit perf wiring (ios-performance-engineering), App Review privacy-label parity (app-store-review-rejections), or sink code (telemetry-facade-pattern).'
 ---
 
 # Apple Three-Piece Analytics

--- a/apple-dev-skills/skills/asc-api-automation/SKILL.md
+++ b/apple-dev-skills/skills/asc-api-automation/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: asc-api-automation
-description: 'Use when automating App Store Connect from a CLI or CI — mint the ES256 JWT from an ASC API `.p8` key (`kid`, `iss` = Issuer ID, `aud` `appstoreconnect-v1`, exp ≤ 20 min), then drive `api.appstoreconnect.apple.com` with curl for TestFlight `betaGroups` / `betaBuildLocalizations`, `appStoreVersions` metadata, `reviewSubmissions` submit-for-review, `salesReports` / `analyticsReportRequests`. No fastlane, no Ruby — a CryptoKit token script + curl. Invoke when asked "automate TestFlight / submission / release notes", writing release tooling, or debugging 401 NOT_AUTHORIZED / 429 RATE_LIMIT_EXCEEDED. API-side ops only: build & upload → xcode-cloud-single-track-ci; `.p8` storage / leak prevention → build-time-secret-injection + apple-public-repo-security.'
+description: 'Use when automating App Store Connect from a script or CI via the ASC REST API (`api.appstoreconnect.apple.com`) — ASC API `.p8` key / JWT auth, TestFlight `betaGroups` / `betaBuildLocalizations`, `appStoreVersions` / `releaseType`, `reviewSubmissions`, `salesReports`, `analyticsReportRequests` — or asked "automate TestFlight / submission / release notes", "should I use fastlane", or debugging 401 NOT_AUTHORIZED / 429 RATE_LIMIT_EXCEEDED. API side only: build & upload → xcode-cloud-single-track-ci / local-archive-export-upload; `.p8` storage → build-time-secret-injection.'
 ---
 
 # App Store Connect API Automation

--- a/apple-dev-skills/skills/build-time-secret-injection/SKILL.md
+++ b/apple-dev-skills/skills/build-time-secret-injection/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: build-time-secret-injection
-description: Use when introducing an AdMob production ID (`GADApplicationIdentifier` Info.plist key, ad unit IDs), ASC API `.p8` key, or any "ships in binary but must stay out of public-repo PR diffs" identifier into an Apple build. Codifies the xcconfig + Info.plist `$()` substitution + `Bundle.main` read pattern, paired with `secrets/.env` for CLI tooling; multi-app `CI_PRODUCT` dispatch + built-bundle smoke-test. Build-time injection mechanism, not the repo-hygiene baseline; for secret-leak prevention (gitleaks, lefthook, GitHub Secret Scanning) see apple-public-repo-security.
+description: Use when wiring a value that ships in the binary but must stay out of public-repo diffs until launch (AdMob `GADApplicationIdentifier` / banner unit ID, a third-party SDK app key) into an Apple build via xcconfig, Info.plist `$()` substitution and a guarded `Bundle.main` read, including `ci_post_clone.sh` generation on Xcode Cloud; or when CLI tooling reads an ASC `.p8` / key ID from `secrets/.env`. Not for signing certs, CloudKit or APNs keys, nor leak prevention (gitleaks, lefthook, Secret Scanning) — see apple-public-repo-security. SDK isolation is monetization-sdk-integration.
 ---
 
 # Build-time Secret Injection (Apple-platform)

--- a/apple-dev-skills/skills/cloudkit-schema-source-of-truth/SKILL.md
+++ b/apple-dev-skills/skills/cloudkit-schema-source-of-truth/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: cloudkit-schema-source-of-truth
-description: Use when a CloudKit-backed app's persistence layer adds or edits a record type, field, or index and the schema needs to reach a container, or when asked "how do I push CloudKit schema to Production", "why can't cktool deploy to prod", or "why is a field silently missing in Production". Covers one committed `.ckdb` per app as the schema source of truth, `xcrun cktool` export/validate/deploy against Development (management token from an env file, passed positionally since cktool rejects piped stdin, purged after use), Production promotion as an irreversible Console-button-only gate `cktool` cannot reach, Production fields/indexes being add-only, and Just-In-Time schema existing only in Development — a field the code writes that Production was never seeded with fails silently.
+description: 'Committed `.ckdb` as the CloudKit schema source of truth, with `xcrun cktool` export / validate / import against Development and Production promotion kept as a Console-only gate. Use when a CloudKit-backed persistence layer adds or edits a record type, field, or index; before any Production schema deploy; or when asked "how do I push CloudKit schema to Production", "why can''t cktool deploy to prod", "why is a field silently missing in Production". Does NOT own the Swift persistence seam → swift-dependency-injection, or token storage → apple-public-repo-security.'
 ---
 
 # CloudKit Schema Source of Truth

--- a/apple-dev-skills/skills/interactive-simulator-ux-audit/SKILL.md
+++ b/apple-dev-skills/skills/interactive-simulator-ux-audit/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: interactive-simulator-ux-audit
-description: Use when auditing an iOS/iPadOS app's live behavior in the Simulator — navigation, modals, back-stack, completion flows, safe-area/Dynamic-Island clipping, offline or signed-out states — bugs a fixed-size snapshot render structurally cannot show. Covers installing `idb` without Homebrew (direct GitHub release + an exec wrapper that preserves rpath), the describe-all → tap → screenshot drive loop, device-point vs screenshot-pixel coordinate spaces, and the "stale build" / "worktree launch crash" false-negative traps. Use when asked to "test the UI", "find UX problems", "drive the simulator", or verify an interactive flow end-to-end. Also covers sizing a parallel-simulator fleet — how many booted simulators fit in RAM when each agent drives its own.
+description: Audit an iOS/iPadOS app's live behavior on a booted Simulator by driving it with `idb` (accessibility tree, taps, screenshots) to find bugs a fixed-frame snapshot cannot show — navigation and modal flows, back-stack, completion screens, safe-area / Dynamic Island clipping, offline and signed-out states, Dynamic Type at AX sizes. Use when asked to test the UI, find UX problems, drive the simulator, verify an interactive flow end-to-end, or size a parallel-simulator fleet. Not for scripted CI-run UI tests → host-driven-xcuitest-e2e; not for native macOS apps, which idb cannot target.
 context: fork
 agent: general-purpose
 argument-hint: "[udid] [flow]"

--- a/apple-dev-skills/skills/ios-accessibility-engineering/SKILL.md
+++ b/apple-dev-skills/skills/ios-accessibility-engineering/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: ios-accessibility-engineering
-description: Concrete VoiceOver / Dynamic Type / touch-target / Reduce Motion implementation guide for SwiftUI and UIKit. Invoke when adding or auditing VoiceOver labels, Dynamic Type support, touch-target sizing, or Reduce Motion behavior, running a WCAG accessibility audit, when asked "make this accessible", or diagnosing an accessibility-related App Review rejection.
+description: Implement and audit VoiceOver (`accessibilityLabel` / `Value` / `Hint`, traits, `accessibilityElement(children:)`, `AccessibilityNotification`), Dynamic Type (text styles, caps, AX5), 44pt touch targets, and Reduce Motion / Transparency for SwiftUI and UIKit, with a WCAG 2.2 mapping. Use when asked to make a screen accessible, when VoiceOver reads the wrong thing, for a pre-submission a11y audit or Accessibility Inspector pass, or an accessibility App Review rejection. Not Rotor / `AccessibilityFocusState` depth; live Simulator driving → interactive-simulator-ux-audit.
 ---
 
 # iOS Accessibility Engineering

--- a/apple-dev-skills/skills/ios-performance-engineering/SKILL.md
+++ b/apple-dev-skills/skills/ios-performance-engineering/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: ios-performance-engineering
-description: Measure and fix iOS/macOS performance — Instruments (Time Profiler, Allocations, SwiftUI instrument, Hangs), os_signpost, MetricKit field telemetry, XCTMetric baselines, launch-time optimisation, memory footprint, binary size. Invoke when diagnosing slowness/hitches/high memory, setting up CI perf baselines, wiring MetricKit, or asking "why is my app slow / using too much memory / large".
+description: Measure and fix iOS/macOS performance with Instruments (Time Profiler, Allocations, Hangs, App Launch), `xctrace` in CI, `OSSignposter`, MetricKit field telemetry (`MXMetricManager`, `MXHangDiagnostic`), `XCTMetric` baselines, launch time, memory footprint, and binary size. Use when diagnosing hangs, hitches, high memory, slow launch, or a large binary, wiring MetricKit, or setting CI perf baselines. SwiftUI body re-render analysis from code review → apple-skills:guide-swiftui-performance-audit or swiftui-expert's `.trace` toolchain; this skill owns measurement and the system-level surface.
 ---
 
 # iOS Performance Engineering

--- a/apple-dev-skills/skills/local-archive-export-upload/SKILL.md
+++ b/apple-dev-skills/skills/local-archive-export-upload/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: local-archive-export-upload
-description: 'Local `xcodebuild archive` → export → upload path to TestFlight when Xcode Cloud is unavailable (quota exhausted, outage, not yet wired). Covers `-exportArchive -exportOptionsPlist` keys (`method`, `destination`, `teamID`, `signingStyle`, `uploadSymbols`), `-authenticationKeyPath` vs `-allowProvisioningUpdates` signing, `xcrun altool --upload-package`, and build-number coordination with Xcode Cloud''s counter. Invoke when asked "ship a build locally / export archive fails / TestFlight without Xcode Cloud". Fallback for `xcode-cloud-single-track-ci`; does NOT cover ASC API automation after upload.'
+description: 'Use when a build must reach TestFlight without Xcode Cloud (quota, outage, CI not wired yet), or when a local `xcodebuild archive` / `-exportArchive -exportOptionsPlist` / `xcrun altool --upload-package` command fails — `ExportOptions.plist` keys (`method`, `destination`, `teamID`, `manageAppVersionAndBuildNumber`), `-authenticationKeyPath` vs `-allowProvisioningUpdates`, `CFBundleVersion` colliding with Xcode Cloud''s counter. Temporary fallback for xcode-cloud-single-track-ci; does NOT cover ASC operations after upload → asc-api-automation, nor `notarytool` notarization.'
 allowed-tools: Bash(xcodebuild archive *) Bash(xcodebuild -exportArchive *)
 ---
 

--- a/apple-dev-skills/skills/mise-tool-management/SKILL.md
+++ b/apple-dev-skills/skills/mise-tool-management/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: mise-tool-management
-description: Use mise (mise.jdx.dev) to manage binary CLI / build tools (swiftlint, swiftformat, xcbeautify, gitleaks, lefthook, etc.) on both dev machines and CI, sharing a single `.mise.toml` for version parity. Invoke when choosing a tool version manager (vs asdf / Homebrew / manual), writing `.mise.toml`, or when asked "how do I manage swiftlint / xcbeautify versions".
+description: 'Use when pinning binary CLI / build tools (swiftlint, xcbeautify, gitleaks, lefthook) with mise so dev machines and CI share one `.mise.toml` — choosing mise vs asdf / Homebrew / manual, writing `.mise.toml` (`aqua:` / `ubi:` backends, `os = ["macos"]` guards), running `mise trust` / `mise install` / `mise exec` from `ci_post_clone.sh` or a fresh git worktree, or debugging "mise exec ignores .mise.toml in a new worktree", `unsupported env: linux/amd64`. Does NOT cover Xcode Cloud workflow design → xcode-cloud-single-track-ci, nor gitleaks / lefthook policy → apple-public-repo-security.'
 ---
 
 # mise Tool Management

--- a/apple-dev-skills/skills/monetization-sdk-integration/SKILL.md
+++ b/apple-dev-skills/skills/monetization-sdk-integration/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: monetization-sdk-integration
-description: Invoke when adding, upgrading, or auditing any third-party monetization SDK (AdMob, UMP, StoreKit wrappers, RevenueCat, ironSource, etc.). Also invoke when reviewing PR diffs that touch the monetization target's ad-bridge sources, or when anyone proposes `import GoogleMobileAds` outside the existing live-bridge file.
+description: 'Use when adding, upgrading, or auditing a third-party monetization SDK (AdMob / Google Mobile Ads, UMP consent, mediation networks, RevenueCat), or when a PR adds `import GoogleMobileAds` outside the single live-bridge file, breaks `canImport` / `.when(platforms: [.iOS])` gating, or lands without a Fake bridge. Owns the break-glass admission test, single-import-site isolation contract, and test seam. Does not cover native StoreKit 2 IAP (storekit2-iap-defaults), production ID storage (build-time-secret-injection), or App Review consequences (app-store-review-rejections).'
 ---
 
 # Monetization SDK Integration

--- a/apple-dev-skills/skills/oslog-logger-defaults/SKILL.md
+++ b/apple-dev-skills/skills/oslog-logger-defaults/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: oslog-logger-defaults
-description: Default logging stack for Apple-platform Swift Apps — Apple's built-in `os.Logger` (no third-party), subsystem = bundle ID, category = module name, dynamic string / object interpolation defaults to `.private` (numeric and Boolean values default to `.public`), with explicit overrides where needed. Invoke when choosing a logging library, writing the first Logger declaration, deciding privacy interpolation, or when asked "OSLog vs SwiftLog vs CocoaLumberjack, which one".
+description: Set up logging for an Apple-platform Swift app with `os.Logger` and decide its `subsystem` / `category` naming and `privacy:` interpolation. Use when choosing a logging library (`os.Logger` vs swift-log `import Logging` vs CocoaLumberjack); when writing the first `Logger(subsystem:category:)`; when deciding `.private` vs `.public` for a value; when asked what `.private` hides in Console.app, sysdiagnose, or `OSLogStore`. Does NOT cover `os_signpost` / Instruments profiling (ios-performance-engineering) or fanning logs out to trackers (telemetry-facade-pattern).
 ---
 
 # OSLog / `os.Logger` Defaults

--- a/apple-dev-skills/skills/swift-dependency-injection/SKILL.md
+++ b/apple-dev-skills/skills/swift-dependency-injection/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: swift-dependency-injection
-description: Testable seam design via protocol injection, SwiftUI environment, and task-local overrides; Swift 6 Sendable rules for dependencies; mentions pointfreeco/swift-dependencies and Factory as library options. Invoke when designing a new service seam, asking "how do I inject CloudKit/network/clock", setting up a composition root, or making code testable.
+description: 'Design injectable seams so Swift services can be swapped for fakes in tests. Use when a type reaches for `URLSession.shared`, `Date()`, `UUID()`, `random(in:)` or a singleton; when asked "how do I inject CloudKit / network / clock" or "should this be a singleton"; when choosing constructor vs `@Environment` / `EnvironmentKey` vs `@TaskLocal` injection; when writing the `makeApp()` composition root; when evaluating swift-dependencies or Factory. Does NOT choose the test framework or snapshot tooling (swift-testing-baseline) or the target layout that hosts the root (swiftpm-modularization).'
 ---
 
 # Swift Dependency Injection

--- a/apple-dev-skills/skills/swift-testing-baseline/SKILL.md
+++ b/apple-dev-skills/skills/swift-testing-baseline/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: swift-testing-baseline
-description: Default testing stack for new Apple-platform Swift projects — swift-testing (no XCTest), pointfreeco/swift-snapshot-testing, protocol-injected fakes for CloudKit / Game Center / network, snapshot images committed to git, CI Xcode version locked to local. Invoke when writing the first test target, choosing a snapshot framework, deciding CloudKit / GameKit test strategy, or when asked "which test framework".
+description: 'Default test stack for new Apple-platform Swift projects — Swift Testing (`@Test` / `#expect`, no XCTest), pointfreeco/swift-snapshot-testing with baselines in git, protocol-injected fakes for CloudKit / Game Center / network. Use when creating the first test target, choosing a snapshot framework or precision policy, deciding whether CI may touch iCloud / Game Center, when a SwiftPM test run hangs on a live CKContainer / GKLocalPlayer, or when asked "XCTest or Swift Testing". Owns the stack decision and CI isolation; Swift Testing syntax and migration → apple-skills:swift-testing.'
 ---
 
 # Swift Testing Baseline

--- a/apple-dev-skills/skills/swift6-concurrency/SKILL.md
+++ b/apple-dev-skills/skills/swift6-concurrency/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: swift6-concurrency
-description: Default to Swift 6 language mode with complete concurrency checking from the first line of code; default actor isolation is `MainActor`, so Sendable is required only for types that cross into `nonisolated` / actor code, not for every in-house type; isolate third-party deps that lag with @preconcurrency. Invoke when writing Package.swift, picking the Swift language mode in Xcode build settings, or when asked "should I turn on strict concurrency?".
+description: 'Swift 6 language mode with complete concurrency checking from the first line of a new Apple-platform project; in-house types treated as `Sendable`; `@preconcurrency import` for lagging deps. Use when setting `swiftLanguageModes` / `swiftSettings` in Package.swift or SWIFT_STRICT_CONCURRENCY / default actor isolation in Xcode build settings, when a new dependency raises Sendable or actor-isolation errors, or when asked "should I turn on strict concurrency". Does NOT own deployment targets → apple-platform-targets; actor / async patterns → apple-skills:swift-concurrency.'
 ---
 
 # Swift 6 / Strict Concurrency

--- a/apple-dev-skills/skills/swiftpm-modularization/SKILL.md
+++ b/apple-dev-skills/skills/swiftpm-modularization/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: swiftpm-modularization
-description: Default modularization shape for Apple-platform Swift Apps — single Swift Package, multi-target, thin App target, DI composition root, restricted Apple framework imports, one test target per production target. Invoke when writing Package.swift, deciding how to split modules, planning portability (e.g. Swift on Android), or when asked "single package or multi-package, how should I split modules".
+description: 'Default module shape for Apple-platform Swift Apps — one Swift Package, multiple targets, a thin App target (`@main` + DI root), CloudKit / GameKit / StoreKit imports confined to service targets, one test target per production target. Use when laying out targets in Package.swift, deciding where a new module or framework import lives, planning core portability (Swift on Android), or when asked "single package or multi-package". Does NOT own `platforms:` → apple-platform-targets, `swiftLanguageModes` → swift6-concurrency, or the test framework → swift-testing-baseline.'
 ---
 
 # SwiftPM Modularization

--- a/apple-dev-skills/skills/swiftui-interaction-footguns/SKILL.md
+++ b/apple-dev-skills/skills/swiftui-interaction-footguns/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: swiftui-interaction-footguns
-description: Checklist of known SwiftUI interaction bugs that slipped past pure-code review (tap-target shrink, sidebar inert Labels, sizeClass on Mac, .task re-fire, theme tint propagation, NSHostingView env). Use when reviewing any SwiftUI View file or a PR that adds Button / NavigationLink / TabView / Form / NavigationSplitView.
+description: 'Checklist of SwiftUI interaction bugs that pass code review but break at runtime: tap-target shrink under `.buttonStyle(.plain)`, inert sidebar `Label`s, `horizontalSizeClass` on Mac, `.task` re-fire, blank `fullScreenCover(isPresented:)` race, stale `dynamicTypeSize` in modals, `.tint` not propagating, `NSHostingView` environment. Use when reviewing a new or changed SwiftUI View, a PR adding Button / NavigationLink / TabView / Form / NavigationSplitView, or after a smoke test surfaces a tap or navigation bug. Navigation shape itself → swiftui-navigation-architecture.'
 ---
 
 # SwiftUI Interaction Footguns

--- a/apple-dev-skills/skills/swiftui-navigation-architecture/SKILL.md
+++ b/apple-dev-skills/skills/swiftui-navigation-architecture/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: swiftui-navigation-architecture
-description: Default navigation shape for SwiftUI Apps (iOS 26 / macOS 26, Swift 6) — value-based `NavigationStack(path:)` over a typed `Route` enum, one `@Observable @MainActor` Router in `.environment`, `navigationDestination(for:)` at the stack root (never in a lazy container), per-transition presentation semantics (push / sheet / `fullScreenCover` / popover / alert / root-swap) incl. macOS behavior (no native `fullScreenCover` → push fallback, pop-to-landing), `item:`-driven modal optionals, `.onOpenURL` deep-link funnel, `NavigationSplitView`, per-tab paths, `Codable` restoration. Invoke when wiring an App's navigation, choosing sheet vs cover vs push, adding deep links / restoration, migrating off `NavigationView`, or asked "router / coordinator in SwiftUI". Bugs → swiftui-interaction-footguns.
+description: 'Wire SwiftUI navigation as data on the iOS 26 / macOS 26, Swift 6 baseline: one `@Observable @MainActor` Router in `.environment`, `NavigationStack(path:)` over a typed `Route` enum, `navigationDestination(for:)` at the stack root, `item:`-driven sheets and covers, `.onOpenURL` deep links, `NavigationSplitView`, per-tab paths, `Codable` restoration. Use when wiring an App''s navigation, choosing push vs sheet vs `fullScreenCover`, adding deep links or restoration, migrating off `NavigationView`, or asked for a router / coordinator in SwiftUI. Runtime bugs → swiftui-interaction-footguns.'
 ---
 
 # SwiftUI Navigation Architecture

--- a/apple-dev-skills/skills/telemetry-facade-pattern/SKILL.md
+++ b/apple-dev-skills/skills/telemetry-facade-pattern/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: telemetry-facade-pattern
-description: Single `Telemetry` SwiftPM target with a fan-out facade — callers say "what happened" (`telemetry.observe(event)`), facade dispatches to multiple sinks (OSLog / NoOp tracking / MetricKit / Game Center). Invoke when deciding logger / tracker coupling, designing telemetry interfaces, or when asked "should Logger and Tracking be one thing".
+description: Design the app-side event pipeline that fans one `telemetry.observe(event)` call out to logging, tracking, MetricKit and Game Center sinks. Use when deciding whether Logger and analytics tracking share one interface; when adding a `TelemetrySink` / `MetricKitSink` / `GameCenterSink`; when a wired-looking sink never fires (score not submitted, achievement not unlocked, `GKLeaderboard.submitScore` unreached); when sink order or UI-blocking sink I/O matters. Does NOT choose the Logger API (oslog-logger-defaults) or which analytics sources to use (apple-three-piece-analytics).
 ---
 
 # Telemetry Facade Pattern

--- a/apple-dev-skills/skills/xcode-cloud-single-track-ci/SKILL.md
+++ b/apple-dev-skills/skills/xcode-cloud-single-track-ci/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: xcode-cloud-single-track-ci
-description: Default CI strategy for solo / small-team Apple-platform projects — Xcode Cloud single-track only (defer GitHub Actions until real pain appears), 4 workflow types (PR / Main / Release / Periodic), pre-merge main on PR CI, Xcode version locked to local. Invoke when setting up CI on a new project, deciding GitHub Actions vs Xcode Cloud, writing ci_scripts/, or when asked "how should CI be set up, do I need dual-track".
+description: 'Use when setting up or changing CI for an Apple-platform project on Xcode Cloud — choosing Xcode Cloud vs GitHub Actions, splitting PR / Main / Release / scheduled workflows, writing `ci_scripts/ci_post_clone.sh` / `ci_pre_xcodebuild.sh` / `ci_post_xcodebuild.sh`, or wiring `CI_BUILD_NUMBER`, `MARKETING_VERSION`, `agvtool` numbering. Or asked "do I need dual-track CI", "main failed after the PR passed", "Xcode Cloud build number collides". Does NOT cover shipping a build by hand when Xcode Cloud is down → local-archive-export-upload, nor ASC REST calls after upload → asc-api-automation.'
 ---
 
 # Xcode Cloud Single-Track CI


### PR DESCRIPTION
# Ledger — phase-2 description-only rewrite (22 apple-dev-skills skills)

Scope: this PR touches only the frontmatter `description:` field of the 22 skills listed in
the task. Every other §3 item in each skill's paragraph (body edits, cross-references, tables,
`references/` moves, etc.) is explicitly out of scope for this PR and is left untouched —
noted but not acted on, per the task's "順手看到本文問題只記錄不改" rule.

Base: `origin/main` @ `b95c02f`. Branch: `audit/p2-apple-descriptions`.

| # | skill | item (short) | status | evidence (file:line after the change, or reason) |
|---|---|---|---|---|
| 1 | apple-three-piece-analytics | description rewrite (A-auth, 593 chars) | FIXED | `apple-dev-skills/skills/apple-three-piece-analytics/SKILL.md:3` |
| 2 | telemetry-facade-pattern | description rewrite (A-auth, 579 chars) | FIXED | `apple-dev-skills/skills/telemetry-facade-pattern/SKILL.md:3` |
| 3 | oslog-logger-defaults | description rewrite (A-auth, 567 chars) | FIXED | `apple-dev-skills/skills/oslog-logger-defaults/SKILL.md:3` |
| 4 | swift-dependency-injection | description rewrite (A-auth, 595 chars) | FIXED | `apple-dev-skills/skills/swift-dependency-injection/SKILL.md:3` |
| 5 | xcode-cloud-single-track-ci | description rewrite (B-auth, 593 chars) | FIXED | `apple-dev-skills/skills/xcode-cloud-single-track-ci/SKILL.md:3` |
| 6 | local-archive-export-upload | description rewrite (B-auth, 578 chars) | FIXED | `apple-dev-skills/skills/local-archive-export-upload/SKILL.md:3` |
| 7 | asc-api-automation | description rewrite (B-auth, 578 chars, 759→578) | FIXED | `apple-dev-skills/skills/asc-api-automation/SKILL.md:3` |
| 8 | mise-tool-management | description rewrite (B-auth, 592 chars) | FIXED | `apple-dev-skills/skills/mise-tool-management/SKILL.md:3` — kept `.mise.toml` spelling per D17 policy (draft already used `.mise.toml` consistently, no change needed) |
| 9 | apple-public-repo-security | description rewrite (C-auth, 577 chars) | FIXED | `apple-dev-skills/skills/apple-public-repo-security/SKILL.md:3` (measured 575 chars; reviewer's stated count is off by 2, content copied verbatim) |
| 10 | build-time-secret-injection | description rewrite (C-auth, 575 chars) | FIXED | `apple-dev-skills/skills/build-time-secret-injection/SKILL.md:3` (measured 587 chars; reviewer's stated count is off, content copied verbatim — no XML/POV/colon-space violation found) |
| 11 | monetization-sdk-integration | description rewrite (C-auth, 593 chars) | FIXED | `apple-dev-skills/skills/monetization-sdk-integration/SKILL.md:3` (measured 577 chars) |
| 12 | app-store-review-rejections | description rewrite (C-auth, 558 chars) | FIXED | `apple-dev-skills/skills/app-store-review-rejections/SKILL.md:3` |
| 13 | swiftui-navigation-architecture | description rewrite (D1-rewrite, 592 chars) | FIXED | `apple-dev-skills/skills/swiftui-navigation-architecture/SKILL.md:3` (draft already stated iOS 26 / macOS 26 — repo main had already moved off the iOS 18/macOS 15 text the D-batch review was written against, per commit `b95c02f` "iOS 26 baseline") |
| 14 | swiftui-interaction-footguns | description rewrite (D2-rewrite, 574 chars) | FIXED | `apple-dev-skills/skills/swiftui-interaction-footguns/SKILL.md:3` |
| 15 | ios-accessibility-engineering | description rewrite (D3-rewrite, ≈575 chars) | FIXED | `apple-dev-skills/skills/ios-accessibility-engineering/SKILL.md:3` |
| 16 | ios-performance-engineering | description rewrite (D4-rewrite, 597 chars) | FIXED | `apple-dev-skills/skills/ios-performance-engineering/SKILL.md:3` — includes the `apple-skills:guide-swiftui-performance-audit` cross-plugin negative-boundary pointer, already correctly prefixed in the draft |
| 17 | interactive-simulator-ux-audit | description rewrite (D6-rewrite, 588 chars, 757→588) | FIXED | `apple-dev-skills/skills/interactive-simulator-ux-audit/SKILL.md:3` — existing `context: fork` / `agent:` / `argument-hint:` frontmatter fields (added in a prior PR) left untouched |
| 18 | swift6-concurrency | description rewrite (E-auth, 579 chars) | FIXED | `apple-dev-skills/skills/swift6-concurrency/SKILL.md:3` — includes `apple-skills:swift-concurrency` cross-plugin pointer, already correctly prefixed |
| 19 | swiftpm-modularization | description rewrite (E-auth, 585 chars) | FIXED_REWORDED | `apple-dev-skills/skills/swiftpm-modularization/SKILL.md:3` — draft's `` one `<Module>Tests` per production target `` contains an XML-tag-like token (`<Module>`) that trips the gate's BLOCKER regex `<[a-zA-Z/][^>]*>` (`scripts/check-skills.py:77`, the same rule that flagged `<Target>`/`<App>` as a BLOCKER for host-driven-xcuitest-e2e in the D-batch report). Reworded to "one test target per production target" (matches the pre-edit live description's phrasing) — meaning unchanged, no angle brackets |
| 20 | swift-testing-baseline | description rewrite (E-auth, 591 chars) | FIXED | `apple-dev-skills/skills/swift-testing-baseline/SKILL.md:3` — includes `apple-skills:swift-testing` cross-plugin pointer, already correctly prefixed |
| 21 | ai-translated-localization | description rewrite (E-auth, ≤600 chars) | FIXED_REWORDED | `apple-dev-skills/skills/ai-translated-localization/SKILL.md:3` — draft's `` `<TRANSLATE>` placeholders `` contains an XML-tag-like token, same gate BLOCKER rule as #19. Reworded to "untranslated placeholder markers" — meaning unchanged, no angle brackets. Draft did not contain the phrase "primary = zh-Hant", so the D10 keep-as-is rule does not apply here; nothing was added or removed regarding primary-locale wording |
| 22 | cloudkit-schema-source-of-truth | description rewrite (E-auth, 572 chars, 787→572) | FIXED | `apple-dev-skills/skills/cloudkit-schema-source-of-truth/SKILL.md:3` (measured 568 chars) |

## `description may summarize workflow` MINOR — before/after

Gate baseline (origin/main, `mise run check`): `BLOCKER 0 · MAJOR 0 · MINOR 10`.
After this PR: `BLOCKER 0 · MAJOR 0 · MINOR 11`.

The heuristic (`scripts/check-skills.py:121`) fires on `→.*→` (two-or-more arrow chars) or
`Step 1` / `1) … 2) …` patterns in the description — it cannot distinguish a workflow summary
from a description that legitimately lists **multiple negative-boundary pointers**
(`Does NOT cover X → skill-a, nor Y → skill-b`), which is exactly what official-skill-rules
and this task ask for ("a negative boundary when needed").

- **Disappeared** (4 — description no longer trips the heuristic): `ai-translated-localization`,
  `interactive-simulator-ux-audit`, `local-archive-export-upload`, `swiftui-navigation-architecture`.
- **Newly appeared** (5 — false positives from legitimate multi-pointer negative boundaries,
  copied verbatim from the reviewer's approved drafts): `cloudkit-schema-source-of-truth`,
  `mise-tool-management`, `swift6-concurrency`, `swiftpm-modularization`,
  `xcode-cloud-single-track-ci`. Each contains 2–3 `→` arrows, one per "Does NOT cover …" /
  "Not for … see …" clause, not a step-by-step workflow. No content in these five actually
  summarizes a process; confirmed by re-reading each rewritten description.
- Net MINOR count: 10 → 11 (+1), explained above per BRIEF's "must not rise except for a new
  legitimate item you explain" rule.
- **Unchanged, flagged before and after** (in scope, still flags the same false-positive
  pattern after rewrite): `asc-api-automation` (row 7) — its new description also carries two
  `→` pointers; net effect on the gate count is zero for this one (already counted in baseline).
- **Unchanged, out of this PR's 22-skill scope**: `apple-platform-targets`,
  `backlog-routing-by-topic`, `claude-skill-plugin-packaging` (name reserved word, unrelated
  rule), `github-contribution-workflow`, `subagent-review-cycles` — not modified by this PR.

## Verification

```
$ mise run check
[check] $ python3 scripts/check-consistency.py
OK — 2 plugins (26/12), catalog + counts + 3 README mirror(s) (README.zh-Hant.md/README.zh-Hans.md/README.ja.md) consistent.
[check] $ python3 scripts/check-skills.py .
BLOCKER 0 · MAJOR 0 · MINOR 11
```

`git diff origin/main --stat`: 22 files changed, 22 insertions(+), 22 deletions(-) — all
`apple-dev-skills/skills/<name>/SKILL.md`, frontmatter `description:` line only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
