### PR TITLE
docs(collaboration-skills): rewrite 11 skill descriptions per phase-2 audit

### DIFF
--- a/collaboration-skills/skills/agent-impl-notes-log/SKILL.md
+++ b/collaboration-skills/skills/agent-impl-notes-log/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: agent-impl-notes-log
-description: "Maintain a running `meetings/{date}_{topic}.impl-notes.md` *during* subagent task execution to capture in-flight design decisions, intentional deviations from spec, considered alternatives, and open questions for Leader/User. Distinct from the post-hoc phase meeting log; this file is updated incrementally as decisions are made. Invoke at the start of any non-trivial subagent dispatch (M- or L-size: touches ≥2 files, adds new behavior, or gets a spec before code), when ambiguity is encountered mid-task, or when about to deviate from spec."
+description: "Keep a running impl-notes file next to the phase meeting log while a subagent executes a task, recording design decisions, intentional deviations from spec, tradeoffs, and open questions as they happen rather than after the fact. Use at the start of any non-trivial subagent dispatch (multi-file change, ambiguous spec, new dependency or module, refactor), when ambiguity is hit mid-task, or before deviating from spec. Not the post-hoc meeting log (session-to-meeting-log); the two coexist."
+argument-hint: "[topic]"
 ---
 
 # Agent Implementation Notes — Running Log

--- a/collaboration-skills/skills/backlog-routing-by-topic/SKILL.md
+++ b/collaboration-skills/skills/backlog-routing-by-topic/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: backlog-routing-by-topic
-description: For repos using the `spec-phase-orchestration` doc layout (design.md / foundations.md / plan.md / methodology.md), route mid-discussion stray ideas to the matching file's §Backlog section by topic — product → design.md; tooling → foundations.md; implementation step → plan.md; collaboration → methodology.md; unclassifiable → today's meeting log §Open questions. Invoke when a stray idea pops up during focused work, when reviewing a meeting log for parking lot items, or when asked "where does this idea go".
+description: Route a stray idea that surfaces mid-task to the §Backlog of the right living doc in a spec-phase-orchestration repo (design.md, foundations.md, plan.md, methodology.md, or today's meeting log) as a single line, without derailing the current work. Use when a not-now-but-don't-forget idea comes up, when tidying a meeting log's parking-lot items, or when asked where an idea should go. Not for decisions that must be acted on now (those belong in the body of plan.md).
 ---
 
 # Backlog Routing by Topic

--- a/collaboration-skills/skills/claude-skill-plugin-packaging/SKILL.md
+++ b/collaboration-skills/skills/claude-skill-plugin-packaging/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: claude-skill-plugin-packaging
-description: How to distribute Claude Code skills for reuse across repos and how to install them — as a plugin via a marketplace, a pinned git-submodule with committed project-scope settings, or globally. Covers the depth-1 discovery rule (why a bare folder/submodule of skills is NOT found), the `settings.json` schema, aggregating other skill repos, and the gotchas. Invoke when sharing skills across projects, wiring a skill plugin into a repo, choosing flat-skills vs plugin, or asked "why aren't my submodule'd skills showing up / how do I install project skills".
+description: Package Claude Code skills as a plugin plus marketplace and install them into other repos — globally, pinned per project via committed settings, or as a skills-dir plugin. Use when sharing skills across repos, wiring an existing skill plugin into a project, choosing flat project skills versus a plugin, aggregating other people's skill repos by reference, or when a submodule or nested folder of skills is not being discovered. Does not cover PR/issue mechanics (github-contribution-workflow) or how to write the skill itself (skill-authoring-patterns).
 ---
 
 # Claude Code Skill Plugin Packaging

--- a/collaboration-skills/skills/github-contribution-workflow/SKILL.md
+++ b/collaboration-skills/skills/github-contribution-workflow/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: github-contribution-workflow
-description: Author GitHub contributions with the gh CLI — open/merge PRs, open issues, create/edit files on GitHub, set repo secrets, configure contribution-flow repo settings. Use when running `gh pr create` / `gh pr merge` / `gh pr checks` / `gh issue create` / `gh secret set` / `gh api`, checking CI before merge, or bumping a submodule pin. Covers Conventional branch/PR-title conventions, Co-Authored-By trailer + 🤖 footer, squash+delete merge, CLEAN-before-merge, `gh secret set` without --body, `git update-index` submodule bumps, the --no-verify rule. Does NOT cover pure local git, diff-vs-commit verification (→ pr-diff-verification), security repo settings (→ apple-public-repo-security), worktree conflicts (→ subagent-conflict-detection), plugin distribution (→ claude-skill-plugin-packaging).
+description: Drive GitHub contributions through the gh CLI — pull requests, issues, GitHub-side file edits, repo secrets, contribution-flow repo settings, submodule pin bumps. Use when about to run `gh pr create` / `gh pr merge` / `gh pr checks` / `gh issue create` / `gh secret set` / `gh api`, or asked "open a PR", "merge this", "bump the submodule". Does NOT cover pure local git, diff-vs-commit sanity (pr-diff-verification), security repo settings (apple-dev-skills:apple-public-repo-security), worktree conflicts (subagent-conflict-detection), plugin distribution (claude-skill-plugin-packaging).
 ---
 
 # GitHub Contribution Workflow

--- a/collaboration-skills/skills/methodology-pattern-extractor/SKILL.md
+++ b/collaboration-skills/skills/methodology-pattern-extractor/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: methodology-pattern-extractor
-description: Read accumulated meeting logs and session JSONL files, extract collaboration patterns that have repeated ≥ 3 times, and append them to `docs/methodology.md` §Patterns. Each entry captures trigger / action / outcome / next-time adjustment. Invoke when the user asks "update methodology", "extract patterns from this session", "consolidate recurring collaboration patterns", or after every 5+ meeting logs accumulate.
+description: Extract recurring collaboration patterns from accumulated meeting logs (optionally session JSONL) and record them in docs/methodology.md with evidence of where each was sighted. Use when the user asks to update methodology, extract patterns from this session, or consolidate recurring collaboration flows; or when five or more meeting logs have accumulated while §Patterns is still empty. Not for writing the meeting logs themselves (session-to-meeting-log) or for parking one-off ideas (backlog-routing-by-topic).
 context: fork
 agent: general-purpose
 argument-hint: "[topic]"

--- a/collaboration-skills/skills/pr-diff-verification/SKILL.md
+++ b/collaboration-skills/skills/pr-diff-verification/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: pr-diff-verification
-description: Use before pushing a branch or opening a PR to verify `git show --stat --summary HEAD` matches what the commit message claims. Prevents the "commit log wrote but code didn't make it" class of accidents where the commit message describes changes that aren't in the diff (e.g. amend overwrote the previous commit's content, force-push lost commits, worktree wipe lost staged work). Invoke whenever Leader is about to `git push` a feature branch OR open a PR.
+description: Check that a branch's actual diff matches what its commit messages and any subagent report claim, before the commits leave the machine. Use before `git push` of a feature branch, before `gh pr create` or `gh pr merge`, after a subagent reports "committed N files", after an amend / rebase / force-push, or when a verification report's headline count looks off. Catches "commit log wrote but code didn't make it" accidents. Does NOT read the diff for correctness (that is a Code Reviewer's job) nor own gh / PR mechanics (github-contribution-workflow).
 allowed-tools: Bash(git show *) Bash(git diff *) Bash(git log *) Bash(git reflog *) Bash(git rev-parse *)
 ---
 

--- a/collaboration-skills/skills/session-to-meeting-log/SKILL.md
+++ b/collaboration-skills/skills/session-to-meeting-log/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: session-to-meeting-log
-description: Read a Claude Code session JSONL log and produce a clean timeline-style meeting log at `meetings/{YYYY-MM-DD}_{topic}.md`. Invoke when the user asks "turn this session into a meeting log", "archive today's discussion", "extract a meeting record from jsonl", or when wrapping up a working session before context window rolls.
+description: Consolidate a Claude Code session JSONL log into a summary-only meeting record under meetings/ (decisions, rejected alternatives, hand-offs, open questions). Use when the user asks to turn a session into a meeting log, archive today's discussion, or extract a record from a .jsonl file; or when a long session is wrapping up before its context rolls. Not for in-flight notes during a subagent task (agent-impl-notes-log) and not for extracting recurring patterns across logs (methodology-pattern-extractor).
 context: fork
 agent: general-purpose
 argument-hint: "[session-id-or-path] [topic]"

--- a/collaboration-skills/skills/spec-phase-orchestration/SKILL.md
+++ b/collaboration-skills/skills/spec-phase-orchestration/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: spec-phase-orchestration
-description: The pre-implementation document pipeline — 5 files + `meetings/` directory (README.md + docs/design.md + docs/foundations.md + docs/plan.md + docs/methodology.md + meetings/), section-by-section approval (§What before §How), prerequisite checklist with Unconfirmed / Resolved gates, "no implementation code before design.md and plan.md approved" rule. Invoke when deciding doc structure for a spec-first project, or when asked "which documents go in the spec phase".
+description: Run the spec-first document phase of a project and gate implementation on it. Use when starting a project that needs a spec before code, deciding which documents the spec phase produces and in what order, choosing whether a section may advance while a prerequisite is unconfirmed, judging whether implementation code may start yet, or when asked "design or foundations first", "which documents go in the spec phase", "can we code before plan.md is approved". Does NOT own where stray ideas are parked (backlog-routing-by-topic) nor the per-section review rounds (subagent-review-cycles).
 ---
 
 # Spec Phase Orchestration

--- a/collaboration-skills/skills/subagent-conflict-detection/SKILL.md
+++ b/collaboration-skills/skills/subagent-conflict-detection/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: subagent-conflict-detection
-description: 'Use before dispatching a subagent with `isolation:"worktree"`, or while another subagent is in flight, to avoid three dispatch hazards — file-scope overlap with an in-flight subagent, a stale dispatch base, and collisions with another live agent/session editing the same checkout or git-submodule path. Invoke when about to call the Agent tool with `isolation:"worktree"`; when another subagent is running; right after a merge or branch switch (verify the dispatch base first); or when another Claude session is editing a shared repo/submodule path.'
+description: 'Use before dispatching a subagent with `isolation:"worktree"`, or while another subagent is in flight, to avoid three dispatch hazards — file-scope overlap with an in-flight subagent, a stale dispatch base, and collisions with another live agent/session editing the same checkout or git-submodule path. Invoke when about to call the Agent tool with `isolation:"worktree"`; when another subagent is running; right after a merge or branch switch; or when another Claude session is editing a shared repo/submodule path. Does NOT cover PR / merge mechanics (github-contribution-workflow) or post-commit diff sanity (pr-diff-verification).'
 allowed-tools: Bash(git worktree list) Bash(git status *) Bash(git log *) Bash(git rev-parse *) Bash(git merge-base *)
 ---
 

--- a/collaboration-skills/skills/subagent-review-cycles/SKILL.md
+++ b/collaboration-skills/skills/subagent-review-cycles/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: subagent-review-cycles
-description: The Leader / Developer / Code-Reviewer triad pattern — Leader dispatches Developer for proposal → Code Reviewer for adversarial review (with WebSearch, no CLI) → Leader accepts/rejects with specific reasons → iterate up to `limit(N)` rounds. Round-1 cosmetic-grade fixes get inline-applied by Leader instead of consuming a round. Invoke when planning multi-round review on a document, dispatching a Code Reviewer subagent, or when asked "how many review rounds / what skills should the Code Reviewer carry".
+description: Structure a multi-round Leader / Developer / Code-Reviewer review of a document or code change. Use when planning how many review rounds to run, dispatching a Code Reviewer subagent and deciding which tools and review criteria it carries, adjudicating a reviewer's BLOCKER / MAJOR / MINOR findings, or when asked "how many review rounds", "may the Code Reviewer run CLI", "what counts as a rejection". Does NOT own the dispatch prompt's required elements (leader-developer-handoff-contract) nor pre-dispatch worktree conflict checks (subagent-conflict-detection).
 ---
 
 # Subagent Review Cycles


### PR DESCRIPTION
## Summary

- Rewrite the frontmatter `description` of 11 `collaboration-skills` skills to the reviewer's
  ready-made drafts from the phase-2 skill audit (`review/F-authoring.md`, `review/G-authoring.md`),
  per `CONSOLIDATED.md` §3. Description is Claude Code's sole routing signal, and the old versions
  were either full workflow summaries (no negative boundary) or missing trigger phrases the body
  actually requires.
- Body content is untouched — that's follow-up PR work. Only `frontmatter description` (plus one
  approved `argument-hint` addition) changed in this PR.
- `agent-impl-notes-log` also gets `argument-hint: "[topic]"` (pre-approved in the audit BRIEF).

## Skills changed (10 commits; `leader-developer-handoff-contract` needed no edit — see ledger)

subagent-review-cycles, subagent-conflict-detection, spec-phase-orchestration,
pr-diff-verification, github-contribution-workflow, session-to-meeting-log,
methodology-pattern-extractor, backlog-routing-by-topic, agent-impl-notes-log,
claude-skill-plugin-packaging.

`skill-authoring-patterns` description intentionally not touched (out of scope).
`claude-skill-plugin-packaging` keeps its name (settled policy).

## Verification

```
$ mise run check
OK — 2 plugins (26/12), catalog + counts + 3 README mirror(s) (README.zh-Hant.md/README.zh-Hans.md/README.ja.md) consistent.
BLOCKER 0 · MAJOR 0 · MINOR 7
```

Baseline on `origin/main` was `BLOCKER 0 · MAJOR 0 · MINOR 10`. The 3-MINOR drop is the
"description may summarize workflow" finding disappearing for `subagent-review-cycles`,
`backlog-routing-by-topic`, and `github-contribution-workflow` as a side effect of the rewrite.

Description lengths (all ≤ 800 char gate, well under):

```
agent-impl-notes-log               491
backlog-routing-by-topic           468
claude-skill-plugin-packaging      554
github-contribution-workflow       590
leader-developer-handoff-contract  557 (unchanged)
methodology-pattern-extractor      514
pr-diff-verification               551
session-to-meeting-log             507
spec-phase-orchestration           587
subagent-conflict-detection        636
subagent-review-cycles             563
```

```
$ git diff origin/main --stat
 collaboration-skills/skills/agent-impl-notes-log/SKILL.md          | 3 ++-
 collaboration-skills/skills/backlog-routing-by-topic/SKILL.md      | 2 +-
 collaboration-skills/skills/claude-skill-plugin-packaging/SKILL.md | 2 +-
 collaboration-skills/skills/github-contribution-workflow/SKILL.md  | 2 +-
 collaboration-skills/skills/methodology-pattern-extractor/SKILL.md | 2 +-
 collaboration-skills/skills/pr-diff-verification/SKILL.md          | 2 +-
 collaboration-skills/skills/session-to-meeting-log/SKILL.md        | 2 +-
 collaboration-skills/skills/spec-phase-orchestration/SKILL.md      | 2 +-
 collaboration-skills/skills/subagent-conflict-detection/SKILL.md   | 2 +-
 collaboration-skills/skills/subagent-review-cycles/SKILL.md        | 2 +-
 10 files changed, 11 insertions(+), 10 deletions(-)
```

Only these 10 `SKILL.md` frontmatter blocks changed. No README, no scripts, no other skill body.

## Deviations from the draft text (both logged in the ledger as FIXED_REWORDED)

1. **github-contribution-workflow** — the F-auth draft referenced `apple-public-repo-security`
   bare, but that skill lives in the `apple-dev-skills` plugin (a different plugin from this
   file's `collaboration-skills`). Per this catalog's cross-plugin-reference rule, changed to
   `apple-dev-skills:apple-public-repo-security`.
2. **agent-impl-notes-log** — the G-auth draft's "whenever ambiguity is hit mid-task" failed the
   gate's trigger-phrase check (`scripts/check-skills.py` requires `\bwhen\b` at a word boundary;
   "whenever" doesn't match). Changed "whenever" → "when". Confirmed this was the fix: MAJOR
   count went 1 → 0 after the reword.

## Ledger

Full item-by-item ledger (51 rows, includes SKIPPED body items explicitly deferred to a follow-up
PR, and N_A rows for frontmatter items already present on `main` from the prior MUST-fix PR #69):
`scratchpad/ledgers/C1.md` in the audit session's scratchpad.

# Ledger C1 — collaboration-skills description rewrite (phase-2 audit)

Scope: frontmatter `description` only for 11 collaboration-skills skills, per CONSOLIDATED.md §3
and review/F-authoring.md + review/G-authoring.md drafts. Body (SKILL.md content) changes deferred
to a follow-up PR — every non-description item below is SKIPPED for that reason.

| # | skill | item (short) | status | evidence (file:line after the change, or reason) |
|---|---|---|---|---|
| 1 | subagent-review-cycles | description 改寫（F-auth，≤600 chars） | FIXED | `collaboration-skills/skills/subagent-review-cycles/SKILL.md:3` — 563 chars, verbatim F-auth draft |
| 2 | subagent-review-cycles | :19 刪 persona 名（institution plugin 私有） | SKIPPED(body change, deferred to follow-up PR — this PR is description-only) | — |
| 3 | subagent-review-cycles | :96 regex 的 `Phase [0-9]+ Part` / `Packages/<target>/Sources/` 改通用 | SKIPPED(body, deferred) | — |
| 4 | subagent-review-cycles | :109 中文節名改英文並指向 `agent-impl-notes-log` | SKIPPED(body, deferred) | — |
| 5 | subagent-review-cycles | :40-47 round-1 cosmetic 判準改兩欄表 | SKIPPED(body, deferred) | — |
| 6 | leader-developer-handoff-contract | description 改寫（F-auth） | N_A (no change needed) | `collaboration-skills/skills/leader-developer-handoff-contract/SKILL.md:3` — already byte-identical to the F-auth draft on `origin/main` (b95c02f); left untouched, no commit for this file |
| 7 | leader-developer-handoff-contract | 模板 `## Constraints` 下加 base SHA 條件列 | SKIPPED(body, deferred) | — |
| 8 | leader-developer-handoff-contract | :104-110 範例的遊戲細節改通用驗收敘述 | SKIPPED(body, deferred) | — |
| 9 | subagent-conflict-detection | description 補否定邊界 | FIXED | `collaboration-skills/skills/subagent-conflict-detection/SKILL.md:3` — 636 chars; appended "Does NOT cover PR / merge mechanics (github-contribution-workflow) or post-commit diff sanity (pr-diff-verification)." and dropped "(verify the dispatch base first)" to offset length, per F-auth §3(a)'s own suggested trade-off |
| 10 | subagent-conflict-detection | :28 `git worktree list` 解析改 `--porcelain` | SKIPPED(body, deferred) | — |
| 11 | subagent-conflict-detection | :86「stash them first」改 WIP commit / `git stash push -u -m` | SKIPPED(body, deferred) | — |
| 12 | subagent-conflict-detection | :88 拆清 v2.1.208 cache / local-HEAD fallback | SKIPPED(body, deferred) | — |
| 13 | subagent-conflict-detection | :135 刪懸空的 `methodology.md §Anti-patterns` 引用 | SKIPPED(body, deferred) | — |
| 14 | subagent-conflict-detection | :141 pre-flight 清單改條件句 | SKIPPED(body, deferred) | — |
| 15 | subagent-conflict-detection | :59-76 `worktree.baseRef` 改表 | SKIPPED(body, deferred) | — |
| 16 | subagent-conflict-detection | :59-96 搬 `references/worktree-base-and-recovery.md` | SKIPPED(body, deferred) | — |
| 17 | subagent-conflict-detection | 唯讀 git `allowed-tools`（建議） | N_A (already present) | `collaboration-skills/skills/subagent-conflict-detection/SKILL.md:4` — `allowed-tools:` line with the read-only git subset already exists on `origin/main`; not part of this PR's description-only scope |
| 18 | spec-phase-orchestration | description 改寫（F-auth） | FIXED | `collaboration-skills/skills/spec-phase-orchestration/SKILL.md:3` — 587 chars, verbatim F-auth draft |
| 19 | spec-phase-orchestration | :67 刪「Swift」 | SKIPPED(body, deferred) | — |
| 20 | spec-phase-orchestration | :58-59 prerequisite 範例其中一則改非 Apple 情境 | SKIPPED(body, deferred) | — |
| 21 | spec-phase-orchestration | :81-86 Deviation 四情境改 `Project shape | Keep | Drop` 表 | SKIPPED(body, deferred) | — |
| 22 | pr-diff-verification | description 改寫（F-auth） | FIXED | `collaboration-skills/skills/pr-diff-verification/SKILL.md:3` — 551 chars, verbatim F-auth draft |
| 23 | pr-diff-verification | :13 與 github-contribution-workflow 的 merge 前檢查對齊 | SKIPPED(body, deferred) | — |
| 24 | pr-diff-verification | :53 節名「When the rule fired in this project」改「Failure modes seen in practice」 | SKIPPED(body, deferred) | — |
| 25 | pr-diff-verification | :78-79「fifth occurrence」改「recurs often enough…」 | SKIPPED(body, deferred) | — |
| 26 | pr-diff-verification | :41-51 原因/修復兩份清單改 `Symptom | Likely cause | Recovery` 表 | SKIPPED(body, deferred) | — |
| 27 | pr-diff-verification | 唯讀 git `allowed-tools`（建議） | N_A (already present) | `collaboration-skills/skills/pr-diff-verification/SKILL.md:4` — `allowed-tools:` line already exists on `origin/main` |
| 28 | github-contribution-workflow | description 改寫（F-auth，≈575 chars，795→575；目前距 DESC_MAX 只剩 5 字元） | FIXED_REWORDED | `collaboration-skills/skills/github-contribution-workflow/SKILL.md:3` — 590 chars (draft ≈575, +15 from the fix below). Reason for reword: the F-auth draft referenced `apple-public-repo-security` bare, but that skill lives in `apple-dev-skills`, a different plugin; per BRIEF §5 cross-plugin references need the `<plugin>:<skill>` prefix, so it was changed to `apple-dev-skills:apple-public-repo-security`. All other skill references in the same sentence (`pr-diff-verification`, `subagent-conflict-detection`, `claude-skill-plugin-packaging`) are same-plugin and kept bare, matching the draft. |
| 29 | github-contribution-workflow | :52「the agreed `Co-Authored-By:` trailer」改「the harness's … (Claude Code adds it by default)」 | SKIPPED(body, deferred) | — |
| 30 | github-contribution-workflow | :51「a "Validate PR title" check」改「a PR-title lint check」 | SKIPPED(body, deferred) | — |
| 31 | github-contribution-workflow | :53 主動改用 `gh pr checks --watch` | SKIPPED(body, deferred) | — |
| 32 | session-to-meeting-log | description 改寫（G-auth） | FIXED | `collaboration-skills/skills/session-to-meeting-log/SKILL.md:3` — 507 chars, verbatim G-auth draft |
| 33 | session-to-meeting-log | :19 Inputs 補「subagent logs live under `<sessionId>/subagents/`; skip unless the user asks」 | SKIPPED(body, deferred) | — |
| 34 | session-to-meeting-log | :90 補 `isSidechain` / `isMeta` 旗標 | SKIPPED(body, deferred) | — |
| 35 | session-to-meeting-log | `context: fork` + `argument-hint "[session-id] [topic]"`（建議） | N_A (already present) | `collaboration-skills/skills/session-to-meeting-log/SKILL.md:4-6` — `context: fork`, `agent: general-purpose`, `argument-hint: "[session-id-or-path] [topic]"` already on `origin/main` |
| 36 | methodology-pattern-extractor | description 改寫（G-auth） | FIXED | `collaboration-skills/skills/methodology-pattern-extractor/SKILL.md:3` — 514 chars, verbatim G-auth draft |
| 37 | methodology-pattern-extractor | :66 §Anti-patterns 指涉寫明是 `docs/methodology.md §Anti-patterns`，三種門檻改表 | SKIPPED(body, deferred) | — |
| 38 | methodology-pattern-extractor | `context: fork`（建議） | N_A (already present) | `collaboration-skills/skills/methodology-pattern-extractor/SKILL.md:4-6` — `context: fork`, `agent: general-purpose`, `argument-hint: "[topic]"` already on `origin/main` |
| 39 | backlog-routing-by-topic | description 改寫（G-auth） | FIXED | `collaboration-skills/skills/backlog-routing-by-topic/SKILL.md:3` — 468 chars, verbatim G-auth draft |
| 40 | backlog-routing-by-topic | :16-22 決策表尾加 tie-break 列 | SKIPPED(body, deferred) | — |
| 41 | agent-impl-notes-log | description 改寫（G-auth） | FIXED_REWORDED | `collaboration-skills/skills/agent-impl-notes-log/SKILL.md:3` — 491 chars. Reason for reword: the G-auth draft's "whenever ambiguity is hit mid-task" failed `scripts/check-skills.py`'s trigger-phrase gate (`\b(when|use for|query|invoke)\b`, word-boundary — "whenever" doesn't match "when" at a word boundary). Changed "whenever" → "when a" is not what was done; actual minimal fix: "whenever" → "when". Verified: `mise run check` MAJOR count 1→0 after the reword. |
| 42 | agent-impl-notes-log | :89 補「or preload it via the agent definition's `skills:` field」 | SKIPPED(body, deferred) | — |
| 43 | agent-impl-notes-log | `argument-hint "[topic]"`（可選，BRIEF 已核准新增） | FIXED | `collaboration-skills/skills/agent-impl-notes-log/SKILL.md:4` — `argument-hint: "[topic]"` added |
| 44 | agent-impl-notes-log | 注意：本 skill 絕不可設 `disable-model-invocation: true` | N_A (no-op honored) | No `disable-model-invocation` field was added anywhere in this PR, consistent with this constraint |
| 45 | claude-skill-plugin-packaging | description 改寫（G-auth） | FIXED | `collaboration-skills/skills/claude-skill-plugin-packaging/SKILL.md:3` — 554 chars, verbatim G-auth draft |
| 46 | claude-skill-plugin-packaging | :136「`git commit -a` skips new files」刪或併入 Verification | SKIPPED(body, deferred) | — |
| 47 | claude-skill-plugin-packaging | :138 token cost 改指向 `skill-authoring-patterns §listing budget` | SKIPPED(body, deferred) | — |
| 48 | claude-skill-plugin-packaging | :32-34 superpowers submodule 軼事去掉括號句 | SKIPPED(body, deferred) | — |
| 49 | claude-skill-plugin-packaging | :71-112 三種安裝模型段首加決策表 | SKIPPED(body, deferred) | — |
| 50 | claude-skill-plugin-packaging | Gotchas 補 reserved marketplace names | SKIPPED(body, deferred) | — |
| 51 | claude-skill-plugin-packaging | 名稱維持不變（已拍板） | N_A (confirmed unchanged) | `collaboration-skills/skills/claude-skill-plugin-packaging/SKILL.md:2` — `name: claude-skill-plugin-packaging` unchanged; directory name unchanged |

## Gate deltas

- Baseline (`origin/main`, before this PR): `BLOCKER 0 · MAJOR 0 · MINOR 10`.
- After all 11 description edits: `BLOCKER 0 · MAJOR 0 · MINOR 7`.
- The "description may summarize workflow" MINOR disappeared for 3 of the assigned skills as a
  side effect of the rewrite: `subagent-review-cycles`, `backlog-routing-by-topic`,
  `github-contribution-workflow`. (Not a task item — recorded per BRIEF instruction.)
- Remaining 7 MINORs are all out of this PR's scope (apple-dev-skills descriptions, and the
  `claude-skill-plugin-packaging` name-reserved-word item, which is policy-deferred per BRIEF/CONSOLIDATED
  §5.0: "可保留（Claude Code plugin 發佈路徑）").
- One self-caught regression during work: amending `agent-impl-notes-log`'s description to fix
  the trigger-phrase MAJOR (item 41) was first `git commit --amend`ed onto the wrong (most-recent)
  commit by mistake, mixing two skills into one commit. Caught before push; fixed via
  `git reset --soft` to `origin/main` and recommitting each of the 10 changed files individually.
  Final `git log` and `git diff origin/main --stat` (pasted in the report) confirm one commit per
  skill and no unintended files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
