### PR TITLE
docs(collaboration-skills): land 2026-09-12 Fable review findings B1a/B2/B3/B4/B8-B13 + routing matrix

### DIFF
--- a/collaboration-skills/skills/agent-impl-notes-log/SKILL.md
+++ b/collaboration-skills/skills/agent-impl-notes-log/SKILL.md
@@ -14,7 +14,6 @@ The phase meeting log (`meetings/{date}_{topic}.md`) is summative — written af
 
 Subagent MUST invoke this skill at the start of any dispatch matching ANY of:
 
-- Touches more than 3 files in production code.
 - Implements behavior whose spec has known ambiguity (e.g., `// UNCONFIRMED` markers, "Unconfirmed ?" prerequisites).
 - Introduces a new dependency, target, or module.
 - Refactors existing code beyond a one-line fix.

--- a/collaboration-skills/skills/claude-skill-plugin-packaging/SKILL.md
+++ b/collaboration-skills/skills/claude-skill-plugin-packaging/SKILL.md
@@ -160,8 +160,11 @@ cd .claude/skills/their-plugin && git checkout v0.1.0 && cd -
 On the next session (after the project-scope trust dialog), it self-loads as
 `their-plugin@skills-dir` — no marketplace, no install step, no settings.json edit.
 Caveats: only resolves when Claude Code is launched from the session's primary working
-directory (no walk-up), and code-running components (hooks, MCP servers) inside a
-skills-dir plugin are restricted. **This repo's own root has only `marketplace.json`,
+directory (no walk-up); and because a project-scope skills-dir plugin's content comes
+from the repository, its code-running components are gated further — MCP servers it
+declares go through the same per-server approval as a project `.mcp.json`, LSP servers
+start only after you trust the workspace, and background monitors do not load
+(personal-scope `~/.claude/skills/` plugins have none of these restrictions). **This repo's own root has only `marketplace.json`,
 not `plugin.json`, so a bare submodule of *this* repo does not self-load this way — use
 B1 or B2.**
 
@@ -201,8 +204,11 @@ submodule only when you need to **vendor + pin** another repo's content into you
 - **Marketplace state is per-user** (`~/.claude/plugins/known_marketplaces.json`), but the **committed project `.claude/settings.json` declaration** is what makes it reproducible for everyone on trust. Marketplace names are checked against a reserved list (`claude-code-marketplace`, `anthropic-marketplace`, `agent-skills`, …) on every load — a name collision silently stops that marketplace from loading.
 - **Token cost**: every enabled skill's description is always-on context — for the exact
   mechanism see the listing-budget reference doc under `skill-authoring-patterns`. `/doctor`
-  and `/skill-doctor` show the actual per-session cost; `skillOverrides: "name-only"` can
-  demote a low-priority plugin to save budget.
+  and `/skill-doctor` show the actual per-session cost. `skillOverrides: "name-only"` only
+  demotes personal/project skills — it does **not** apply to plugin skills ("Plugin skills
+  are not affected by `skillOverrides`. Manage those through `/plugin` instead."); for a
+  plugin the only levers are disabling it via `/plugin`, or raising the consumer's
+  `skillListingBudgetFraction`.
 - **Relative marketplace paths resolve for both git-based and local-directory marketplaces**
   — they fail only when the marketplace was added by a direct URL to `marketplace.json`. A
   `directory` source resolves against the *containing* repo's main checkout (including from

--- a/collaboration-skills/skills/leader-developer-handoff-contract/SKILL.md
+++ b/collaboration-skills/skills/leader-developer-handoff-contract/SKILL.md
@@ -40,6 +40,7 @@ Every dispatch prompt must contain:
 - List the skill names the sub-agent should invoke (with plugin prefix).
 - Don't assume the sub-agent will guess.
 - Example: "invoke `apple-dev-skills:swift6-concurrency`, `apple-dev-skills:swiftpm-modularization`, `apple-dev-skills:swift-testing-baseline`; review-style dispatches also list `collaboration-skills:subagent-review-cycles`".
+- When the dispatch target is a custom agent (`.claude/agents/` or a plugin's `agents/`), list them in that agent's `skills:` frontmatter instead — Claude Code preloads those at startup (the full skill content is injected, not only the description), so the prompt only needs to name skills the agent definition doesn't already carry. See https://code.claude.com/docs/en/sub-agents.
 
 ### 4. Expected return format
 

--- a/collaboration-skills/skills/methodology-pattern-extractor/SKILL.md
+++ b/collaboration-skills/skills/methodology-pattern-extractor/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: methodology-pattern-extractor
-description: Extract recurring collaboration patterns from accumulated meeting logs (optionally session JSONL) and record them in docs/methodology.md with evidence of where each was sighted. Use when the user asks to update methodology, extract patterns from this session, or consolidate recurring collaboration flows; or when five or more meeting logs have accumulated while §Patterns is still empty. Not for writing the meeting logs themselves (session-to-meeting-log) or for parking one-off ideas (backlog-routing-by-topic). Takes no arguments — the fork scans all of `meetings/*.md`.
+description: Extract recurring collaboration patterns from accumulated meeting logs (optionally session JSONL) and record them in docs/methodology.md with evidence of where each was sighted. Use when the user asks to update methodology, extract recurring patterns across the meeting logs, or consolidate recurring collaboration flows; or when five or more meeting logs have accumulated while §Patterns is still empty. Not for writing the meeting logs themselves (session-to-meeting-log) or for parking one-off ideas (backlog-routing-by-topic). Takes no arguments — the fork scans all of `meetings/*.md`.
 context: fork
 agent: general-purpose
 ---

--- a/collaboration-skills/skills/session-to-meeting-log/SKILL.md
+++ b/collaboration-skills/skills/session-to-meeting-log/SKILL.md
@@ -17,6 +17,13 @@ argument-hint: "[session-id-or-path] [topic]"
 
 ## Inputs
 
+### Arguments
+
+- `$0` — `[session-id-or-path]`: the session id, or a full path to the `.jsonl`. Required.
+- `$1` — `[topic]`: kebab-case topic for `meetings/{YYYY-MM-DD}_{topic}.md`. Optional — when
+  no second argument is passed the placeholder stays as literal `$1`; derive the topic from
+  the session's dominant subject instead.
+
 ### Locating the session file
 
 - Default location: `~/.claude/projects/<encoded-project-path>/<sessionId>.jsonl`

--- a/collaboration-skills/skills/skill-authoring-patterns/SKILL.md
+++ b/collaboration-skills/skills/skill-authoring-patterns/SKILL.md
@@ -42,6 +42,7 @@ listing cap for unrelated reasons.
 - **Embed the framework symbols / APIs that should trigger it** — `Sendable`, `@MainActor`, `MetricKit`, `AccessibilityFocusState`. This is the highest-leverage delta for *framework* skills: an agent routing on "I'm getting a Sendable error" only lands here if `Sendable` is in the description.
 - **Chain trigger scenarios** as a short list ("Use when … ; when … ; when …").
 - **Add a negative boundary when over-firing is a real risk** (e.g. "discussing screens" vs "generate a mockup") — name when NOT to fire.
+- **If the trigger is really *a file type*** (`*.xcstrings`, `Package.swift`), prefer the official `paths:` frontmatter over a prose file trigger — it takes glob patterns, and Claude then loads the skill automatically only when working with matching files. `mise run check` flags prose file-triggers as `candidate for paths:`.
 - Routing is the model's judgment, not literal string matching — write for a reader deciding "is this my situation?", not for a regex.
 
 ```
@@ -73,7 +74,7 @@ gaps in the "today" column are historical debt, not evidence the convention is o
 | `## Rationale` | *why* this default was chosen. Unique to this catalog. | Not retrofitted | 20/38 |
 | `## Deviation considerations` | *when to override* the default, and the cost (e.g. "Drop to iOS 18 when an existing user base still runs it — every Liquid Glass API then needs an availability guard, and the pre-26 chrome must be snapshot-tested separately"). Also ours. | Not retrofitted | 22/38 |
 | `## Common Mistakes` | concrete, anti-pattern-named items ("Using `DateFormatter()` in `body`"), as many as are real — do not pad to a number. | Not retrofitted; older skills express this as inline anti-pattern sections instead. | 10/38 |
-| `## Review Checklist` | a `- [ ]` list at the **end**, runnable top-to-bottom. | Not retrofitted; older skills use a prose `## Verification checklist` instead. | 25/38 (incl. the older prose form; `mise run check`'s section matrix) |
+| `## Review Checklist` | a `- [ ]` list at the **end**, runnable top-to-bottom. | Not retrofitted; older skills use a prose `## Verification checklist` instead. | 26/38 (incl. the older prose form; `mise run check`'s section matrix) |
 
 - **`## Related skills`** — siblings by name.
 

--- a/collaboration-skills/skills/skill-authoring-patterns/references/listing-budget.md
+++ b/collaboration-skills/skills/skill-authoring-patterns/references/listing-budget.md
@@ -4,4 +4,29 @@ Claude Code loads a listing of every skill's name + `description` into context o
 
 The practical implication for this catalog: the scarce resource is not "can my one `description` fit" — this catalog already runs `DESC_MAX = 800` in `scripts/check-consistency.py`, deliberately tighter than the official 1,536-char cap (and also under the 1,024-char hard limit the platform Agent Skills spec enforces for claude.ai / Skills API uploads), precisely because 38 skills' descriptions compete for one shared budget every session. Every new skill's `description` is a permanent tax on that shared budget, paid on every session regardless of whether the skill ever fires. So before adding a skill, ask **"is this trigger phrase worth permanently occupying part of every session's listing budget?"** — not just "does this description fit under 800 chars".
 
+## Where this catalog stands against that budget
+
+Measured total (an estimate — re-scan before quoting it; `mise run check` also prints each skill's `desc len`):
+
+```
+$ python3 - <<'EOF'
+import re, glob
+tot = 0; n = 0
+for f in sorted(glob.glob('*/skills/*/SKILL.md')):
+    fm = re.search(r'^---\n(.*?)\n---', open(f).read(), re.S).group(1)
+    d = re.search(r'^description:\s*(.*?)(?=^\w[\w-]*:|\Z)', fm, re.S | re.M).group(1).strip()
+    if d[0] == d[-1] and d[0] in "'\"": d = d[1:-1]
+    tot += len(d); n += 1
+print(f"skills={n} total_desc_chars={tot} avg={tot // n}")
+EOF
+skills=38 total_desc_chars=21953 avg=577
+```
+
+So the 38 first-party descriptions alone total ≈ 22k characters (2026-09-12 scan). On a 200k-token model the default 1% budget is ≈ 2,000 tokens ≈ 8,000 characters (4-chars-per-token rule of thumb) — this catalog by itself is close to 3× that before any other plugin's skills are counted, so on such a model the least-used skills here run with a bare name and never auto-route. On a 1M-context model the same 1% (≈ 40k chars) holds the whole catalog. The two truncations differ: budget overflow drops **whole** descriptions, least-used first; the per-entry 1,536-char cap cuts one entry from the end (hence "put the key use case first").
+
+What each side can do about it:
+
+- **Consumer**: raise `skillListingBudgetFraction` (`0.02` = 2%; `0.03` ≈ 24k chars on a 200k model, enough for this catalog) or set `SLASH_COMMAND_TOOL_CHAR_BUDGET` to a fixed character count; disable plugins you don't need via `/plugin`. `skillOverrides: "name-only"` does **not** help for this catalog — "Plugin skills are not affected by `skillOverrides`. Manage those through `/plugin` instead." ([Claude Code docs, Skills](https://code.claude.com/docs/en/skills))
+- **Author (this repo)**: put the key use case in the first sentence, and treat every new skill as a permanent charge against the shared budget — see above.
+
 `when_to_use` is a real frontmatter field (appended to `description` in the listing and counted toward the same 1,536-char cap) meant for trigger phrases / example requests. None of this catalog's 38 skills declares `when_to_use` in frontmatter (`grep -l '^when_to_use:' **/SKILL.md` → 0 hits; a plain `grep -rl when_to_use` also matches this paragraph's own mention of the field name, so target the frontmatter line specifically) — this catalog folds trigger phrasing directly into `description` instead (see the router form in `SKILL.md`). That's a deliberate, not accidental, choice: keeping trigger wording in one field is simpler to audit against `DESC_MAX` than splitting it across two fields that share a cap.

--- a/collaboration-skills/skills/subagent-conflict-detection/SKILL.md
+++ b/collaboration-skills/skills/subagent-conflict-detection/SKILL.md
@@ -33,12 +33,19 @@ Plain `git worktree list` is fine for a human to eyeball, but don't parse it: fi
 on `[main]` breaks when the default branch isn't named `main`, and splitting on
 whitespace breaks on a path containing a space. `--porcelain` sidesteps both — `tail -n
 +2` drops the first (main-checkout) `worktree` line. For each remaining worktree path,
-capture (run from inside that path, not via `-C`, so the commands match the
-`Bash(git status *)` / `Bash(git log *)` rules the way this skill's `allowed-tools`
-writes them):
+capture:
 - Branch checked out
 - Dirty files: `(cd <path> && git status --short)`
 - Most recent commit subject: `(cd <path> && git log -1 --format=%s)`
+
+Expect one permission prompt per worktree for these two checks, whichever form you write
+them in. Per the [permissions docs](https://code.claude.com/docs/en/permissions), a Bash
+rule "must match each subcommand independently"; `git -C <path> status` is a different
+invocation form that `Bash(git status *)` doesn't match; and `cd` combined with `git`
+"prompts when the `cd` changes into a different directory, since running `git` in a new
+directory can execute that directory's hooks". So this skill's `allowed-tools` covers the
+Step-1 listing (`Bash(git worktree *)`) but not the per-worktree checks — the prompt is
+expected; approve it.
 
 ### Step 2 — enumerate the NEW dispatch's likely file scope
 

--- a/collaboration-skills/skills/subagent-review-cycles/SKILL.md
+++ b/collaboration-skills/skills/subagent-review-cycles/SKILL.md
@@ -81,7 +81,7 @@ REJECT must cite specific evidence (API doc, prior decision, design constraint);
 ## Verification checklist
 
 - Every absence claim ("not defined", "no coverage") in a review finding cites the grep/search command and its zero-hit output — otherwise it doesn't count as a finding.
-- Each round has an explicit dispatch prompt (all 5 elements present).
+- Each round has an explicit dispatch prompt (all 5 items of §Dispatch contract for Code Reviewer present, on top of the 6 elements from `leader-developer-handoff-contract`).
 - Each review finding has an explicit accept / reject label + reason.
 - When limit(N) is reached without convergence, pause; don't keep iterating indefinitely.
 - Cosmetic fixes are inline-edited by the Leader; don't burn a round on them.
@@ -95,6 +95,6 @@ For the full sweep procedure, command, disposition rule, and anti-pattern, read 
 
 ## Related skills
 
-- `leader-developer-handoff-contract`: details the 5 elements of each sub-agent dispatch.
+- `leader-developer-handoff-contract`: details the 6 required elements of every dispatch prompt.
 - `spec-phase-orchestration`: review cycles are usually embedded in the spec phase.
 - `methodology-pattern-extractor`: "round-1 cosmetic inline edit" is a codifiable pattern.


### PR DESCRIPTION
## Summary

PR-2 of the 2026-09-12 Fable review: every finding that lands in `collaboration-skills/**` (REPORT-B). Scope is docs-only; no new skills, no bookend retrofits, no description compression (Q1 settled as (a) documentation only).

Findings that touch Claude Code's own behaviour were re-checked against the official pages (`skills.md`, `permissions.md`, `plugins-reference.md`, `sub-agents.md`, `settings-reference.md`) before editing; the quoted sentences are in each commit body.

| Finding | Change | File |
|---|---|---|
| B1(a) MAJOR | New "Where this catalog stands" section: measured total (38 descriptions = 21,953 chars, scan command included, labelled estimate), 200k-model 1% ≈ 8k chars, consumer lever `skillListingBudgetFraction`, explicit "`skillOverrides` does not apply to plugin skills" | `skill-authoring-patterns/references/listing-budget.md` |
| B2 MAJOR | Token-cost gotcha no longer claims `skillOverrides: "name-only"` can demote a plugin; states the real levers (`/plugin` disable, `skillListingBudgetFraction`) | `claude-skill-plugin-packaging/SKILL.md` |
| B3 MAJOR | Handoff contract has 6 elements (D12); the Code Reviewer contract's own 5 items named explicitly | `subagent-review-cycles/SKILL.md` |
| B4 MAJOR | Dropped the wrong "run via `cd` so it matches `allowed-tools`" rationale; now says the per-worktree `git status`/`git log` checks prompt once whichever form is used (compound rules match per subcommand; `cd` + `git` into another directory prompts). Docs-based wording only, not tested | `subagent-conflict-detection/SKILL.md` |
| B8 | Removed the contradictory "> 3 files" MUST threshold (≥ 2 already covers it) | `agent-impl-notes-log/SKILL.md` |
| B9 (this half) | `## Inputs` now maps `argument-hint` positions to `$0` / `$1` | `session-to-meeting-log/SKILL.md` |
| B10 | Skills-dir caveat states the three documented project-scope limits (MCP per-server approval, LSP after trust, monitors don't load) instead of "hooks, MCP servers are restricted" | `claude-skill-plugin-packaging/SKILL.md` |
| B11 | 25/38 → 26/38 (gate: `Review Checklist\|Verification checklist: 12/38 missing`) | `skill-authoring-patterns/SKILL.md` |
| B12 | Router bullet: prefer official `paths:` over a prose file trigger; gate flags candidates | `skill-authoring-patterns/SKILL.md` |
| B13 | §3 points to a custom agent's `skills:` preload field | `leader-developer-handoff-contract/SKILL.md` |
| B §2 matrix | Description no longer says "extract patterns from this session" (collided with `session-to-meeting-log`, both forks) | `methodology-pattern-extractor/SKILL.md` |

Not in this PR (by dispatch rules): B1(b) gate WARN (PR-3), B1(c) compression, the `interactive-simulator-ux-audit` half of B9 (PR-1), any new skill.

## Verification

- `python3 scripts/check-consistency.py` → `OK — 2 plugins (26/12), catalog + counts + 3 README mirror(s) … consistent.` (exit 0)
- `python3 scripts/check-skills.py .` → `BLOCKER 0 · MAJOR 0 · MINOR 1` (the settled `claude` reserved-word MINOR; exit 0)
- The python snippet embedded in `listing-budget.md` was extracted from the committed file and re-run: `skills=38 total_desc_chars=21953 avg=577`
- `git diff origin/main...HEAD --stat` touches only `collaboration-skills/**` (9 files, +58 / −12)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
