### PR TITLE
chore(infra): fix gate false-greens, quote-gate gaps, externals drift, README-hook clobber, stale CI actions

### DIFF
--- a/.claude-plugin/externals-snapshot.json
+++ b/.claude-plugin/externals-snapshot.json
@@ -5,7 +5,7 @@
     "manifest_present": true,
     "path": null,
     "repo": "Prisma-Labs-Dev/apple-skills",
-    "skill_count": 33
+    "skill_count": 31
   },
   "caveman": {
     "archived": false,

--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -2,7 +2,7 @@ name: Repo audit (upkeep)
 
 on:
   schedule:
-    - cron: '0 20 * * 0'   # 04:00 Asia/Taipei (UTC+8) daily
+    - cron: '0 20 * * 0'   # 04:00 Asia/Taipei (UTC+8), every Sunday (weekly)
   workflow_dispatch:
 
 permissions:
@@ -12,6 +12,6 @@ permissions:
 
 jobs:
   audit:
-    uses: wei18/upkeep/.github/workflows/audit.yml@v1
+    uses: wei18/upkeep/.github/workflows/audit.yml@v2
     secrets:
       claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}

--- a/.github/workflows/consistency.yml
+++ b/.github/workflows/consistency.yml
@@ -6,6 +6,6 @@ jobs:
   check:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: jdx/mise-action@v2
+      - uses: actions/checkout@v7
+      - uses: jdx/mise-action@v4
       - run: mise run check

--- a/.mise.toml
+++ b/.mise.toml
@@ -6,19 +6,19 @@ description = "SSOT consistency gate + SKILL.md format gate (two plugins, catalo
 run = ["python3 scripts/check-consistency.py", "python3 scripts/check-skills.py ."]
 
 [tasks.check-skills]
-description = "SKILL.md frontmatter/format gate only (official Agent Skills rules + catalog conventions); fails on any BLOCKER"
+description = "SKILL.md frontmatter/format gate only (official Agent Skills rules + catalog conventions); fails on any BLOCKER or MAJOR"
 run = "python3 scripts/check-skills.py ."
 
 [tasks.readme-zh]
-description = "Regenerate README.zh-Hant.md from README.md (needs claude on PATH)"
+description = "Manual-only fallback: regenerate README.zh-Hant.md from README.md (needs claude on PATH). Default is hand-mirroring — see CONTRIBUTING.md; not run by pre-commit or CI."
 run = "scripts/gen-readme-zh.sh zh-Hant"
 
 [tasks.readme-zh-hans]
-description = "Regenerate README.zh-Hans.md from README.md (needs claude on PATH)"
+description = "Manual-only fallback: regenerate README.zh-Hans.md from README.md (needs claude on PATH). Default is hand-mirroring — see CONTRIBUTING.md; not run by pre-commit or CI."
 run = "scripts/gen-readme-zh.sh zh-Hans"
 
 [tasks.readme-ja]
-description = "Regenerate README.ja.md from README.md (needs claude on PATH)"
+description = "Manual-only fallback: regenerate README.ja.md from README.md (needs claude on PATH). Default is hand-mirroring — see CONTRIBUTING.md; not run by pre-commit or CI."
 run = "scripts/gen-readme-zh.sh ja"
 
 [tasks.bump]

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -16,34 +16,34 @@ mise install && lefthook install
   `mise run check-skills` (`scripts/check-skills.py`), which checks every `SKILL.md` against the
   official Agent Skills / Claude Code frontmatter rules (`name`/`description` limits, known
   frontmatter keys, `context: fork` should name an `agent:` (defaults to general-purpose)) plus this catalog's own conventions
-  (section matrix, `references/` pointers, cross-plugin refs); fails the gate on any BLOCKER.
-- `mise run readme-zh` — regenerate `README.zh-Hant.md` (Catalog heading `## 目錄`) from
-  `README.md` (needs `claude` on PATH; auto-fires in pre-commit when `README.md` changes).
+  (section matrix, `references/` pointers, cross-plugin refs); fails the gate on any BLOCKER or MAJOR.
+- `mise run readme-zh` — manual-only fallback: regenerate `README.zh-Hant.md` (Catalog heading
+  `## 目錄`) from `README.md` (needs `claude` on PATH). Not run by pre-commit or CI — see
+  "README mirrors" below for the default hand-mirror workflow.
 - `mise run readme-zh-hans` — same, for `README.zh-Hans.md` (Catalog heading `## 目录`).
 - `mise run readme-ja` — same, for `README.ja.md` (Catalog heading `## カタログ`).
-  Every mirror listed in `scripts/mirrors.py` has its own task and its own pre-commit
-  trigger; add both when a mirror is added.
+  Every mirror listed in `scripts/mirrors.py` has its own task; add one when a mirror is added.
 
-### README mirrors: hand-mirror by default, regenerate only as fallback
+### README mirrors: hand-mirror only, regenerate is a manual fallback
 
 Full regeneration is non-deterministic — even for a 2-line content fix it rewrites
 ~40 lines of synonym churn (and has previously flipped full-width punctuation to
-half-width), burying the real change in review. So hand-mirroring is the default:
+half-width), burying the real change in review. So hand-mirroring is the default, and
+neither path is wired into pre-commit or CI — `mise run check` only verifies freshness
+(rule 4), it never regenerates:
 
 - **Default — any content change**: hand-mirror the same lines into each mirror in
   `scripts/mirrors.py` (currently `README.zh-Hant.md`, `## 目錄`; `README.zh-Hans.md`,
-  `## 目录`; `README.ja.md`, `## カタログ`), re-stamp each one's freshness marker, and
-  commit with the regen hooks excluded (they would otherwise clobber the hand-mirror
-  with a full regen):
+  `## 目录`; `README.ja.md`, `## カタログ`) and re-stamp each one's freshness marker:
 
   ```bash
   for f in README.zh-Hant.md README.zh-Hans.md README.ja.md; do
     sed -i '' "s/src-sha: [0-9a-f]*/src-sha: $(git hash-object README.md)/" "$f"
   done
   git add README.md README.zh-Hant.md README.zh-Hans.md README.ja.md
-  LEFTHOOK_EXCLUDE=readme-zh,readme-zh-hans,readme-ja git commit -m "..."   # `check` still runs and verifies freshness
+  git commit -m "..."   # `mise run check` still runs and verifies freshness
   ```
-- **Fallback — large / structural changes**: run `mise run readme-zh` for a full
+- **Fallback — large / structural changes**: run `mise run readme-zh` (etc.) for a full
   regeneration, then manually re-check punctuation (full-width vs half-width) and
   wording before committing — regeneration is not a substitute for review.
 
@@ -81,9 +81,14 @@ constant, the matching plugin's `marketplace.json` description count, and README
 "install only the N first-party skills" sentence — then run `mise run check`.
 
 Two gate rules `mise run check` enforces on the frontmatter `description`:
-- Max 800 characters.
-- If it contains `": "`, quote the whole value — an unquoted `": "` breaks strict YAML
-  parsers (see #42).
+- Max 800 characters (measured on the value itself — quotes, if any, don't count).
+- If it isn't a YAML block scalar (`description: >`), quote the whole value when it
+  contains any of: `": "` (see #42), a leading YAML indicator character (`[`, `{`, `&`,
+  `*`, `>`, `|`, `#`, `%`, `@`, `` ` ``, `!`), `" #"` (starts a YAML comment, silently
+  truncating everything after it), a leading `"- "` (block-sequence indicator), or a
+  trailing `":"` (mapping-value indicator) — each of these breaks or silently mis-parses
+  under a strict YAML parser. A quoted value must itself be valid YAML: no unescaped `"`
+  inside a double-quoted value, no unescaped `'` (use `''`) inside a single-quoted value.
 
 ### 3. Report a field note (skill vs reality)
 

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -1,14 +1,5 @@
 pre-commit:
   parallel: false
   commands:
-    readme-zh:
-      glob: "README.md"
-      run: mise run readme-zh
-    readme-zh-hans:
-      glob: "README.md"
-      run: mise run readme-zh-hans
-    readme-ja:
-      glob: "README.md"
-      run: mise run readme-ja
     check:
       run: mise run check

--- a/scripts/bump-version.py
+++ b/scripts/bump-version.py
@@ -52,11 +52,15 @@ def set_plugin_version(plugin_dir: str, version: str):
     print(f"  {plugin_dir}: -> {version} (plugin.json + marketplace entry)")
 
 
-def set_marketplace_version(version: str):
-    # Refuse to bump while any mirror is already stale — otherwise the re-stamp
-    # below just re-freshens a src-sha that was never an honest mirror of README.md
-    # (regression: bump-version.py --marketplace silently launders a stale mirror
-    # into a green gate, see check-consistency.py rule 4).
+def precheck_marketplace_mirrors():
+    """Refuse to bump `--marketplace` while any mirror is already stale — otherwise the
+    re-stamp in set_marketplace_version() just re-freshens a src-sha that was never an
+    honest mirror of README.md (regression: bump-version.py --marketplace silently
+    launders a stale mirror into a green gate, see check-consistency.py rule 4).
+
+    Called before ANY file is written (not just before the marketplace edits) so a
+    multi-flag bump (e.g. --apple + --marketplace) can't die here after --apple's
+    plugin.json + marketplace.json edits are already on disk — a non-atomic partial bump."""
     pre_sha = subprocess.run(["git", "hash-object", "README.md"], cwd=ROOT,
                              capture_output=True, text=True, check=True).stdout.strip()
     for mirror_name in MIRRORS:
@@ -65,6 +69,8 @@ def set_marketplace_version(version: str):
         if not m or m.group(1) != pre_sha:
             die(f"{mirror_name} src-sha is stale vs README.md — run `mise run readme-zh` first, then re-run bump")
 
+
+def set_marketplace_version(version: str):
     MP.write_text(sub_once(MP.read_text(encoding="utf-8"),
                            r'("metadata"\s*:\s*\{[^}]*?"version"\s*:\s*")' + SEMVER + r'(")',
                            rf"\g<1>{version}\g<2>", "marketplace metadata"), encoding="utf-8")
@@ -95,6 +101,8 @@ def main():
         ap.error("nothing to bump — pass at least one of --marketplace/--apple/--collab")
     for v in (args.marketplace, args.apple, args.collab):
         if v and not re.fullmatch(SEMVER, v): die(f"not a semver: {v}")
+
+    if args.marketplace: precheck_marketplace_mirrors()  # before any write — see docstring
 
     if args.apple: set_plugin_version("apple-dev-skills", args.apple)
     if args.collab: set_plugin_version("collaboration-skills", args.collab)

--- a/scripts/check-consistency.py
+++ b/scripts/check-consistency.py
@@ -85,22 +85,49 @@ for plugin, expected in PLUGINS.items():
         md = sdir / name / "SKILL.md"
         if not md.is_file(): fail(f"[skill] {plugin}/{name}: no SKILL.md"); continue
         fn = fm_field(md, "name")
-        if fn != name: fail(f"[skill] {plugin}/{name}: frontmatter name={fn!r} != dir")
+        # name is legitimately either bare or quoted YAML — strip matching outer quotes
+        # before comparing so `name: "foo"` isn't misreported as name != dir.
+        fn_bare = fn[1:-1] if fn and len(fn) >= 2 and fn[0] in "'\"" and fn[-1] == fn[0] else fn
+        if fn_bare != name: fail(f"[skill] {plugin}/{name}: frontmatter name={fn!r} != dir")
         # 7. description length budget
         desc = fm_field(md, "description")
         # A block scalar (`description: >`) is already YAML-safe: everything after the
         # indicator is literal text, so `: ` and indicator characters need no quoting.
         block = bool(desc) and desc.startswith(BLOCK_SCALAR)
         if block: desc = desc[len(BLOCK_SCALAR):]
-        if desc is None: fail(f"[skill] {plugin}/{name}: no frontmatter description")
-        elif len(desc) > DESC_MAX:
-            fail(f"[skill] {plugin}/{name}: description {len(desc)} chars > {DESC_MAX}")
-        # 10. description must survive a strict YAML parse — fm_field() returns the
-        # raw value (quotes intact, not stripped), so check quoting directly on it.
-        if desc and not block:
-            quoted = len(desc) >= 2 and desc[0] in "'\"" and desc[-1] == desc[0]
-            if not quoted and (": " in desc or desc[0] in "[]{}&*>|#%@`!"):
-                fail(f"[skill] {plugin}/{name}: description must be quoted (contains ': ' or a YAML indicator)")
+        if desc is None:
+            fail(f"[skill] {plugin}/{name}: no frontmatter description")
+        else:
+            quoted = not block and len(desc) >= 2 and desc[0] in "'\"" and desc[-1] == desc[0]
+            # Length counts the value a consumer actually sees (quotes stripped), matching
+            # check-skills.py's parse_front() — otherwise a quoted description that needs
+            # quoting only because of a ': ' or indicator gets penalized twice for it.
+            desc_len = len(desc[1:-1]) if quoted else len(desc)
+            if desc_len > DESC_MAX:
+                fail(f"[skill] {plugin}/{name}: description {desc_len} chars > {DESC_MAX}")
+            # 10. description must survive a strict YAML parse — fm_field() returns the
+            # raw value (quotes intact, not stripped), so check quoting directly on it.
+            if desc and not block:
+                if not quoted:
+                    if ": " in desc or desc[0] in "[]{}&*>|#%@`!":
+                        fail(f"[skill] {plugin}/{name}: description must be quoted (contains ': ' or a YAML indicator)")
+                    if " #" in desc:
+                        fail(f"[skill] {plugin}/{name}: description must be quoted "
+                             f"(contains ' #' — starts a YAML comment, silently truncating the value)")
+                    if desc.startswith("- "):
+                        fail(f"[skill] {plugin}/{name}: description must be quoted "
+                             f"(starts with '- ' — a YAML block-sequence indicator)")
+                    if desc.endswith(":"):
+                        fail(f"[skill] {plugin}/{name}: description must be quoted "
+                             f"(ends with ':' — a YAML mapping-value indicator)")
+                else:
+                    inner = desc[1:-1]
+                    if desc[0] == '"' and re.search(r'(?<!\\)"', inner):
+                        fail(f"[skill] {plugin}/{name}: description has an unescaped "
+                             f'\'"\' inside a double-quoted value — breaks YAML parsing')
+                    if desc[0] == "'" and "'" in re.sub(r"''", "", inner):
+                        fail(f"[skill] {plugin}/{name}: description has an unescaped "
+                             f"\"'\" inside a single-quoted value (use '' to escape) — breaks YAML parsing")
 
 # helper: scope README Catalog section
 def scoped(text: str, *markers: str) -> str:

--- a/scripts/check-externals.py
+++ b/scripts/check-externals.py
@@ -91,9 +91,17 @@ def external_entries(mp: dict) -> list[tuple[str, str, str | None]]:
 
 def probe(repo: str, path: str | None) -> dict:
     info = gh_json("api", f"repos/{repo}", "--jq", "{archived: .archived, license: .license.spdx_id}")
-    tree = gh_json("api", f"repos/{repo}/git/trees/HEAD?recursive=1", "--jq", "[.tree[].path]")
+    resp = gh_json("api", f"repos/{repo}/git/trees/HEAD?recursive=1",
+                   "--jq", "{truncated: .truncated, tree: [.tree[].path]}")
+    if resp.get("truncated"):
+        die(f"[check-externals] {repo}: git tree API response is truncated (repo too large for a "
+            f"single recursive listing) — skill_count below would silently undercount; fetch per-directory instead.")
+    tree = resp["tree"]
     prefix = f"{path}/" if path else ""
     manifest_present = f"{prefix}.claude-plugin/plugin.json" in tree
+    # Only `skills/**/SKILL.md` counts — a repo may keep additional SKILL.md files under a
+    # sibling directory (e.g. upstream apple-skills' `disabled-skills/`, which its own README
+    # documents as not loaded by any agent) that must NOT count toward skill_count.
     skills_prefix = f"{prefix}skills/"
     skill_count = sum(1 for t in tree if t.startswith(skills_prefix) and t.endswith("/SKILL.md"))
     return {

--- a/scripts/check-skills.py
+++ b/scripts/check-skills.py
@@ -43,16 +43,27 @@ def is_quoted_example(body, start, end):
     after = body[end:line_end]
     return bool(re.search(r'"[^"]*$', before)) and bool(re.search(r'^[^"]*"', after))
 
-skills = {}
-for plugin, sub in PLUGINS.items():
-    for d in sorted(glob.glob(os.path.join(ROOT, sub, "*"))):
-        if os.path.isfile(os.path.join(d, "SKILL.md")):
-            skills[os.path.basename(d)] = (plugin, d)
-
 findings = []   # (severity, skill, rule, detail)
 matrix = {}
 def add(sev, skill, rule, detail): findings.append((sev, skill, rule, detail))
 
+skills = {}
+for plugin, sub in PLUGINS.items():
+    for d in sorted(glob.glob(os.path.join(ROOT, sub, "*"))):
+        if os.path.isfile(os.path.join(d, "SKILL.md")):
+            base = os.path.basename(d)
+            if base in skills and skills[base][0] != plugin:
+                add("BLOCKER", base, "duplicate skill name across plugins",
+                    f"{skills[base][0]}/{skills[base][1]} vs {plugin}/{d}")
+            skills[base] = (plugin, d)
+
+if not skills:
+    print(f"ERROR: 0 skills found under repo-root {ROOT!r} (looked for */SKILL.md under "
+          f"{list(PLUGINS.values())}) — wrong <repo-root> argument? "
+          f"Usage: python3 check-skills.py <repo-root> [--md out.md]", file=sys.stderr)
+    sys.exit(1)
+
+total_desc_chars = 0
 for name, (plugin, d) in skills.items():
     path = os.path.join(d, "SKILL.md")
     text = open(path, encoding="utf-8").read()
@@ -70,6 +81,7 @@ for name, (plugin, d) in skills.items():
         add("MINOR", name, "name reserved word", f"{n} (only blocks the claude.ai upload path, not Claude Code)")
     # --- official description rules
     desc = fm.get("description","")
+    total_desc_chars += len(desc)
     if not desc: add("BLOCKER", name, "description empty", "")
     L = len(desc) + len(fm.get("when_to_use",""))
     if len(desc) > 1024: add("BLOCKER", name, "description<=1024 (API)", f"{len(desc)}")
@@ -136,6 +148,18 @@ out = []
 out.append(f"# Skill gate report — {len(skills)} skills\n")
 counts = {s: sum(1 for f in findings if f[0]==s) for s in sev_order}
 out.append(f"BLOCKER {counts['BLOCKER']} · MAJOR {counts['MAJOR']} · MINOR {counts['MINOR']}\n")
+# Description budget WARN (not gated): the official `skillListingBudgetFraction` setting
+# defaults to 0.01 of a model's context window — for a 200k-token model that's ~2000 tokens
+# reserved for the always-on skill listing shown before any skill is invoked. Estimate
+# tokens as chars/4 (no tokenizer dependency); warn only, never fail the gate on this.
+DESC_BUDGET_TOKENS = 2000
+CHARS_PER_TOKEN = 4
+est_tokens = total_desc_chars / CHARS_PER_TOKEN
+if est_tokens > DESC_BUDGET_TOKENS:
+    out.append(f"WARN: {len(skills)} descriptions total {total_desc_chars} chars "
+               f"(~{est_tokens:.0f} tokens at ~{CHARS_PER_TOKEN} chars/token) > default "
+               f"skillListingBudgetFraction budget (~{DESC_BUDGET_TOKENS} tokens for a 200k-token "
+               f"model) — not gated\n")
 out.append("## Findings\n\n| sev | skill | rule | detail |\n|---|---|---|---|")
 for s, n, r, dt in findings:
     dt = dt.replace("|", "&#124;")
@@ -152,5 +176,5 @@ report = "\n".join(out)
 if "--md" in sys.argv: open(sys.argv[sys.argv.index("--md")+1], "w").write(report)
 print(report if "--md" not in sys.argv else f"wrote report; {counts}")
 
-if counts["BLOCKER"] > 0:
+if counts["BLOCKER"] > 0 or counts["MAJOR"] > 0:
     sys.exit(1)

--- a/scripts/mirrors.py
+++ b/scripts/mirrors.py
@@ -4,9 +4,11 @@ Each entry maps a mirror file to the heading text that opens its localized
 Catalog-equivalent section (used by check-consistency.py rule 9 to scope the
 coverage check, mirroring rule 2's scoping of README.md's own "## Catalog").
 
-Add a locale here — and only here — when a new language mirror lands; both
 check-consistency.py and bump-version.py loop over this mapping instead of
-hardcoding a filename.
+hardcoding a filename — but adding a new language mirror still touches four
+places, not just this file: this MIRRORS dict, check-consistency.py's
+MIRROR_TASK (mirror filename -> its regenerator task), scripts/gen-readme-zh.sh's
+locale case statement, and .mise.toml's per-locale `readme-*` task definition.
 """
 MIRRORS = {
     "README.zh-Hant.md": "## 目錄",


### PR DESCRIPTION
## Summary

Landing PR-3 of 4 parallel Fable-review remediation PRs (scripts/gate/CI infra;
see internal handoff `2026-09-12-fable-review/REPORT-C-infra.md`). Base:
`origin/main` @ e6b599c (post-#79; only touches `collaboration-skills/**`, no
overlap with this PR's `scripts/**`/`.github/**` scope).

- **`check-skills.py`**: fails the gate on any MAJOR (not just BLOCKER, zero
  cost today); a 0-skill run under the given repo-root now exits 1 with a
  clear message instead of silently exiting 0; a skill-name collision across
  the two plugins is now a BLOCKER instead of a silent dict-overwrite; new
  WARN (ungated) when the 38 descriptions' total length exceeds the official
  `skillListingBudgetFraction` default budget (~2000 tokens for a 200k-token
  model) — currently ~5.5k tokens.
- **`check-consistency.py`**: the quote gate only rejected `': '` or a leading
  YAML indicator char; verified against PyYAML that 4 more patterns also break
  or silently mis-parse (unquoted `' #'` truncates mid-comment, unquoted
  trailing `:`, unquoted leading `- `, an unescaped quote inside an
  already-quoted value) and gated all of them. Also fixed two misfires found
  in the same pass: `name: "quoted"` was wrongly flagged as `!= dir`, and the
  800-char limit double-counted wrapping quote characters versus
  `check-skills.py`.
- **`check-externals.py`**: die on a truncated tree-API response instead of
  silently undercounting; accepted the `apple-skills` drift
  (`skill_count: 33 -> 31`) after confirming it's upstream skills moving into
  their own `disabled-skills/` dir (not new skills, no overlap introduced) —
  license/manifest/archived status all unchanged.
- **`bump-version.py`**: the marketplace mirror-staleness precheck now runs
  before any file write, so a combined `--apple --marketplace` bump can't die
  partway through with two files already written.
- **`lefthook.yml`**: dropped the three README regen pre-commit hooks — they
  silently clobbered a hand-mirrored edit unless `LEFTHOOK_EXCLUDE` was
  remembered on every commit, the opposite of the documented default.
  Regeneration is now purely manual; `CONTRIBUTING.md` and `.mise.toml`
  updated to match.
- **`.github/workflows/**`**: bumped `actions/checkout` v4→v7,
  `jdx/mise-action` v2→v4, `wei18/upkeep` reusable workflow v1→v2 (verified
  the v2 workflow's `secrets`/inputs contract is unchanged); fixed the audit
  workflow's cron comment (says "daily", schedule is weekly).
- **`mirrors.py`**: corrected the "add a locale here — and only here"
  docstring claim (it's actually 4 places).

## Verification

`mise trust && mise run check` — green (BLOCKER 0 · MAJOR 0 · MINOR 1,
pre-existing reserved-word MINOR, unrelated to this PR).

Negative-test matrix (each gate change: broke it → confirmed red → restored →
confirmed green):
- 0-skill false green: running check-skills.py with a repo-root that resolves
  to no skills → now exit 1 with message (was exit 0).
- MAJOR now gates: injected an unknown frontmatter key → exit 1 (was exit 0).
- Duplicate skill name across plugins → BLOCKER, exit 1.
- 5 quote-gate patterns (` #` mid-value, unescaped `"`/`'` inside a quoted
  value, trailing `:`, leading `- `) — each individually injected into a real
  skill's description → each caught (`FAIL`, exit 1) → restored → green.
- `name: "quoted"` misfire and the 800-char quote-counting misfire — both
  confirmed fixed (green where they'd previously have failed).
- Description-budget WARN — confirmed it prints on the current catalog
  (~5.5k tokens) without affecting exit code.
- `check-externals.py` truncated-tree guard — unit-tested via a monkey-patched
  `gh_json` returning `truncated: true`; confirmed `SystemExit(1)`.
- `bump-version.py` atomicity — staled a mirror's `src-sha`, ran a combined
  `--apple --marketplace` bump, confirmed `plugin.json`/`marketplace.json`
  were untouched after the expected die (previously they'd have been written
  first).

## Out of scope / deferred (see full report to Leader for detail)

- `install-flat.sh`'s hardcoded `wei18/apple-dev-skills` (medium confidence,
  no applicable official source to verify a fork-support redesign against —
  left unverified/unchanged).
- Adding `permissions:` blocks beyond what's already in `audit.yml`.
- A scheduled `check-externals` drift-detection workflow (proposed, not
  implemented per dispatch).
- README-facing consequences of the externals drift (belongs to the parallel
  README PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
