### PR TITLE
fix(gate): stop flagging routing arrows as workflow summaries

### DIFF
--- a/scripts/check-skills.py
+++ b/scripts/check-skills.py
@@ -118,8 +118,14 @@ for name, (plugin, d) in skills.items():
     # --- prose triggers that official `paths:` could replace
     m = PATHS_HINT.search(desc + "\n" + body[:1500])
     if m and "paths" not in fm: add("MINOR", name, "prose file-trigger; candidate for paths:", m.group(0))
-    # --- description summarizing workflow (heuristic: numbered steps / arrows)
-    if re.search(r"(→.*→|Step ?1|\b1\)\s.*\b2\)\s)", desc): add("MINOR", name, "description may summarize workflow", desc[:80])
+    # --- description summarizing workflow (heuristic: numbered steps / arrows).
+    # An arrow whose right-hand side is a skill name (`X → other-skill`, `X → plugin:other-skill`)
+    # is a routing pointer / negative boundary, which the doctrine allows; only arrows that
+    # chain non-skill words (`archive → export → upload`) count as a workflow summary.
+    routing = re.compile(r"→\s*`?(?:[a-z0-9-]+:)?([a-z0-9-]+)`?")
+    step_arrows = sum(1 for m in re.finditer("→", desc)
+                      if not (routing.match(desc, m.start()) and routing.match(desc, m.start()).group(1) in skills))
+    if step_arrows >= 2 or re.search(r"(Step ?1|\b1\)\s.*\b2\)\s)", desc): add("MINOR", name, "description may summarize workflow", desc[:80])
 
 sev_order = {"BLOCKER":0,"MAJOR":1,"MINOR":2}
 findings.sort(key=lambda f:(sev_order[f[0]], f[1], f[2]))

--- a/scripts/check-skills.py
+++ b/scripts/check-skills.py
@@ -122,9 +122,12 @@ for name, (plugin, d) in skills.items():
     # An arrow whose right-hand side is a skill name (`X → other-skill`, `X → plugin:other-skill`)
     # is a routing pointer / negative boundary, which the doctrine allows; only arrows that
     # chain non-skill words (`archive → export → upload`) count as a workflow summary.
-    routing = re.compile(r"→\s*`?(?:[a-z0-9-]+:)?([a-z0-9-]+)`?")
-    step_arrows = sum(1 for m in re.finditer("→", desc)
-                      if not (routing.match(desc, m.start()) and routing.match(desc, m.start()).group(1) in skills))
+    # A `plugin:skill` target (any prefix, incl. aggregated externals) is routing by form alone.
+    routing = re.compile(r"→\s*`?(?:(?P<prefix>[a-z0-9-]+):)?(?P<skill>[a-z0-9-]+)`?")
+    def is_routing(m):
+        r = routing.match(desc, m.start())
+        return bool(r) and (r.group("prefix") is not None or r.group("skill") in skills)
+    step_arrows = sum(1 for m in re.finditer("→", desc) if not is_routing(m))
     if step_arrows >= 2 or re.search(r"(Step ?1|\b1\)\s.*\b2\)\s)", desc): add("MINOR", name, "description may summarize workflow", desc[:80])
 
 sev_order = {"BLOCKER":0,"MAJOR":1,"MINOR":2}


### PR DESCRIPTION
## What

`scripts/check-skills.py`: the "description may summarize workflow" MINOR fired on any description containing two `→`. After PR #70/#71 rewrote descriptions to the official doctrine, all 7 remaining hits were negative-boundary routing pointers (`Does NOT own X → other-skill, or Y → other-skill`), which the doctrine explicitly allows. Two independent acceptance sweeps (PR #70, #71) judged each hit sentence-by-sentence as a false positive.

## Change

An arrow whose right-hand side is a catalog skill name (bare or `plugin:skill`) is a routing pointer and no longer counts; only arrows chaining non-skill words count, and two of those still flag.

## Verification

- `mise run check`: `OK — 2 plugins`, `BLOCKER 0 · MAJOR 0 · MINOR 1` (only the `claude-skill-plugin-packaging` reserved-word note — the phase-2 target state).
- Negative test: injecting `(archive → export → upload)` into one description raises `MINOR 2` with the workflow rule on that skill; reverted before commit.

Awaiting user review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)