### PR TITLE
fix(gate): let routing-arrow targets be wrapped in backticks, bold or italics

### DIFF
--- a/scripts/check-skills.py
+++ b/scripts/check-skills.py
@@ -123,7 +123,7 @@ for name, (plugin, d) in skills.items():
     # is a routing pointer / negative boundary, which the doctrine allows; only arrows that
     # chain non-skill words (`archive → export → upload`) count as a workflow summary.
     # A `plugin:skill` target (any prefix, incl. aggregated externals) is routing by form alone.
-    routing = re.compile(r"→\s*`?(?:(?P<prefix>[a-z0-9-]+):)?(?P<skill>[a-z0-9-]+)`?")
+    routing = re.compile(r"→\s*[`*_]*(?:(?P<prefix>[a-z0-9-]+):)?(?P<skill>[a-z0-9-]+)[`*_]*")
     def is_routing(m):
         r = routing.match(desc, m.start())
         return bool(r) and (r.group("prefix") is not None or r.group("skill") in skills)


### PR DESCRIPTION
Follow-up to #75 from the post-merge CR of #73–#76: a routing target wrapped as `→ **`skill`**` or `→ _plugin:skill_` was counted as a workflow arrow. The regex now tolerates backtick / bold / italic wrappers on either side of the target.

Verification: `mise run check` → `OK — 2 plugins`, `BLOCKER 0 · MAJOR 0 · MINOR 1`. Negative tests on a scratch description: wrapped routing targets → no finding; `archive → export → upload` and `C → **nope** → nah` → finding (reverted before commit).

🤖 Generated with [Claude Code](https://claude.com/claude-code)