### PR TITLE
refactor(apple-dev-skills): move long samples, scripts and war stories into references/ and scripts/ (8 skills) + D10

### DIFF
--- a/apple-dev-skills/skills/ai-translated-localization/SKILL.md
+++ b/apple-dev-skills/skills/ai-translated-localization/SKILL.md
@@ -25,7 +25,7 @@ description: 'Localization scope and AI-translation execution for Apple-platform
 | Locale | Code | Notes |
 |---|---|---|
 | English | `en` | Catalog `sourceLanguage`; translation source for the fan-out |
-| Traditional Chinese | `zh-Hant` | Primary language — author-written alongside `en`, never AI-translated |
+| Traditional Chinese | `zh-Hant` | Primary language (author's native locale in the origin project; substitute yours) — author-written alongside `en`, never AI-translated |
 | Japanese | `ja` | Largest adjacent market outside the Chinese sphere |
 | Simplified Chinese | `zh-Hans` | Converted from `zh-Hant` + Mainland phrasing review |
 | Spanish | `es` | World's second largest native-speaker base |
@@ -58,7 +58,7 @@ description: 'Localization scope and AI-translation execution for Apple-platform
 - 7 locales cover most of the global market while remaining a polish scope a solo developer can sustain.
 - AI translation quality for App UI strings (short, clear context) is at commercial level; long marketing copy is still recommended for human review.
 - xcstrings JSON structure is naturally friendly to AI / diff / version control.
-- `zh-Hant` as primary reflects the author's native-language accuracy; `en` is the
+- Primary = the author's native locale (`zh-Hant` in the origin project); `en` is the
   fan-out source because translator competence is broader from English (see Field notes).
 
 ## Deviation considerations
@@ -75,7 +75,7 @@ Use when actually performing a translation pass. The flow is **source-pair seed 
 ### Step 1 — Seed source pair (en + zh-Hant)
 
 - Source language for translation **must be English** (broader translator competence across all target locales than zh-Hant).
-- Authors write English first; zh-Hant is the project's primary native locale and is hand-written in parallel — *not* AI-translated from English. Both are written by the author with intent; the other 5 locales fan out from `en`.
+- Authors write English first; the primary locale (the author's native locale — `zh-Hant` in the origin project) is hand-written in parallel — *not* AI-translated from English. Both are written by the author with intent; the other 5 locales fan out from `en`.
 - Each new key lands in xcstrings with **at minimum** `en` + `zh-Hant` populated and `extractionState: manual`.
 - Other 5 locales (`ja`, `zh-Hans`, `es`, `th`, `ko`) start either absent or with the placeholder string `<TRANSLATE>` so the fan-out pass can find them with a single grep.
 
@@ -158,6 +158,6 @@ For the xcstrings JSON schema (including the `"version"` field and plural variat
 
 Real translation passes have surfaced these recurring decisions:
 
-- **Source = `en`, primary = `zh-Hant`** — both written by author. The other 5 fan out from `en` because translator competence is broader from English than from Chinese for `th` / `ko` / `es`.
+- **Source = `en`, primary = the author's native locale (`zh-Hant` in the origin project)** — both written by author. The other 5 fan out from `en` because translator competence is broader from English than from Chinese for `th` / `ko` / `es`.
 - **Glossary beats per-string correctness** — visual consistency across screens matters more than the perfect translation of any single string.
 - **5 locales in one pass is the sweet spot** — fewer wastes the per-pass setup; more risks AI fatigue degradation on the last locales. 1 commit per locale keeps PR review tractable.

--- a/apple-dev-skills/skills/ai-translated-localization/SKILL.md
+++ b/apple-dev-skills/skills/ai-translated-localization/SKILL.md
@@ -93,34 +93,9 @@ After translation, set that locale's `stringUnit.state` to `translated` — `tra
 
 ### Step 3 — Tricky-case review (locale-specific gotchas)
 
-Lessons captured from real translation passes. Apply these as a second-pass review after the bulk AI fan-out.
-
-**Japanese (`ja`):**
-- Prefer **semantic** over literal. "Pencil" (notes / candidate input) → メモ, NOT 鉛筆. The literal kanji confuses Japanese users; the semantic UI term is correct.
-- Drop politeness markers (`です` / `ます`) in button labels and short UI strings — Japanese app UIs are typically declarative/imperative, not polite.
-- 漢字 vs かな: prefer 漢字 for nouns, ひらがな for particles, カタカナ for loanwords. Don't romanize unless the source is romanized.
-
-**Thai (`th`):**
-- **No politeness markers** (`ครับ` / `ค่ะ`) in UI strings unless the app's voice is deliberately conversational. Calm/neutral apps drop them.
-- Compound nouns: "leaderboard" → กระดานผู้นำ (no single-word equivalent). Accept the multi-word form.
-- Thai has **no word boundaries** — sentence length affects line break behavior. UI strings >24 chars need spot-check rendering.
-
-**Korean (`ko`):**
-- Use **informal-formal** style (해요체) for app UI by default — neither too casual (반말) nor overly formal (합쇼체).
-- 한자 should be avoided unless disambiguation is needed; pure 한글 is the modern default.
-- Postpositions (조사) change based on preceding character's final consonant; AI usually handles this, but spot-check `을/를`, `이/가`, `은/는`.
-
-**Spanish (`es`):**
-- Default to **neutral Latin American Spanish** unless the project explicitly targets Spain (`es-ES`). Avoid `vosotros` forms; use `ustedes`.
-- Gender agreement: nouns referring to the user (e.g., "completed") need gender-neutral phrasing if the user's gender is unknown.
-
-**Simplified Chinese (`zh-Hans`):**
-- Convert from `zh-Hant` (not from `en`) for terminology consistency; the AI still needs to substitute Mainland-preferred terms (软件 vs 軟體, 移动 vs 行動, 视频 vs 影片).
-- DON'T just run `tongwen` character conversion — phrase choice differs (e.g., zh-Hant 「設定」 → zh-Hans 「设置」, not 「設定 → 设定」).
-
-**English (`en`):**
-- US English by default. UK spellings (`colour`, `centre`, `analyse`) only if explicitly targeted.
-- Sentence case for buttons and UI; Title Case only for proper nouns and app section headers.
+Lessons captured from real translation passes, to apply as a second-pass review after the bulk
+AI fan-out — per-locale gotchas for `ja`, `th`, `ko`, `es`, `zh-Hans`, and `en` are in
+`references/locale-gotchas.md`.
 
 ### Step 4 — Visual / glossary consistency
 
@@ -150,28 +125,9 @@ Verification gates before merging a translation pass:
 
 If the repo has a per-key completeness gate (recommended, see Step 5), it checks **per-key
 locale completeness**: every key present in a catalog has all declared locales, no `<TRANSLATE>`.
-Two things it does **NOT** catch — both have shipped English-fallback bugs in real projects:
-
-1. **A required key being *absent* entirely.** The gate validates keys that
-   exist; it cannot know a newly-activated capability *needs* a key that no
-   catalog has. When an app adopts a shared feature (audio settings, ATT primer,
-   reminders), its catalog can ship missing keys → the UI renders raw dotted keys
-   or English literals, and the gate stays green. After wiring any shared-UI
-   capability into a new app, **diff its catalog's key set against an app that
-   already has the feature** (real-world: a new game adopted shared audio-settings
-   UI without copying the required catalog keys; another adopted an ATT primer
-   and the raw dotted keys appeared at runtime — both passed the gate).
-2. **Multi-app repos sharing UI modules only:** a key referenced from shared UI code
-   but absent from an app's catalog. Per-key completeness alone will NOT catch this
-   — the gate only validates keys that already exist in a catalog, so a key
-   referenced from a shared UI module that the app's own catalog never declares
-   renders raw at runtime while the gate stays green. **Build a shared-code
-   dotted-key gate:** every dotted-namespace key (e.g. `leave.game.close`,
-   `att.primer.title`) referenced from a shared UI module (SharedUI / SettingsUI /
-   any shared UI module) must exist in **every** app catalog or CI fails. Scope it
-   to *dotted* keys to avoid app-conditional English-phrase false positives —
-   English-phrase shared keys are a separate, harder case (no dotted namespace to
-   anchor on; track them with a dedicated audit rather than this gate).
+For the two blind spots it does **NOT** catch (a required key being absent entirely, and
+multi-app repos sharing UI modules only) — both have shipped English-fallback bugs in real
+projects — read `references/l10n-gates.md`.
 
 ### xcstrings editing footgun
 
@@ -184,10 +140,7 @@ buries the real change. Splicing keeps a clean, reviewable diff (real example:
 
 ### Tooling notes
 
-- xcstrings is JSON; parse with any JSON library. Schema: `{"version": "1.0", "sourceLanguage": "en", "strings": {<key>: {"localizations": {<locale>: {"stringUnit": {"state": "translated", "value": "..."}}}}}}`. The top-level `"version"` field auto-bumps to `1.1` when Xcode 26's type-safe symbol generation or AI-generated comments touch the catalog — preserve it verbatim when splicing (see the splice footgun above).
-- Plural variations use `{"variations": {"plural": {<cldr-form>: {"stringUnit": {...}}}}}` instead of a single `stringUnit`.
-- When fanning out via an LLM, send a single key + source + glossary in the prompt; don't batch hundreds at once (latency wins less than accuracy loses).
-- For ASC metadata (App Store description, keywords, "what's new"), use the **same flow** but route to the ASC API endpoints rather than xcstrings. The translation principles (length budget, register, gotchas) apply identically.
+For the xcstrings JSON schema (including the `"version"` field and plural variations) and LLM fan-out / ASC-metadata tooling notes, read `references/xcstrings-format.md`.
 
 ## Verification checklist
 

--- a/apple-dev-skills/skills/ai-translated-localization/references/l10n-gates.md
+++ b/apple-dev-skills/skills/ai-translated-localization/references/l10n-gates.md
@@ -1,0 +1,28 @@
+# L10n Gate Scope And Blind Spots
+
+### L10n gate scope — and its two blind spots
+
+If the repo has a per-key completeness gate (recommended, see Step 5), it checks **per-key
+locale completeness**: every key present in a catalog has all declared locales, no `<TRANSLATE>`.
+Two things it does **NOT** catch — both have shipped English-fallback bugs in real projects:
+
+1. **A required key being *absent* entirely.** The gate validates keys that
+   exist; it cannot know a newly-activated capability *needs* a key that no
+   catalog has. When an app adopts a shared feature (audio settings, ATT primer,
+   reminders), its catalog can ship missing keys → the UI renders raw dotted keys
+   or English literals, and the gate stays green. After wiring any shared-UI
+   capability into a new app, **diff its catalog's key set against an app that
+   already has the feature** (real-world: a new game adopted shared audio-settings
+   UI without copying the required catalog keys; another adopted an ATT primer
+   and the raw dotted keys appeared at runtime — both passed the gate).
+2. **Multi-app repos sharing UI modules only:** a key referenced from shared UI code
+   but absent from an app's catalog. Per-key completeness alone will NOT catch this
+   — the gate only validates keys that already exist in a catalog, so a key
+   referenced from a shared UI module that the app's own catalog never declares
+   renders raw at runtime while the gate stays green. **Build a shared-code
+   dotted-key gate:** every dotted-namespace key (e.g. `leave.game.close`,
+   `att.primer.title`) referenced from a shared UI module (SharedUI / SettingsUI /
+   any shared UI module) must exist in **every** app catalog or CI fails. Scope it
+   to *dotted* keys to avoid app-conditional English-phrase false positives —
+   English-phrase shared keys are a separate, harder case (no dotted namespace to
+   anchor on; track them with a dedicated audit rather than this gate).

--- a/apple-dev-skills/skills/ai-translated-localization/references/locale-gotchas.md
+++ b/apple-dev-skills/skills/ai-translated-localization/references/locale-gotchas.md
@@ -1,0 +1,32 @@
+# Locale Gotchas
+
+### Step 3 — Tricky-case review (locale-specific gotchas)
+
+Lessons captured from real translation passes. Apply these as a second-pass review after the bulk AI fan-out.
+
+**Japanese (`ja`):**
+- Prefer **semantic** over literal. "Pencil" (notes / candidate input) → メモ, NOT 鉛筆. The literal kanji confuses Japanese users; the semantic UI term is correct.
+- Drop politeness markers (`です` / `ます`) in button labels and short UI strings — Japanese app UIs are typically declarative/imperative, not polite.
+- 漢字 vs かな: prefer 漢字 for nouns, ひらがな for particles, カタカナ for loanwords. Don't romanize unless the source is romanized.
+
+**Thai (`th`):**
+- **No politeness markers** (`ครับ` / `ค่ะ`) in UI strings unless the app's voice is deliberately conversational. Calm/neutral apps drop them.
+- Compound nouns: "leaderboard" → กระดานผู้นำ (no single-word equivalent). Accept the multi-word form.
+- Thai has **no word boundaries** — sentence length affects line break behavior. UI strings >24 chars need spot-check rendering.
+
+**Korean (`ko`):**
+- Use **informal-formal** style (해요체) for app UI by default — neither too casual (반말) nor overly formal (합쇼체).
+- 한자 should be avoided unless disambiguation is needed; pure 한글 is the modern default.
+- Postpositions (조사) change based on preceding character's final consonant; AI usually handles this, but spot-check `을/를`, `이/가`, `은/는`.
+
+**Spanish (`es`):**
+- Default to **neutral Latin American Spanish** unless the project explicitly targets Spain (`es-ES`). Avoid `vosotros` forms; use `ustedes`.
+- Gender agreement: nouns referring to the user (e.g., "completed") need gender-neutral phrasing if the user's gender is unknown.
+
+**Simplified Chinese (`zh-Hans`):**
+- Convert from `zh-Hant` (not from `en`) for terminology consistency; the AI still needs to substitute Mainland-preferred terms (软件 vs 軟體, 移动 vs 行動, 视频 vs 影片).
+- DON'T just run `tongwen` character conversion — phrase choice differs (e.g., zh-Hant 「設定」 → zh-Hans 「设置」, not 「設定 → 设定」).
+
+**English (`en`):**
+- US English by default. UK spellings (`colour`, `centre`, `analyse`) only if explicitly targeted.
+- Sentence case for buttons and UI; Title Case only for proper nouns and app section headers.

--- a/apple-dev-skills/skills/ai-translated-localization/references/xcstrings-format.md
+++ b/apple-dev-skills/skills/ai-translated-localization/references/xcstrings-format.md
@@ -1,0 +1,8 @@
+# Xcstrings Format And Tooling Notes
+
+### Tooling notes
+
+- xcstrings is JSON; parse with any JSON library. Schema: `{"version": "1.0", "sourceLanguage": "en", "strings": {<key>: {"localizations": {<locale>: {"stringUnit": {"state": "translated", "value": "..."}}}}}}`. The top-level `"version"` field auto-bumps to `1.1` when Xcode 26's type-safe symbol generation or AI-generated comments touch the catalog — preserve it verbatim when splicing (see the splice footgun above).
+- Plural variations use `{"variations": {"plural": {<cldr-form>: {"stringUnit": {...}}}}}` instead of a single `stringUnit`.
+- When fanning out via an LLM, send a single key + source + glossary in the prompt; don't batch hundreds at once (latency wins less than accuracy loses).
+- For ASC metadata (App Store description, keywords, "what's new"), use the **same flow** but route to the ASC API endpoints rather than xcstrings. The translation principles (length budget, register, gotchas) apply identically.

--- a/apple-dev-skills/skills/asc-api-automation/SKILL.md
+++ b/apple-dev-skills/skills/asc-api-automation/SKILL.md
@@ -42,38 +42,7 @@ ASC_KEY_PATH=secrets/AuthKey_2X9R4HXF34.p8
 
 Claims (verified against Apple's *Generating tokens for API requests*, 2026-07): header `alg: ES256` (the only accepted algorithm), `kid`, `typ: JWT`; payload `iss` (**Issuer ID**, the UUID from Users and Access → Integrations — not your Team ID), `iat`, `exp` (invalid if more than 20 minutes ahead — **exception**: a token carrying `scope` and restricted to GET requests on allow-listed resources can live up to 6 months, per Apple's *Determine the Appropriate Token Lifetime*), `aud: "appstoreconnect-v1"`, optional `scope` (array of allowed requests like `"GET /v1/apps"` — pin single-purpose tokens to single endpoints).
 
-`scripts/mint-asc-token.swift`:
-
-```swift
-#!/usr/bin/env swift
-import CryptoKit
-import Foundation
-
-let env = ProcessInfo.processInfo.environment
-guard let keyID = env["ASC_KEY_ID"], let issuerID = env["ASC_ISSUER_ID"],
-      let keyPath = env["ASC_KEY_PATH"] else {
-    FileHandle.standardError.write(Data("Set ASC_KEY_ID / ASC_ISSUER_ID / ASC_KEY_PATH (source secrets/.env)\n".utf8))
-    exit(1)
-}
-
-func b64url(_ data: Data) -> String {
-    data.base64EncodedString()
-        .replacingOccurrences(of: "+", with: "-")
-        .replacingOccurrences(of: "/", with: "_")
-        .replacingOccurrences(of: "=", with: "")
-}
-
-let now = Int(Date().timeIntervalSince1970)
-let header = #"{"alg":"ES256","kid":"\#(keyID)","typ":"JWT"}"#
-// Apple rejects exp > 20 min ahead; 10 min leaves slack for clock skew.
-let payload = #"{"iss":"\#(issuerID)","iat":\#(now),"exp":\#(now + 600),"aud":"appstoreconnect-v1"}"#
-let signingInput = b64url(Data(header.utf8)) + "." + b64url(Data(payload.utf8))
-
-let pem = try String(contentsOfFile: keyPath, encoding: .utf8)
-let key = try P256.Signing.PrivateKey(pemRepresentation: pem)
-let signature = try key.signature(for: Data(signingInput.utf8))  // ECDSA + SHA-256 = ES256
-print(signingInput + "." + b64url(signature.rawRepresentation))  // rawRepresentation = r‖s, the JWT wire format
-```
+The script is `scripts/mint-asc-token.swift` (CryptoKit, zero dependencies).
 
 ```bash
 source secrets/.env
@@ -122,30 +91,9 @@ The `POST reviewSubmissions` → `POST reviewSubmissionItems` → `PATCH submitt
 
 The three prerequisites above are gaps in an otherwise-scriptable flow. These are different:
 Apple publishes no REST resource for them at all, so no amount of scripting closes the gap —
-budget a manual, one-time (or rarely-repeated) click in the ASC web UI.
-
-- **Verified ✓ — Agreements, Tax, and Banking (including accepting the Paid Apps Agreement).**
-  Apple's App Store Connect API topic index (`developer.apple.com/tutorials/data/documentation/AppStoreConnectAPI.md`,
-  checked 2026-09) lists every automatable area — App Store, TestFlight, Game Center,
-  Provisioning, Xcode Cloud, Webhooks, Reporting, Users and Access, Alternative App
-  Distribution — and "Agreements, Tax, and Banking" is absent from all of them; no
-  `agreements`/`taxForms`/`bankAccounts`-shaped resource exists anywhere in the reference.
-  ASC Help's *Schedule price changes for apps* page confirms the practical consequence for
-  this skill's pricing prerequisite above: "If you've accepted the Paid Apps Agreement and
-  submitted your app for review, you can schedule price changes for your app" — the
-  Agreement is accepted only in ASC's *Manage Agreements* section, by the Account Holder, in
-  the browser. This is the actual gate behind the "app pricing must be set first" prerequisite
-  above, not a scriptable pricing endpoint being missing (as of 2026, `POST /v1/appPriceSchedules`
-  does exist for pricing itself — but it 404s/403s until the Agreement is accepted, and the
-  Agreement has no API path).
-- **Verified ✓ — App promo codes (whole-app free-download codes, Apps → \<App\> → Promo Codes).**
-  ASC Help's *Request and manage promo codes* page (`developer.apple.com/help/app-store-connect/offer-promo-codes/request-and-manage-promo-codes`)
-  documents only the web click-path ("In Apps, select the app you want to view. In the
-  sidebar, click Promo Codes. The Promo Code page opens with Generate selected.") with no
-  REST alternative mentioned; no `promoCodes`-shaped resource appears in the API topic index
-  either. Don't confuse this with **Subscription Offer Codes**, which do have a documented API
-  (`POST /v1/subscriptionOfferCodeCustomCodes` and siblings under *Subscription Offer Codes*)
-  — the API gap is specific to whole-app promo codes, not offer codes in general.
+budget a manual, one-time (or rarely-repeated) click in the ASC web UI. For the two verified
+cases (Agreements/Tax/Banking, and whole-app Promo Codes vs Subscription Offer Codes) and their
+sourcing, read `references/no-api-steps.md`.
 
 ## Release automation: SemVer, changelog, and explicit releaseType
 

--- a/apple-dev-skills/skills/asc-api-automation/references/no-api-steps.md
+++ b/apple-dev-skills/skills/asc-api-automation/references/no-api-steps.md
@@ -1,0 +1,30 @@
+# Steps With No ASC API At All
+
+## Steps with no ASC API at all — must be clicked by a human
+
+The three prerequisites above are gaps in an otherwise-scriptable flow. These are different:
+Apple publishes no REST resource for them at all, so no amount of scripting closes the gap —
+budget a manual, one-time (or rarely-repeated) click in the ASC web UI.
+
+- **Verified ✓ — Agreements, Tax, and Banking (including accepting the Paid Apps Agreement).**
+  Apple's App Store Connect API topic index (`developer.apple.com/tutorials/data/documentation/AppStoreConnectAPI.md`,
+  checked 2026-09) lists every automatable area — App Store, TestFlight, Game Center,
+  Provisioning, Xcode Cloud, Webhooks, Reporting, Users and Access, Alternative App
+  Distribution — and "Agreements, Tax, and Banking" is absent from all of them; no
+  `agreements`/`taxForms`/`bankAccounts`-shaped resource exists anywhere in the reference.
+  ASC Help's *Schedule price changes for apps* page confirms the practical consequence for
+  this skill's pricing prerequisite above: "If you've accepted the Paid Apps Agreement and
+  submitted your app for review, you can schedule price changes for your app" — the
+  Agreement is accepted only in ASC's *Manage Agreements* section, by the Account Holder, in
+  the browser. This is the actual gate behind the "app pricing must be set first" prerequisite
+  above, not a scriptable pricing endpoint being missing (as of 2026, `POST /v1/appPriceSchedules`
+  does exist for pricing itself — but it 404s/403s until the Agreement is accepted, and the
+  Agreement has no API path).
+- **Verified ✓ — App promo codes (whole-app free-download codes, Apps → \<App\> → Promo Codes).**
+  ASC Help's *Request and manage promo codes* page (`developer.apple.com/help/app-store-connect/offer-promo-codes/request-and-manage-promo-codes`)
+  documents only the web click-path ("In Apps, select the app you want to view. In the
+  sidebar, click Promo Codes. The Promo Code page opens with Generate selected.") with no
+  REST alternative mentioned; no `promoCodes`-shaped resource appears in the API topic index
+  either. Don't confuse this with **Subscription Offer Codes**, which do have a documented API
+  (`POST /v1/subscriptionOfferCodeCustomCodes` and siblings under *Subscription Offer Codes*)
+  — the API gap is specific to whole-app promo codes, not offer codes in general.

--- a/apple-dev-skills/skills/asc-api-automation/scripts/mint-asc-token.swift
+++ b/apple-dev-skills/skills/asc-api-automation/scripts/mint-asc-token.swift
@@ -1,0 +1,46 @@
+#!/usr/bin/env swift
+//
+// mint-asc-token.swift — mint a short-lived App Store Connect API JWT.
+//
+// Usage:
+//   source secrets/.env   # sets ASC_KEY_ID / ASC_ISSUER_ID / ASC_KEY_PATH
+//   ASC_TOKEN=$(swift scripts/mint-asc-token.swift)
+//   curl -sf -H "Authorization: Bearer $ASC_TOKEN" "https://api.appstoreconnect.apple.com/v1/apps?limit=200"
+//
+// Required env (from secrets/.env, gitignored — see build-time-secret-injection):
+//   ASC_KEY_ID     — the API key's Key ID (Users and Access → Integrations)
+//   ASC_ISSUER_ID  — the Issuer ID (UUID, not your Team ID)
+//   ASC_KEY_PATH   — path to the downloaded AuthKey_<ASC_KEY_ID>.p8
+//
+// Mint fresh per run; a job that outlives the token re-mints instead of
+// extending `exp`. See ../SKILL.md "Mint the token" for the claims this
+// token carries and why (source: Apple's *Generating tokens for API
+// requests*, 2026-07).
+//
+import CryptoKit
+import Foundation
+
+let env = ProcessInfo.processInfo.environment
+guard let keyID = env["ASC_KEY_ID"], let issuerID = env["ASC_ISSUER_ID"],
+      let keyPath = env["ASC_KEY_PATH"] else {
+    FileHandle.standardError.write(Data("Set ASC_KEY_ID / ASC_ISSUER_ID / ASC_KEY_PATH (source secrets/.env)\n".utf8))
+    exit(1)
+}
+
+func b64url(_ data: Data) -> String {
+    data.base64EncodedString()
+        .replacingOccurrences(of: "+", with: "-")
+        .replacingOccurrences(of: "/", with: "_")
+        .replacingOccurrences(of: "=", with: "")
+}
+
+let now = Int(Date().timeIntervalSince1970)
+let header = #"{"alg":"ES256","kid":"\#(keyID)","typ":"JWT"}"#
+// Apple rejects exp > 20 min ahead; 10 min leaves slack for clock skew.
+let payload = #"{"iss":"\#(issuerID)","iat":\#(now),"exp":\#(now + 600),"aud":"appstoreconnect-v1"}"#
+let signingInput = b64url(Data(header.utf8)) + "." + b64url(Data(payload.utf8))
+
+let pem = try String(contentsOfFile: keyPath, encoding: .utf8)
+let key = try P256.Signing.PrivateKey(pemRepresentation: pem)
+let signature = try key.signature(for: Data(signingInput.utf8))  // ECDSA + SHA-256 = ES256
+print(signingInput + "." + b64url(signature.rawRepresentation))  // rawRepresentation = r‖s, the JWT wire format

--- a/apple-dev-skills/skills/build-time-secret-injection/SKILL.md
+++ b/apple-dev-skills/skills/build-time-secret-injection/SKILL.md
@@ -81,30 +81,7 @@ Wrap multiple xcconfigs via a `Config-{Debug,Release}.xcconfig` that `#include?`
 
 ### Multi-app dispatch in `ci_post_clone.sh`
 
-When one repo ships multiple app schemes (e.g. AppA + AppB), XCC sets `$CI_PRODUCT` and `$CI_XCODE_SCHEME` per workflow. Case-switch on the scheme to pick the right env-var prefix:
-
-```bash
-case "${CI_XCODE_SCHEME:-${CI_PRODUCT:-}}" in
-  AppA)
-    APP_ID="${APP_A_ADMOB_APP_ID:?missing APP_A_ADMOB_APP_ID}"
-    BANNER_UNIT_ID="${APP_A_ADMOB_BANNER_UNIT_ID:?missing APP_A_ADMOB_BANNER_UNIT_ID}"
-    ;;
-  AppB)
-    APP_ID="${APP_B_ADMOB_APP_ID:?missing APP_B_ADMOB_APP_ID}"
-    BANNER_UNIT_ID="${APP_B_ADMOB_BANNER_UNIT_ID:?missing APP_B_ADMOB_BANNER_UNIT_ID}"
-    ;;
-  *)
-    echo "Unknown CI_XCODE_SCHEME: ${CI_XCODE_SCHEME:-}" >&2
-    exit 1
-    ;;
-esac
-cat > Tuist/AdMob.xcconfig <<EOF
-ADMOB_APP_ID = ${APP_ID}
-ADMOB_BANNER_UNIT_ID = ${BANNER_UNIT_ID}
-EOF
-```
-
-Run **before** `tuist generate` so the per-target xcconfig reference resolves.
+When one repo ships multiple app schemes (e.g. AppA + AppB), XCC sets `$CI_PRODUCT` and `$CI_XCODE_SCHEME` per workflow. For the case-switch that picks the right env-var prefix per scheme, read `references/multi-app-ci-dispatch.md`.
 
 ### Non-Tuist projects
 
@@ -150,31 +127,20 @@ Consider adding a build-phase script that asserts no `$()` literals survived sub
 
 8. **Tuist `tuist generate` silently clobbering unmanaged xcconfigs.** If `Tuist/<Domain>.xcconfig` exists but is NOT referenced in `Project.swift`'s `.settings(configurations:)`, Tuist regen drops it from the project. Verify Project.swift wiring before assuming xcconfig is active.
 
-## Checklist when adding a new secret value
+## Verification checklist
 
-1. Decide layer:
-   - Consumed by Xcode build / Info.plist / Bundle.main read → Layer 1 xcconfig
-   - Consumed by `swift run` / CLI scripts / shell → Layer 2 `.env`
-2. Add KEY to appropriate `.example` file with sandbox/test default value
-3. Add inline comment in `.example` describing purpose + where to find the real one (name the out-of-repo vault entry — password manager / team vault — NEVER the literal value)
-4. If Layer 1: add `$(KEY)` substitution to `Info.plist`; add reading code via `Bundle.main` with guard (cover nil / empty / `$(...)` literal); add smoke test for key presence in source plist
-5. If Layer 1 CI path: extend `ci_post_clone.sh` to write the new KEY from XCC env var with `${VAR:?missing message}` fail-fast; if multi-app, branch on `$CI_XCODE_SCHEME`
-6. Run `grep -r "<real-prod-value>" .` (excluding gitignored dirs) — must return zero hits
-7. Record the real values in the out-of-repo secret store (password manager / team vault) and note which entry holds them — never in a tracked file
+Use this both when adding a new secret value and when auditing an existing implementation.
 
-## Verification checklist (audit existing implementations)
-
-- [ ] Root `.gitignore` has `Tuist/*.xcconfig` + `!Tuist/*.xcconfig.example`
-- [ ] `secrets/.gitignore` inner deny-list present (`* / !*.example / !README.md / !example/ / !example/**`); `git check-ignore -v secrets/example/README.md` reports nothing
+- [ ] Decide the layer: Xcode build / Info.plist / `Bundle.main` read → Layer 1 xcconfig; `swift run` / CLI scripts / shell → Layer 2 `secrets/.env`
+- [ ] Root `.gitignore` has `Tuist/*.xcconfig` + `!Tuist/*.xcconfig.example`; `secrets/.gitignore` inner deny-list present (`* / !*.example / !README.md / !example/ / !example/**`) — `git check-ignore -v secrets/example/README.md` reports nothing
+- [ ] KEY is added to the appropriate `.example` file with a sandbox/test default value, with an inline comment naming the out-of-repo vault entry that holds the real value (password manager / team vault) — never the literal value
 - [ ] `Project.swift` per-target `.settings(configurations:)` references the xcconfig
-- [ ] `Info.plist` uses `$(KEY)` substitution for each secret
-- [ ] App code reads via `Bundle.main.object(forInfoDictionaryKey:)` with guard (NOT `as!`)
-- [ ] Runtime guard rejects `nil`, empty, and `$(...)` literal
-- [ ] Smoke test reads source plist for key-presence assertion
-- [ ] `ci_post_clone.sh` writes xcconfig BEFORE `tuist generate`
-- [ ] Multi-app: `case` on `$CI_XCODE_SCHEME` selects per-app env vars
+- [ ] Layer 1: `Info.plist` uses `$(KEY)` substitution for each secret; app code reads via `Bundle.main.object(forInfoDictionaryKey:)` with a guard (NOT `as!`) that rejects `nil`, empty, and the `$(...)` literal
+- [ ] Smoke test reads the source plist for a key-presence assertion
+- [ ] `ci_post_clone.sh` writes the xcconfig from the XCC env var (`${VAR:?missing message}`) BEFORE `tuist generate`; if multi-app, `case` on `$CI_XCODE_SCHEME` selects per-app env vars — see `references/multi-app-ci-dispatch.md`
 - [ ] XCC Workflow Environment Variables UI lists each KEY (per scheme if multi-app), marked Secret
-- [ ] `grep -r "<real-prod-value>" .` returns zero hits across all tracked files
+- [ ] `grep -r "<real-prod-value>" .` (excluding gitignored dirs) returns zero hits across all tracked files
+- [ ] The real value is recorded in the out-of-repo secret store, noting which entry holds it — never in a tracked file
 
 ## Related skills
 

--- a/apple-dev-skills/skills/build-time-secret-injection/references/multi-app-ci-dispatch.md
+++ b/apple-dev-skills/skills/build-time-secret-injection/references/multi-app-ci-dispatch.md
@@ -1,0 +1,28 @@
+# Multi-App CI Dispatch
+
+### Multi-app dispatch in `ci_post_clone.sh`
+
+When one repo ships multiple app schemes (e.g. AppA + AppB), XCC sets `$CI_PRODUCT` and `$CI_XCODE_SCHEME` per workflow. Case-switch on the scheme to pick the right env-var prefix:
+
+```bash
+case "${CI_XCODE_SCHEME:-${CI_PRODUCT:-}}" in
+  AppA)
+    APP_ID="${APP_A_ADMOB_APP_ID:?missing APP_A_ADMOB_APP_ID}"
+    BANNER_UNIT_ID="${APP_A_ADMOB_BANNER_UNIT_ID:?missing APP_A_ADMOB_BANNER_UNIT_ID}"
+    ;;
+  AppB)
+    APP_ID="${APP_B_ADMOB_APP_ID:?missing APP_B_ADMOB_APP_ID}"
+    BANNER_UNIT_ID="${APP_B_ADMOB_BANNER_UNIT_ID:?missing APP_B_ADMOB_BANNER_UNIT_ID}"
+    ;;
+  *)
+    echo "Unknown CI_XCODE_SCHEME: ${CI_XCODE_SCHEME:-}" >&2
+    exit 1
+    ;;
+esac
+cat > Tuist/AdMob.xcconfig <<EOF
+ADMOB_APP_ID = ${APP_ID}
+ADMOB_BANNER_UNIT_ID = ${BANNER_UNIT_ID}
+EOF
+```
+
+Run **before** `tuist generate` so the per-target xcconfig reference resolves.

--- a/apple-dev-skills/skills/cloudkit-schema-source-of-truth/SKILL.md
+++ b/apple-dev-skills/skills/cloudkit-schema-source-of-truth/SKILL.md
@@ -43,36 +43,13 @@ hardcoded in tooling.
 
 ## Workflow
 
-```bash
-# Load credentials for this shell session only.
-set -a; source secrets/.env; set +a
+1. Authenticate `cktool` for this session (positional arg — see gotcha 1 below).
+2. Export the live Development schema to the committed source-of-truth file (seed step first: run a debug build once so the app's JIT schema provisions the Development container, THEN export).
+3. Pre-flight: validate the committed `.ckdb` against the live container before importing.
+4. Deploy to Development — freely runnable and reversible.
+5. Always clear the token from `cktool`'s keychain store when done (via a shell `trap ... EXIT` around steps 1–4, so it's purged even if a step fails midway).
 
-# 1. Authenticate cktool for this session (positional arg — see gotcha 1 below).
-xcrun cktool save-token --type management --force "$CK_MANAGEMENT_TOKEN"
-
-# 2. Export the live Development schema to the committed source-of-truth file.
-#    Seed step first: run a debug build once so the app's JIT schema provisions
-#    the Development container, THEN export.
-xcrun cktool export-schema \
-  --team-id "$CK_TEAM_ID" --container-id "$CK_CONTAINER_ID" \
-  --environment development > cloudkit/myapp.ckdb
-
-# 3. Pre-flight: validate the committed .ckdb against the live container before importing.
-xcrun cktool validate-schema \
-  --team-id "$CK_TEAM_ID" --container-id "$CK_CONTAINER_ID" \
-  --environment development --file cloudkit/myapp.ckdb
-
-# 4. Deploy to Development — freely runnable and reversible.
-xcrun cktool import-schema \
-  --team-id "$CK_TEAM_ID" --container-id "$CK_CONTAINER_ID" \
-  --environment development --file cloudkit/myapp.ckdb
-
-# 5. Always clear the token from cktool's keychain store when done.
-xcrun cktool remove-token --type management --force
-```
-
-Run step 5 in a shell `trap ... EXIT` around steps 1–4 so the token is purged even if a step
-fails midway.
+Runnable as `scripts/ck-schema-dev.sh` — see that file for the exact `cktool` invocations and flags.
 
 ## Inputs / outputs
 

--- a/apple-dev-skills/skills/cloudkit-schema-source-of-truth/scripts/ck-schema-dev.sh
+++ b/apple-dev-skills/skills/cloudkit-schema-source-of-truth/scripts/ck-schema-dev.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+#
+# ck-schema-dev.sh — export, validate, and deploy the CloudKit Development
+# schema. See ../SKILL.md for the full workflow, live-run gotchas, and the
+# Production-promotion safety gate (Console-only, user-owned) — this script
+# never touches Production.
+#
+# Usage: scripts/ck-schema-dev.sh
+# Requires secrets/.env (gitignored) exporting:
+#   CK_MANAGEMENT_TOKEN, CK_TEAM_ID, CK_CONTAINER_ID
+#
+set -euo pipefail
+
+# Always clear the token from cktool's keychain store, even on failure.
+trap 'xcrun cktool remove-token --type management --force' EXIT
+
+# Load credentials for this shell session only.
+set -a; source secrets/.env; set +a
+
+# 1. Authenticate cktool for this session (positional arg — see gotcha 1 in SKILL.md).
+xcrun cktool save-token --type management --force "$CK_MANAGEMENT_TOKEN"
+
+# 2. Export the live Development schema to the committed source-of-truth file.
+#    Seed step first: run a debug build once so the app's JIT schema provisions
+#    the Development container, THEN export.
+xcrun cktool export-schema \
+  --team-id "$CK_TEAM_ID" --container-id "$CK_CONTAINER_ID" \
+  --environment development > cloudkit/myapp.ckdb
+
+# 3. Pre-flight: validate the committed .ckdb against the live container before importing.
+xcrun cktool validate-schema \
+  --team-id "$CK_TEAM_ID" --container-id "$CK_CONTAINER_ID" \
+  --environment development --file cloudkit/myapp.ckdb
+
+# 4. Deploy to Development — freely runnable and reversible.
+xcrun cktool import-schema \
+  --team-id "$CK_TEAM_ID" --container-id "$CK_CONTAINER_ID" \
+  --environment development --file cloudkit/myapp.ckdb
+
+# 5. Token cleanup happens via the trap above, even if a step failed midway.

--- a/apple-dev-skills/skills/interactive-simulator-ux-audit/SKILL.md
+++ b/apple-dev-skills/skills/interactive-simulator-ux-audit/SKILL.md
@@ -91,30 +91,10 @@ and already give a usable answer for most cases.
    already saturate the machine, that's the normal case — reduce how many agents/sessions
    run at once until it fits. As a dated, third-party reference point only (not a catalog
    default): on a 16 GB M1 Pro, stock simulators reportedly start thrashing around 5
-   concurrent instances (`simslim/README.md:9`, verified 2026-09-03). If step 1's math
-   already gets you a workable number, stop here — step 3 is optional and unrelated to the
-   rest of this skill.
-3. **Only if still constrained and willing to trade away some background services**, a
-   persistent per-simulator daemon-disable is available via third-party tooling. Gate on
-   `command -v simslim` first — if it's absent, that's fine, stop at step 2, nothing else in
-   this skill depends on it. To install without Homebrew: `go install
-   github.com/mobai-app/simslim/cmd/simslim@latest` (a Go toolchain can be provisioned
-   through `mise`, see `mise-tool-management`); or download the plain release tarball
-   directly, `simslim-v0.8.0-macos-arm64.tar.gz` from
-   `https://github.com/MobAI-App/simslim/releases/download/v0.8.0/` (asset name/version
-   verified via `gh release view MobAI-App/simslim`, 2026-09-03 — simslim's own README
-   documents only Homebrew and `go install`, `simslim/README.md:29-41`, so this direct-tarball
-   path isn't in its docs either). Once present, it's one command per simulator: `simslim on
-   <udid>` to disable, `simslim off <udid>` to revert.
-   - Persistence only survives reboot on iOS 18.5+ runtimes; older runtimes are rejected
-     before anything is touched (`simslim/README.md:303-307`).
-   - Slimming drops Spotlight/in-Settings search, push notifications (`apsd`) and StoreKit
-     testing (`storekitd`), and universal links (`swcd`) unless kept via `--except`/`--keep`
-     (`simslim/README.md:342-347`).
-   - `erase`, delete+recreate, and "Erase All Content and Settings" all revert to stock; the
-     profile must be reapplied (`simslim/README.md:331-336`).
-   - This skill doesn't track simslim's CLI beyond the two commands above — its own README
-     is the source of truth for anything else.
+   concurrent instances (`https://github.com/MobAI-App/simslim`, verified 2026-09-03). If
+   step 1's math already gets you a workable number, stop here — an optional third step
+   (a per-simulator daemon-disable) is in `references/simulator-fleet-sizing.md` and is
+   unrelated to the rest of this skill.
 
 ## Build + install the app under test
 

--- a/apple-dev-skills/skills/interactive-simulator-ux-audit/references/simulator-fleet-sizing.md
+++ b/apple-dev-skills/skills/interactive-simulator-ux-audit/references/simulator-fleet-sizing.md
@@ -1,0 +1,23 @@
+# Simulator Fleet Sizing — Optional `simslim` Step
+
+3. **Only if still constrained and willing to trade away some background services**, a
+   persistent per-simulator daemon-disable is available via third-party tooling. Gate on
+   `command -v simslim` first — if it's absent, that's fine, stop at step 2, nothing else in
+   this skill depends on it. To install without Homebrew: `go install
+   github.com/mobai-app/simslim/cmd/simslim@latest` (a Go toolchain can be provisioned
+   through `mise`, see `mise-tool-management`); or download the plain release tarball
+   directly, `simslim-v0.8.0-macos-arm64.tar.gz` from
+   `https://github.com/MobAI-App/simslim/releases/download/v0.8.0/` (asset name/version
+   verified via `gh release view MobAI-App/simslim`, 2026-09-03 — simslim's own README
+   documents only Homebrew and `go install`, so this direct-tarball
+   path isn't in its docs either). Once present, it's one command per simulator: `simslim on
+   <udid>` to disable, `simslim off <udid>` to revert.
+   - Persistence only survives reboot on iOS 18.5+ runtimes; older runtimes are rejected
+     before anything is touched. See `https://github.com/MobAI-App/simslim` for current behavior.
+   - Slimming drops Spotlight/in-Settings search, push notifications (`apsd`) and StoreKit
+     testing (`storekitd`), and universal links (`swcd`) unless kept via `--except`/`--keep`.
+     See `https://github.com/MobAI-App/simslim` for current behavior.
+   - `erase`, delete+recreate, and "Erase All Content and Settings" all revert to stock; the
+     profile must be reapplied. See `https://github.com/MobAI-App/simslim` for current behavior.
+   - This skill doesn't track simslim's CLI beyond the two commands above — its own README
+     is the source of truth for anything else.

--- a/apple-dev-skills/skills/ios-performance-engineering/SKILL.md
+++ b/apple-dev-skills/skills/ios-performance-engineering/SKILL.md
@@ -110,26 +110,7 @@ Common traps: eager `CKContainer.default()` on the main thread (hangs until enti
 
 **Footprint vs leaks**: Instruments Allocations shows the heap; use `vmmap` or the Memory Debugger in Xcode to see the full virtual memory map (dirty pages, compressed pages, mapped files). The OS terminates apps that exceed their footprint budget silently — a JetsamEvent log entry whose reason reads `per-process-limit` (or `highwater`). Reduce by:
 
-- **Image downsampling**: never decode a 4K image to display it at 100 pt. Use `ImageIO` with `kCGImageSourceThumbnailMaxPixelSize` or `UIGraphicsImageRenderer` to decode at display resolution.
-
-```swift
-func downsample(imageAt url: URL, to pointSize: CGSize, scale: CGFloat) -> UIImage {
-    let options: [CFString: Any] = [
-        kCGImageSourceShouldCacheImmediately: false,
-        kCGImageSourceShouldCache: false
-    ]
-    let src = CGImageSourceCreateWithURL(url as CFURL, options as CFDictionary)!
-    let maxDim = max(pointSize.width, pointSize.height) * scale
-    let thumbOptions: [CFString: Any] = [
-        kCGImageSourceCreateThumbnailWithTransform: true,
-        kCGImageSourceCreateThumbnailFromImageAlways: true,
-        kCGImageSourceThumbnailMaxPixelSize: maxDim
-    ]
-    let cgImage = CGImageSourceCreateThumbnailAtIndex(src, 0, thumbOptions as CFDictionary)!
-    return UIImage(cgImage: cgImage)
-}
-```
-
+- **Image downsampling**: never decode a 4K image to display it at 100 pt. Use `ImageIO` with `kCGImageSourceThumbnailMaxPixelSize` or `UIGraphicsImageRenderer` to decode at display resolution. For the `downsample(imageAt:to:scale:)` sample, read `references/samples.md`.
 - **`autoreleasepool`** in tight loops that allocate many Objective-C objects (e.g. iterating `NSManagedObject` fetches, calling `UIImage(named:)` in a loop). The pool drains at the end of each `autoreleasepool { }` block rather than at the runloop turn boundary.
 - **Retain cycles**: `[weak self]` in closures stored on `self`; `weak var delegate` in delegation patterns. The Leaks instrument and the Memory Graph Debugger (product menu → Debug Memory Graph) visualise the reference graph and highlight cycles in red.
 
@@ -145,33 +126,7 @@ Large binaries increase download time and App Store review scrutiny. Primary lev
 
 ## MetricKit — field performance telemetry
 
-MetricKit delivers on-device aggregated performance metrics to your app once per day (diagnostic payloads are delivered immediately, with no disconnect-from-Xcode condition, since iOS 15 / macOS 12):
-
-```swift
-import MetricKit
-
-final class MetricKitReceiver: NSObject, MXMetricManagerSubscriber {
-    func didReceive(_ payloads: [MXMetricPayload]) {
-        for payload in payloads {
-            // CPU time, memory, disk, network, display — aggregated over 24 h
-            let cpuTime = payload.cpuMetrics?.cumulativeCPUTime
-            let avgMemory = payload.memoryMetrics?.averageSuspendedMemory
-            // Forward to your telemetry sink
-        }
-    }
-
-    func didReceive(_ payloads: [MXDiagnosticPayload]) {
-        for payload in payloads {
-            // MXHangDiagnostic, MXCrashDiagnostic, MXCPUExceptionDiagnostic
-            let hangs = payload.hangDiagnostics    // call trees for hang events
-            // Persist or upload for analysis
-        }
-    }
-}
-
-// Register at app start — one call, lives for the app lifetime
-MXMetricManager.shared.add(receiver)
-```
+MetricKit delivers on-device aggregated performance metrics to your app once per day (diagnostic payloads are delivered immediately, with no disconnect-from-Xcode condition, since iOS 15 / macOS 12). For the full `MXMetricManagerSubscriber` receiver sample, read `references/samples.md`.
 
 MetricKit data reflects **real user conditions** (actual device, network, battery state), making it the authoritative source for field performance signals. Key metric classes:
 
@@ -190,18 +145,7 @@ Wire MetricKit as a **sink** in your telemetry facade (per `telemetry-facade-pat
 
 ## `XCTMetric` and `measure {}` baselines in CI
 
-```swift
-func testScrollPerformance() {
-    let app = XCUIApplication()
-    app.launch()
-    measure(metrics: [XCTOSSignpostMetric.scrollDecelerationMetric,
-                      XCTMemoryMetric(application: app),
-                      XCTCPUMetric(application: app)]) {
-        // simulate the action
-        app.swipeUp()
-    }
-}
-```
+For the `testScrollPerformance` sample wiring `XCTOSSignpostMetric.scrollDecelerationMetric`, `XCTMemoryMetric`, and `XCTCPUMetric` into `measure {}`, read `references/samples.md`.
 
 `measure {}` runs the block 5 times (by default) and records the mean. On first run, set the baseline via the inline editor in Xcode. Subsequent runs fail on either of two independent thresholds, both configurable per metric: **Max % Relative Standard Deviation** (default 10%) and **Max % Deviation** from the baseline average (default 10%) — exceeding either one fails the test; it is not a single product formula. Commit baselines in `.xcbaseline` files alongside the test file.
 

--- a/apple-dev-skills/skills/ios-performance-engineering/references/samples.md
+++ b/apple-dev-skills/skills/ios-performance-engineering/references/samples.md
@@ -1,0 +1,64 @@
+# Samples
+
+## Image downsampling (ImageIO)
+
+```swift
+func downsample(imageAt url: URL, to pointSize: CGSize, scale: CGFloat) -> UIImage {
+    let options: [CFString: Any] = [
+        kCGImageSourceShouldCacheImmediately: false,
+        kCGImageSourceShouldCache: false
+    ]
+    let src = CGImageSourceCreateWithURL(url as CFURL, options as CFDictionary)!
+    let maxDim = max(pointSize.width, pointSize.height) * scale
+    let thumbOptions: [CFString: Any] = [
+        kCGImageSourceCreateThumbnailWithTransform: true,
+        kCGImageSourceCreateThumbnailFromImageAlways: true,
+        kCGImageSourceThumbnailMaxPixelSize: maxDim
+    ]
+    let cgImage = CGImageSourceCreateThumbnailAtIndex(src, 0, thumbOptions as CFDictionary)!
+    return UIImage(cgImage: cgImage)
+}
+```
+
+## MetricKit receiver (MXMetricManagerSubscriber)
+
+```swift
+import MetricKit
+
+final class MetricKitReceiver: NSObject, MXMetricManagerSubscriber {
+    func didReceive(_ payloads: [MXMetricPayload]) {
+        for payload in payloads {
+            // CPU time, memory, disk, network, display — aggregated over 24 h
+            let cpuTime = payload.cpuMetrics?.cumulativeCPUTime
+            let avgMemory = payload.memoryMetrics?.averageSuspendedMemory
+            // Forward to your telemetry sink
+        }
+    }
+
+    func didReceive(_ payloads: [MXDiagnosticPayload]) {
+        for payload in payloads {
+            // MXHangDiagnostic, MXCrashDiagnostic, MXCPUExceptionDiagnostic
+            let hangs = payload.hangDiagnostics    // call trees for hang events
+            // Persist or upload for analysis
+        }
+    }
+}
+
+// Register at app start — one call, lives for the app lifetime
+MXMetricManager.shared.add(receiver)
+```
+
+## XCTMetric baseline test
+
+```swift
+func testScrollPerformance() {
+    let app = XCUIApplication()
+    app.launch()
+    measure(metrics: [XCTOSSignpostMetric.scrollDecelerationMetric,
+                      XCTMemoryMetric(application: app),
+                      XCTCPUMetric(application: app)]) {
+        // simulate the action
+        app.swipeUp()
+    }
+}
+```

--- a/apple-dev-skills/skills/local-archive-export-upload/SKILL.md
+++ b/apple-dev-skills/skills/local-archive-export-upload/SKILL.md
@@ -125,32 +125,14 @@ that counter:
 - Set `manageAppVersionAndBuildNumber: false` (above) so Xcode's export-time
   bump doesn't fight your chosen number.
 
-## War stories (evidence tier in italics)
-
-- **A pre-`touch`ed ExportOptions.plist breaks `PlistBuddy`** — it can't parse
-  a 0-byte file ("Cannot parse a NULL or zero-length data"); remove the file
-  first and let `PlistBuddy Add` create it fresh. *Practice observed* — the
-  actual first-run failure on a real project's local-upload script.
-- **Export-compliance can silently gate a build in "Processing."** Declaring
-  `ITSAppUsesNonExemptEncryption` (`false` if you ship no custom encryption)
-  once means every future upload skips ASC's interactive compliance question;
-  a new app without it isn't blocked outright but holds pending a human answer
-  in the ASC web UI (see `app-store-review-rejections`'s 2.5.x row). *Practice
-  observed.*
-- **`app-store` → `app-store-connect` rename (Xcode 15+)** confirmed live in
-  `xcodebuild -help`'s own deprecation note. *Doc-verified*, Xcode 26.5.
-- **The six load-bearing exportOptionsPlist keys** — confirmed as the common
-  shape across four real ExportOptions.plist files (2 apps × 2 platforms) and
-  cross-checked against `xcodebuild -help`'s key list. *Doc-verified +
-  cross-project-observed.*
-
 ## Rationale
 
 Every flag and key here is verifiable straight from Apple's own CLI (`man
 xcodebuild`, `xcodebuild -help`, `xcrun altool --help`) — no fastlane, no
 third-party packaging tool, consistent with this catalog's no-Homebrew /
 Apple-native-first baseline (`asc-api-automation` makes the same call for ASC
-REST automation).
+REST automation). Provenance for each claim (doc-verified vs practice-observed)
+is in `references/evidence.md`.
 
 ## Deviation considerations
 

--- a/apple-dev-skills/skills/local-archive-export-upload/references/evidence.md
+++ b/apple-dev-skills/skills/local-archive-export-upload/references/evidence.md
@@ -1,0 +1,20 @@
+# Evidence
+
+## War stories (evidence tier in italics)
+
+- **A pre-`touch`ed ExportOptions.plist breaks `PlistBuddy`** — it can't parse
+  a 0-byte file ("Cannot parse a NULL or zero-length data"); remove the file
+  first and let `PlistBuddy Add` create it fresh. *Practice observed* — the
+  actual first-run failure on a real project's local-upload script.
+- **Export-compliance can silently gate a build in "Processing."** Declaring
+  `ITSAppUsesNonExemptEncryption` (`false` if you ship no custom encryption)
+  once means every future upload skips ASC's interactive compliance question;
+  a new app without it isn't blocked outright but holds pending a human answer
+  in the ASC web UI (see `app-store-review-rejections`'s 2.5.x row). *Practice
+  observed.*
+- **`app-store` → `app-store-connect` rename (Xcode 15+)** confirmed live in
+  `xcodebuild -help`'s own deprecation note. *Doc-verified*, Xcode 26.5.
+- **The six load-bearing exportOptionsPlist keys** — confirmed as the common
+  shape across four real ExportOptions.plist files (2 apps × 2 platforms) and
+  cross-checked against `xcodebuild -help`'s key list. *Doc-verified +
+  cross-project-observed.*

--- a/apple-dev-skills/skills/telemetry-facade-pattern/SKILL.md
+++ b/apple-dev-skills/skills/telemetry-facade-pattern/SKILL.md
@@ -63,46 +63,9 @@ public struct NoOpTrackingSink: TelemetrySink {
 - The App target's DI composition root injects sinks into the facade.
 - Sinks are **failure-isolated** (one sink throwing or timing out must not stop the others) but **not order-free**: the facade forwards in array order, and a sink that reads state another sink writes must come after it (see trap 2).
 
-#### Wiring traps (hard-won — real project lessons)
-
-A sink that *exists as a type* is worth **zero** until it is in the **live** sinks
-array. Five traps, in the order they bit:
-
-1. **Existing-but-unwired = dead code.** Real-world example: a `GameCenterSink`
-   and its achievement-evaluation logic were fully written but never added to
-   the live `Telemetry` sinks list (the composition root shipped
-   `[OSLogSink, NoOpTrackingSink]` only) → no score, no achievement, silently.
-   **Verify the composition root's actual sinks array**, not that the sink type
-   compiles. `git log -S "GameCenterSink("` showing only the creation commit is
-   the smoking gun.
-2. **Sink ordering matters when one sink reads another's write.** The facade
-   forwards in array order, so a sink that *writes* state another sink *reads*
-   must come first — e.g. a persistence sink writes a counter (a completed-session
-   count) **before** `GameCenterSink`'s evaluator reads it; reversed = an
-   off-by-one where a count-based achievement fires one completion late. Make
-   read/write sink order explicit and test it.
-3. **I/O sinks on a gameplay-reachable path must not block.** Completion events
-   are reached from the interactive path (e.g. an interactive input handler →
-   a completion event → `telemetry.observe`). A sink doing CloudKit reads +
-   GameKit network I/O synchronously there **freezes the UI**. Forward to such sinks on a
-   **detached, order-preserving Task** (chain each on the previous so events
-   still forward in order) and return immediately; keep the fast sinks
-   (OSLog / NoOp) synchronous.
-4. **Late-binding to break the construction cycle.** When a sink needs deps
-   (persistence, GameCenter) that themselves need `Telemetry`, you cannot build
-   it at Telemetry-construction time. Wire a `DeferredSink` placeholder into the
-   facade at startup, then `setDownstream([real sinks])` once (sync, from the
-   `@MainActor` composition root) after all deps are assembled. A `final class
-   … : Sendable` (not an actor, and not `@unchecked`) backed by
-   `Synchronization.Mutex<[any TelemetrySink]>` (iOS 18+ / macOS 15+) keeps
-   `setDownstream` synchronous via `downstream.withLock { $0 = sinks }`;
-   `receive` snapshots the sinks under `withLock` before any `await`.
-5. **The sink firing ≠ the terminal call working.** Tracing "wire 2 things"
-   uncovered a third gap: the GameKit terminal (`submitScore`/`reportAchievement`)
-   was a stub that no-op'd / threw. **Trace to the actual platform call**
-   (`GKLeaderboard.submitScore`, `GKAchievement.report`), not just to the sink.
-   Terminal GameKit/StoreKit calls are device-gated — verify on a real device +
-   sandbox, never claim "done" from a green headless suite.
+For the five composition-root wiring traps (existing-but-unwired sinks, sink
+ordering, blocking I/O on the gameplay path, late-binding, and sink-fired vs
+terminal-call-succeeded), read `references/wiring-traps.md`.
 
 ## Rationale
 

--- a/apple-dev-skills/skills/telemetry-facade-pattern/references/wiring-traps.md
+++ b/apple-dev-skills/skills/telemetry-facade-pattern/references/wiring-traps.md
@@ -1,0 +1,42 @@
+# Wiring Traps
+
+#### Wiring traps (hard-won — real project lessons)
+
+A sink that *exists as a type* is worth **zero** until it is in the **live** sinks
+array. Five traps, in the order they bit:
+
+1. **Existing-but-unwired = dead code.** Real-world example: a `GameCenterSink`
+   and its achievement-evaluation logic were fully written but never added to
+   the live `Telemetry` sinks list (the composition root shipped
+   `[OSLogSink, NoOpTrackingSink]` only) → no score, no achievement, silently.
+   **Verify the composition root's actual sinks array**, not that the sink type
+   compiles. `git log -S "GameCenterSink("` showing only the creation commit is
+   the smoking gun.
+2. **Sink ordering matters when one sink reads another's write.** The facade
+   forwards in array order, so a sink that *writes* state another sink *reads*
+   must come first — e.g. a persistence sink writes a counter (a completed-session
+   count) **before** `GameCenterSink`'s evaluator reads it; reversed = an
+   off-by-one where a count-based achievement fires one completion late. Make
+   read/write sink order explicit and test it.
+3. **I/O sinks on a gameplay-reachable path must not block.** Completion events
+   are reached from the interactive path (e.g. an interactive input handler →
+   a completion event → `telemetry.observe`). A sink doing CloudKit reads +
+   GameKit network I/O synchronously there **freezes the UI**. Forward to such sinks on a
+   **detached, order-preserving Task** (chain each on the previous so events
+   still forward in order) and return immediately; keep the fast sinks
+   (OSLog / NoOp) synchronous.
+4. **Late-binding to break the construction cycle.** When a sink needs deps
+   (persistence, GameCenter) that themselves need `Telemetry`, you cannot build
+   it at Telemetry-construction time. Wire a `DeferredSink` placeholder into the
+   facade at startup, then `setDownstream([real sinks])` once (sync, from the
+   `@MainActor` composition root) after all deps are assembled. A `final class
+   … : Sendable` (not an actor, and not `@unchecked`) backed by
+   `Synchronization.Mutex<[any TelemetrySink]>` (iOS 18+ / macOS 15+) keeps
+   `setDownstream` synchronous via `downstream.withLock { $0 = sinks }`;
+   `receive` snapshots the sinks under `withLock` before any `await`.
+5. **The sink firing ≠ the terminal call working.** Tracing "wire 2 things"
+   uncovered a third gap: the GameKit terminal (`submitScore`/`reportAchievement`)
+   was a stub that no-op'd / threw. **Trace to the actual platform call**
+   (`GKLeaderboard.submitScore`, `GKAchievement.report`), not just to the sink.
+   Terminal GameKit/StoreKit calls are device-gated — verify on a real device +
+   sandbox, never claim "done" from a green headless suite.


### PR DESCRIPTION
# Ledger A4 — phase-2 references/scripts moves + D10 (8 skills + 1)

Branch: `audit/p2-apple-references`. Base: `origin/main` @ `0a23cb1`.

Scope: the `SKIPPED(deferred to references PR)` items from ledgers A2.md / A3.md — every
§3 "move to references/ or scripts/" item that phase-2 body-improvement PRs #73/#76
deliberately skipped — plus the D10 primary-locale rewrite for ai-translated-localization,
plus confirming swiftpm-modularization's pin-parity item is N/A (heading already annotated
in #76, no move needed).

| # | skill | item (short) | status | evidence (file:line after the change, or reason) |
|---|---|---|---|---|
| 1 | telemetry-facade-pattern | :56-92 wiring traps → `references/wiring-traps.md` | FIXED | `apple-dev-skills/skills/telemetry-facade-pattern/SKILL.md:66-68` (pointer: "For the five composition-root wiring traps ... read `references/wiring-traps.md`"); `apple-dev-skills/skills/telemetry-facade-pattern/references/wiring-traps.md:1` (title) — content verified byte-identical to `git show origin/main:.../SKILL.md` lines 66-105 via `diff` |
| 2 | local-archive-export-upload | :127-144 War stories → `references/evidence.md` | FIXED | `apple-dev-skills/skills/local-archive-export-upload/SKILL.md:134` (pointer appended to end of Rationale: "Provenance for each claim ... is in `references/evidence.md`."); `apple-dev-skills/skills/local-archive-export-upload/references/evidence.md:1` — content verified byte-identical to origin/main lines 128-145 via `diff` |
| 3 | asc-api-automation | :47-76 mint-token script → `scripts/mint-asc-token.swift` | FIXED | `apple-dev-skills/skills/asc-api-automation/scripts/mint-asc-token.swift` (shebang line 1, usage/env comment lines 2-18, code body verified byte-identical to origin/main lines 49-75 via `diff`; executable bit set; `swift scripts/mint-asc-token.swift` runs standalone and prints the expected missing-env-var message with exit 1); pointer at `apple-dev-skills/skills/asc-api-automation/SKILL.md:45` ("The script is `scripts/mint-asc-token.swift`") |
| 4 | asc-api-automation | :119-146 "Steps with no ASC API at all" → `references/no-api-steps.md` | FIXED | `apple-dev-skills/skills/asc-api-automation/references/no-api-steps.md:1` — content verified byte-identical to origin/main lines 121-148 via `diff`; pointer at `apple-dev-skills/skills/asc-api-automation/SKILL.md:96` |
| 5 | asc-api-automation | :111-117 three blockers table | N_A(already FIXED in #73) | `apple-dev-skills/skills/asc-api-automation/SKILL.md:82-88` — table already present, untouched this PR |
| 6 | build-time-secret-injection | :76-99 multi-app CI dispatch → `references/multi-app-ci-dispatch.md`, merge two checklists | FIXED | `apple-dev-skills/skills/build-time-secret-injection/references/multi-app-ci-dispatch.md:1` — content verified byte-identical to origin/main lines 82-107 via `diff`; pointer at `apple-dev-skills/skills/build-time-secret-injection/SKILL.md:84`; the two checklists ("Checklist when adding a new secret value" + "Verification checklist (audit existing implementations)") merged into one `## Verification checklist` — see `apple-dev-skills/skills/build-time-secret-injection/SKILL.md:140` for the merged multi-app-dispatch bullet |
| 7 | ios-performance-engineering | :107-121/:141-165/:183-194 three long samples → `references/samples.md` | FIXED | `apple-dev-skills/skills/ios-performance-engineering/references/samples.md:1` — all three code blocks (downsample function, `MXMetricManagerSubscriber` receiver, `XCTMetric` test) verified byte-identical to origin/main via three separate `diff`s; pointers at `apple-dev-skills/skills/ios-performance-engineering/SKILL.md:113`, `:129`, `:148`; 3-line `OSSignposter` snippet kept inline at `SKILL.md:57-61` |
| 8 | interactive-simulator-ux-audit | :63-90 simslim step 3 → `references/simulator-fleet-sizing.md`, drop `simslim/README.md:NN` line citations, use GitHub URL | FIXED | `apple-dev-skills/skills/interactive-simulator-ux-audit/references/simulator-fleet-sizing.md:1`; pointer + citation fix at `apple-dev-skills/skills/interactive-simulator-ux-audit/SKILL.md:94-96` (now cites `https://github.com/MobAI-App/simslim` instead of `simslim/README.md:9`); `grep -n "README.md:" apple-dev-skills/skills/interactive-simulator-ux-audit/SKILL.md` returns zero hits; steps 1-2 (arithmetic sizing) kept inline per D-authoring.md D6 finding |
| 9 | ai-translated-localization | :94-123 Step 3 locale gotchas → `references/locale-gotchas.md` | FIXED | `apple-dev-skills/skills/ai-translated-localization/references/locale-gotchas.md:1` — content (ja/th/ko/es/zh-Hans/en gotchas) verified byte-identical to origin/main lines 94-123 via `diff`; pointer at `apple-dev-skills/skills/ai-translated-localization/SKILL.md:98` |
| 10 | ai-translated-localization | :147-172 L10n gate blind spots + dotted-key gate → `references/l10n-gates.md` | FIXED | `apple-dev-skills/skills/ai-translated-localization/references/l10n-gates.md:1` — content verified byte-identical to origin/main lines 149-174 via `diff`; pointer at `apple-dev-skills/skills/ai-translated-localization/SKILL.md:130` |
| 11 | ai-translated-localization | :183-188 xcstrings schema / tooling → `references/xcstrings-format.md` | FIXED | `apple-dev-skills/skills/ai-translated-localization/references/xcstrings-format.md:1` — content verified byte-identical to origin/main lines 185-190 via `diff`; pointer at `apple-dev-skills/skills/ai-translated-localization/SKILL.md:143`; the ":174-181" xcstrings-editing-footgun / splice section stays inline per E-authoring.md §5 |
| 12 | ai-translated-localization | D10 — "primary = zh-Hant ... author's native-language accuracy" → author-relative wording | FIXED_REWORDED | `apple-dev-skills/skills/ai-translated-localization/SKILL.md:28` (locale table row, adds "(author's native locale in the origin project; substitute yours)"), `:61` (Rationale: "Primary = the author's native locale (`zh-Hant` in the origin project)"), `:78` (Step 1: "the primary locale (the author's native locale — `zh-Hant` in the origin project)"), `:161` (Field notes: "primary = the author's native locale (`zh-Hant` in the origin project)"); description (`SKILL.md:3`) already generic ("source / primary language rule"), no zh-Hant mention — left unchanged |
| 13 | cloudkit-schema-source-of-truth | :46-75 30-line bash → `scripts/ck-schema-dev.sh`, body left to 5 steps | FIXED | `apple-dev-skills/skills/cloudkit-schema-source-of-truth/scripts/ck-schema-dev.sh` (shebang, `set -euo pipefail`, top usage/env comment, executable bit, `bash -n` syntax-checked clean; implements the `trap ... EXIT` cleanup the prose already prescribed); `apple-dev-skills/skills/cloudkit-schema-source-of-truth/SKILL.md:44-51` — 5-step one-line summary + pointer ("Runnable as `scripts/ck-schema-dev.sh`") |
| 14 | swiftpm-modularization | :94-97 monorepo pin-parity heading annotation | N_A(already FIXED in #76) | `apple-dev-skills/skills/swiftpm-modularization/SKILL.md:94` — `### Pin parity across sibling apps (multi-app monorepos only)` already present; `grep -n "multi-app monorepos only" apple-dev-skills/skills/swiftpm-modularization/SKILL.md` confirms; no move performed per task's explicit N_A rule |

## Statistics (from command output, not hand-counted)

Line-count drop per SKILL.md (`wc -l`, before = `git show origin/main:<path> | wc -l`, after = current):

```
telemetry-facade-pattern/SKILL.md:              138 -> 101
local-archive-export-upload/SKILL.md:           201 -> 183
asc-api-automation/SKILL.md:                    198 -> 146
build-time-secret-injection/SKILL.md:           183 -> 149
ios-performance-engineering/SKILL.md:           229 -> 173
interactive-simulator-ux-audit/SKILL.md:        252 -> 232
ai-translated-localization/SKILL.md:            210 -> 163
cloudkit-schema-source-of-truth/SKILL.md:       200 -> 177
```

`git diff origin/main --stat` (run from the worktree, branch `audit/p2-apple-references`):

```
 .../skills/ai-translated-localization/SKILL.md     | 69 ++++------------------
 .../references/l10n-gates.md                       | 28 +++++++++
 .../references/locale-gotchas.md                   | 32 ++++++++++
 .../references/xcstrings-format.md                 |  8 +++
 .../skills/asc-api-automation/SKILL.md             | 60 ++-----------------
 .../asc-api-automation/references/no-api-steps.md  | 30 ++++++++++
 .../scripts/mint-asc-token.swift                   | 46 +++++++++++++++
 .../skills/build-time-secret-injection/SKILL.md    | 56 ++++--------------
 .../references/multi-app-ci-dispatch.md            | 28 +++++++++
 .../cloudkit-schema-source-of-truth/SKILL.md       | 37 +++---------
 .../scripts/ck-schema-dev.sh                       | 40 +++++++++++++
 .../skills/interactive-simulator-ux-audit/SKILL.md | 28 ++-------
 .../references/simulator-fleet-sizing.md           | 23 ++++++++
 .../skills/ios-performance-engineering/SKILL.md    | 62 +------------------
 .../references/samples.md                          | 64 ++++++++++++++++++++
 .../skills/local-archive-export-upload/SKILL.md    | 22 +------
 .../references/evidence.md                         | 20 +++++++
 .../skills/telemetry-facade-pattern/SKILL.md       | 43 +-------------
 .../references/wiring-traps.md                     | 42 +++++++++++++
 19 files changed, 406 insertions(+), 332 deletions(-)
```

9 skill directories touched (the 8 with moves + ai-translated-localization for D10), no
README / repo-root scripts/ changes.

Gate (baseline and final are identical — no regression):

```
$ mise run check | grep -E "BLOCKER|MAJOR|MINOR|OK —"
OK — 2 plugins (26/12), catalog + counts + 3 README mirror(s) (README.zh-Hant.md/README.zh-Hans.md/README.ja.md) consistent.
BLOCKER 0 · MAJOR 0 · MINOR 1
```

The single MINOR is `claude-skill-plugin-packaging`'s reserved-word note (pre-existing,
unrelated to this PR). `grep -i "never pointed to"` against the full `mise run check` output
returns zero hits — no orphaned references/ files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
