### PR TITLE
docs(readme): fix caveman token claim, skillOverrides advice, dangling fragments

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -27,7 +27,7 @@
     {
       "name": "apple-skills",
       "source": { "source": "github", "repo": "Prisma-Labs-Dev/apple-skills" },
-      "description": "Aggregated (not authored here). Broad Apple-framework skills — SwiftUI, UIKit, Swift Testing, Concurrency, SwiftData, App Intents, WidgetKit, StoreKit, HealthKit, MapKit, TipKit, and more. By Prisma Labs (vabole), MIT.",
+      "description": "Aggregated (not authored here). Broad Apple-framework skills — SwiftUI, UIKit, Swift Testing, Concurrency, SwiftData, App Intents, WidgetKit, StoreKit, HealthKit, MapKit, TipKit, apple-aso, hig, simulator-utils, xcuitest, and more (a handful more ship disabled by default in disabled-skills/). By Prisma Labs (vabole), MIT.",
       "author": { "name": "Prisma Labs (vabole)" },
       "category": "workflow"
     },
@@ -48,7 +48,7 @@
     {
       "name": "caveman",
       "source": { "source": "github", "repo": "JuliusBrussee/caveman" },
-      "description": "Aggregated (not authored here). Ultra-compressed communication mode that cuts ~75% of tokens, now grown into a 20-skill suite (commit discipline, review, refactor verbs, plus 4 skills — caveman-discover, caveman-manage, caveman-evidence-review, caveman-setup — for the author's hosted Caveman Cloud commercial service). General agent behavior. By JuliusBrussee; skills are MIT, the repo also ships a Business Source License 1.1 engine.",
+      "description": "Aggregated (not authored here). Ultra-compressed communication mode that cuts ~65% of output tokens (author's measurement), now grown into a 20-skill suite (commit discipline, review, refactor verbs, plus 4 skills — caveman-discover, caveman-manage, caveman-evidence-review, caveman-setup — for the author's hosted Caveman Cloud commercial service). Ships SessionStart and UserPromptSubmit hooks (needs node on PATH; runs on every prompt). General agent behavior. By JuliusBrussee; skills are MIT, the repo also ships a Business Source License 1.1 engine.",
       "author": { "name": "JuliusBrussee" },
       "category": "workflow"
     },

--- a/README.ja.md
+++ b/README.ja.md
@@ -5,13 +5,14 @@
 >
 > 言語：[English](README.md) · [繁體中文](README.zh-Hant.md) · [简体中文](README.zh-Hans.md) · [日本語](README.ja.md)
 
-apple-dev-skillsは、アイデアをApp Storeへのリリースまで導く個人開発者や小規模チームのための
-**マーケットプレイス**です。ファーストパーティのスキルは大きく二つに分かれています。作って
-いるものそのものを担う**Apple/Swift**スキルと、Claude Code自体の操り方——計画、レビュー、
-リリース——を担う**harness engineering**スキルです。どのスキルも実際にリリースまで漕ぎ着けた
-実戦のエピソードに裏打ちされた、立場のある既定値であり、一貫性ゲートによって守られています。
-あわせて、他に類を見ない**外部**スキルプラグインを**参照という形で集約**し——ここでは書かず、
-リンクと著者クレジットのみで——決してコピーせずに並べています。
+apple-dev-skillsは、**iOS 26 / macOS 26を下限**とした新規（greenfield）アプリを、アイデアから
+App Storeへのリリースまで導く個人開発者や小規模チームのための**マーケットプレイス**です。
+ファーストパーティのスキルは大きく二つに分かれています。作っているものそのものを担う
+**Apple/Swift**スキルと、**harness engineering**スキル（Claude Code自体の操り方——ディスパッチ、
+レビュー、リリース）です。どのスキルも実際にリリースまで漕ぎ着けた実戦のエピソードに裏打ち
+された、立場のある既定値であり、一貫性ゲートによって守られています。あわせて、他に類を
+見ない**外部**スキルプラグインを**参照という形で集約**し——ここでは書かず、リンクと著者
+クレジットのみで——決してコピーせずに並べています。
 
 ## クイックスタート
 
@@ -23,11 +24,15 @@ Claude Codeのsession内で実行します。
 ```
 /plugin marketplace add wei18/apple-dev-skills
 /plugin install apple-dev-skills@apple-dev-skills          # 26 Apple/Swift skills
-/plugin install collaboration-skills@apple-dev-skills      # 12 agent-collaboration skills
+/plugin install collaboration-skills@apple-dev-skills      # 12 harness-engineering skills
 ```
 
-インストール結果に`Run /reload-plugins to activate.`と表示されたら実行してください——古い
-クライアントでは常に必要な手順です。
+インストールするたびに詳細ペインが開きます——**User**スコープを選んでください。形式は
+`plugin@marketplace`で、このmarketplaceはたまたま最初のpluginと同じ名前です。
+
+インストール結果に`Run /reload-plugins to activate.`と表示された場合、Claude Codeが自動的に
+実行します。次のメッセージで会話を再読み込みすると警告された場合は、`/reload-plugins --force`
+を実行してください。
 
 どちらか一方でも両方でもインストール可能です。外部プラグインも同じ方法でインストールできます。
 例：`/plugin install swiftui-expert@apple-dev-skills`。
@@ -43,9 +48,13 @@ Claude Codeのsession内で実行します。
 `/apple-dev-skills:swift6-concurrency`。`/skills`でインストール済みのスキル一覧と、それぞれが
 どのプラグイン由来かを確認できます。
 
-> 新しくインストールされたスキルは、Claude Codeのスキル一覧のcontext予算が溢れたときに
-> 最初に説明文を失います。`/doctor`で一覧のコストを確認してください。厳しい場合はsettingsで
-> `skillListingBudgetFraction` / `skillOverrides`を調整してください。
+> 両方のプラグインをインストールすると、ファーストパーティの説明文が全38件——約5,500
+> トークン——読み込まれます。これはデフォルトの1%スキル一覧予算（200kコンテキストモデルで
+> 2,000トークン）の約2.7倍で、外部プラグインを含めない数字です。スキル一覧の予算はcontext
+> windowの1%です。溢れると、Claude Codeは呼び出し頻度が低いスキルから順に説明文を落とし
+> ます——新しくインストールしたスキルはその筆頭です。`/doctor`で一覧のコストを確認し、
+> 厳しければ`skillListingBudgetFraction`（例：`0.02`）を上げるか、使わないpluginを
+> `/plugin`から無効化してください。
 
 ## カタログ
 
@@ -63,7 +72,7 @@ Claude Codeのsession内で実行します。
 | Skill | 一言でいうと |
 |---|---|
 | `swift6-concurrency` | Swift 6言語モード + 完全なconcurrencyチェック；デフォルトのactor isolationは`MainActor`、`nonisolated` / actorへ跨る箇所のみSendableが必要 |
-| `apple-platform-targets` | デフォルトはiOS 26 / macOS 26、Xcode 26.x；既存ユーザーが旧バージョンの場合のみ18 / 15へ下げる |
+| `apple-platform-targets` | デフォルトはiOS 26 / macOS 26、Xcode 26.x；既存ユーザーが旧バージョンの場合のみiOS 18 / macOS 15（または17 / 14）へ下げる |
 | `swiftpm-modularization` | 単一Package、マルチtarget、薄いApp、DI composition root、テストは1対1 |
 | `swift-testing-baseline` | swift-testing + pointfreeco snapshot；protocol fake；厳格/寛容なsnapshotゲート |
 | `xcode-cloud-single-track-ci` | シングルトラックのXcode Cloud；PR / Main / Release / Periodic；merge前のPR CI |
@@ -87,24 +96,26 @@ Claude Codeのsession内で実行します。
 | `ios-design-mockup` | specから単一HTMLファイルのiOSデザインモックアップを生成——iPhoneフレーム + トークン |
 | `interactive-simulator-ux-audit` | `idb`（tap/describe/screenshot）で起動中のSimulatorを操作し、スナップショットでは見つからないナビゲーション／モーダル／safe-areaのバグを検出 |
 | `host-driven-xcuitest-e2e` | Tuist経由でアプリを起動しXCUITest E2Eを実行——専用scheme配線 + macOSウィンドウ座標でのクリック操作 |
-| `cloudkit-schema-source-of-truth` | バージョン管理された`.ckdb` + `cktool`によるDevelopmentへのexport／validate／deploy；ProductionはConsoleのみのユーザー管理ゲート |
+| `cloudkit-schema-source-of-truth` | バージョン管理された`.ckdb` + `cktool`によるDevelopmentへのexport／validate／import；ProductionはConsoleのみのユーザー管理ゲート |
 
 ### collaboration-skills（12）—— harness engineering：ディスパッチ、レビュー、リリース
 
 | Skill | 一言でいうと |
 |---|---|
 | `spec-phase-orchestration` | 実装前のドキュメントパイプライン；セクションごとの承認 |
-| `subagent-review-cycles` | Leader / Developer / Code-Reviewerのトライアド；1ラウンド目の外観上の指摘はinlineで即対応；limit(N) |
+| `subagent-review-cycles` | Leader / Developer / Code-Reviewerのトライアド；ラウンド数と却下の基準 |
 | `leader-developer-handoff-contract` | sub-agentへのディスパッチ時に必須の6要素 |
-| `agent-impl-notes-log` | sub-agentタスク進行中のリアルタイムimpl-notes——意思決定、逸脱、未解決の疑問 |
+| `agent-impl-notes-log`† | sub-agentタスク進行中のリアルタイムimpl-notes——意思決定、逸脱、未解決の疑問 |
 | `subagent-conflict-detection` | 新しいsub-agentの作業対象が進行中のworktreeと重複していないか確認 |
-| `methodology-pattern-extractor` | 会議記録から3回以上繰り返されるパターンを抽出 |
-| `session-to-meeting-log` | Claude Codeのsessionを会議記録にまとめる；逐語録ではなく要約 |
+| `methodology-pattern-extractor`† | 会議記録から3回以上繰り返されるパターンを抽出 |
+| `session-to-meeting-log`† | Claude Codeのsessionを会議記録にまとめる；逐語録ではなく要約 |
 | `pr-diff-verification` | push／PR作成前に`git show --stat --summary HEAD`がcommitの主張と一致することを確認 |
-| `backlog-routing-by-topic` | 散発的なアイデアをトピックごとに対応するspecファイルの§Backlogへ振り分け |
-| `claude-skill-plugin-packaging` | Claude Codeスキルの配布／インストール——depth-1ルール、plugin + marketplace、集約 |
+| `backlog-routing-by-topic`† | 散発的なアイデアをトピックごとに対応するspecファイルの§Backlogへ振り分け |
+| `claude-skill-plugin-packaging` | Claude Codeスキルの配布／インストール——depth-1ルール、plugin + marketplace、プロジェクト単位で固定インストール、参照による集約 |
 | `skill-authoring-patterns` | `superpowers:writing-skills`の上に重なるApple/Swiftカタログ層——routerの説明文、bookendセクション、二層のreferences、エビデンスベースのCR |
-| `github-contribution-workflow` | gh-CLIによるコントリビューションループ——PR、issue、GitHubファイル操作、secrets、コントリビューションフローのrepo設定；規約 + merge前のCLEAN |
+| `github-contribution-workflow` | gh-CLIによるコントリビューションループ——PR、issue、GitHubファイル操作、secrets、コントリビューションフローのrepo設定；規約 |
+
+† `spec-phase-orchestration`のドキュメント構成（`design.md` / `plan.md` / `meetings/`）を前提とします。
 
 ### 外部プラグイン集約（7）—— 参照によるクレジット付き集約
 
@@ -119,12 +130,12 @@ APIです、Xはこう作ります」。ファーストパーティのスキル�
 OSLogのみ、避けるべき既知の実行時バグ）。トピックが重なる箇所でも、両者は重複ではなく、
 答える詳細度のレベルが違うだけです。
 
-| Plugin | Author | Covers |
+| Plugin | 作者 | 対象範囲 |
 |---|---|---|
-| [`apple-skills`](https://github.com/Prisma-Labs-Dev/apple-skills) | Prisma Labs (vabole), MIT | 幅広いAppleフレームワーク——SwiftUI、SwiftData、App Intents、WidgetKit、StoreKit、HealthKit……に加え、SwiftUIパフォーマンス監査ガイド（コードファースト、view-update要因）も収録。`ios-performance-engineering` のInstruments / MetricKit計測と相補的 |
+| [`apple-skills`](https://github.com/Prisma-Labs-Dev/apple-skills) | Prisma Labs (vabole), MIT | 幅広いAppleフレームワーク——SwiftUI、SwiftData、App Intents、WidgetKit、StoreKit、HealthKit、`apple-aso`、`hig`……に加え、SwiftUIパフォーマンス監査ガイドも収録。`ios-performance-engineering`のInstruments / MetricKit計測と相補的。さらに`simulator-utils`と`xcuitest`も収録（このカタログのSimulator／XCUITestスキルとの役割分担は下記参照）。一部のスキルは`disabled-skills/`に置かれており、リポジトリには残るもののagentには読み込まれません |
 | [`swiftui-expert`](https://github.com/AvdLee/SwiftUI-Agent-Skill) | Antoine van der Lee (MIT) | SwiftUIパターン、Swift Charts、Liquid Glass、Instrumentsツールチェーン |
 | [`swiftui-pro`](https://github.com/twostraws/SwiftUI-Agent-Skill) | Paul Hudson (MIT) | SwiftUIの落とし穴、非推奨APIのウォッチリスト、iOS 26 / Liquid Glass |
-| [`caveman`](https://github.com/JuliusBrussee/caveman) | JuliusBrussee (MIT) | 超圧縮されたコミュニケーションモード——トークンを約75%削減（汎用的なagentの振る舞い） |
+| [`caveman`](https://github.com/JuliusBrussee/caveman) | JuliusBrussee (MIT) | 超圧縮されたコミュニケーションモード——出力トークンを約65%削減（著者による計測）。`SessionStart`／`UserPromptSubmit`フックを追加インストール（PATH上に`node`が必要、毎回のプロンプトで実行）（汎用的なagentの振る舞い） |
 | [`ponytail`](https://github.com/DietrichGebert/ponytail) | DietrichGebert (MIT) | 「怠け者のシニア開発者」モード——最もシンプルで最短の解法を強制する（汎用的なagentの振る舞い） |
 | [`i-have-adhd`](https://github.com/ayghri/i-have-adhd) | Ayoub G. (MIT) | 常時ONのADHDフレンドリーな出力モード——番号付きステップ、毎ターン状態を再掲示（汎用的なagentの振る舞い） |
 | [`xcode-build-skill`](https://github.com/pzep1/xcode-build-skill) | pz (MIT) | `xcodebuild`/`xcrun simctl` CLIチートシート——scheme → simulator → build → install → launch → screenshot |
@@ -132,19 +143,22 @@ OSLogのみ、避けるべき既知の実行時バグ）。トピックが重な
 `caveman`のライセンス：skills自体はMIT、repoにはBSL-1.1ライセンスのengineも含まれています。
 `caveman`はその後20スキルからなるスイートへと成長しました。そのうち4つ（`caveman-discover`、
 `caveman-manage`、`caveman-evidence-review`、`caveman-setup`）は、著者自身がホストする商用
-サービスCaveman Cloudについて説明したものです（汎用的なagentの振る舞い）。
+サービスCaveman Cloudについて説明したものです。
 
 `i-have-adhd`は`caveman`（トークン圧縮）や`ponytail`（解法の単純化）とは異なり、構造を
 形作ります。
 
-`xcode-build-skill`はCLI駆動で、`interactive-simulator-ux-audit`（idb駆動のインタラクティブ
-UX監査）や`host-driven-xcuitest-e2e`（Tuist scheme配線のXCUITest E2E）とは別物です——三者は
-重複しません。
+`xcode-build-skill`（`xcodebuild`/`simctl`のループ）と`apple-skills:simulator-utils`
+（`simctl`の単発操作）はCLIリファレンスです。`interactive-simulator-ux-audit`は探索的な監査
+のために`idb`を操作し、`host-driven-xcuitest-e2e`はCI向けにTuist schemeを配線します——
+`apple-skills:xcuitest`はそれが前提とするAPIリファレンスです。
 
 `apple-skills`は`vabole`の個人アカウントから`Prisma-Labs-Dev`organizationへ移管されました。
 この表には移管後のrepoを掲載しています。
 
 ## 他のインストール方法
+
+（Aは上記のクイックスタートです。）
 
 ### B —— チーム向けの固定バージョン
 
@@ -166,8 +180,10 @@ UX監査）や`host-driven-xcuitest-e2e`（Tuist scheme配線のXCUITest E2E）�
 ```
 
 これをcommitしておけば、コラボレーターがそのプロジェクトフォルダを信頼した時点で、追加の
-確認なしに自動的にこのmarketplaceが使えるようになります。それでもClaude Codeがあるプラグイン
-を未インストールと報告する場合は、表示された`/plugin install`コマンドを一度実行してください。
+確認なしに自動的にこのmarketplaceが使えるようになります。2つのファーストパーティプラグイン
+は相対パスのエントリなので、この時点でインストール済みです。外部プラグインはGitHubソース
+のため、`enabledPlugins`は他の人には自動インストールされません——各コラボレーターは、
+Claude Codeが表示する`claude plugin install …`の行を一度実行する必要があります。
 
 ### C —— `npx skills`（フラット、プラグイン不使用）
 
@@ -205,4 +221,4 @@ scripts/install-flat.sh --dry-run   # preview the `npx skills add` commands
 `docs/superpowers/`にありました——現在は廃止され、git履歴として保存されています。
 `git log -- docs/`で見つけることができます。MIT——[LICENSE](LICENSE)を参照してください。
 
-<!-- src-sha: 92addee1cd524bf074406c50bf882691f565f7a8 -->
+<!-- src-sha: 717b9af19a42afc699c85476dae674477abc3726 -->

--- a/README.ja.md
+++ b/README.ja.md
@@ -52,7 +52,7 @@ Claude Codeのsession内で実行します。
 > トークン——読み込まれます。これはデフォルトの1%スキル一覧予算（200kコンテキストモデルで
 > 2,000トークン）の約2.7倍で、外部プラグインを含めない数字です。スキル一覧の予算はcontext
 > windowの1%です。溢れると、Claude Codeは呼び出し頻度が低いスキルから順に説明文を落とし
-> ます——新しくインストールしたスキルはその筆頭です。`/doctor`で一覧のコストを確認し、
+> ます。実際には、まだ呼び出し履歴のない新しくインストールしたスキルがそれに当たりがちです。`/doctor`で一覧のコストを確認し、
 > 厳しければ`skillListingBudgetFraction`（例：`0.02`）を上げるか、使わないpluginを
 > `/plugin`から無効化してください。
 
@@ -221,4 +221,4 @@ scripts/install-flat.sh --dry-run   # preview the `npx skills add` commands
 `docs/superpowers/`にありました——現在は廃止され、git履歴として保存されています。
 `git log -- docs/`で見つけることができます。MIT——[LICENSE](LICENSE)を参照してください。
 
-<!-- src-sha: 717b9af19a42afc699c85476dae674477abc3726 -->
+<!-- src-sha: 7699870110c96d109c7bcda48151e19787a07aa3 -->

--- a/README.md
+++ b/README.md
@@ -5,13 +5,13 @@
 >
 > Languages: [English](README.md) · [繁體中文](README.zh-Hant.md) · [简体中文](README.zh-Hans.md) · [日本語](README.ja.md)
 
-apple-dev-skills is one **marketplace** for independent developers and small teams
-taking an idea to a shipped App Store release. Its first-party skills come in two halves:
-**Apple/Swift** skills for what you are building, and **harness engineering** skills for
-how you direct Claude Code itself — planning, reviewing, and shipping the work. Every
-skill is an opinionated default backed by a shipped-it war story and held to a consistency
-gate. Alongside them sit best-of-breed **external** skill plugins, **aggregated by
-reference** — not written here, linked and credited to their authors, never copied.
+apple-dev-skills is one **marketplace** for independent developers and small teams building
+a new, greenfield app on the **iOS 26 / macOS 26 floor** — from idea to a shipped App Store
+release. Its first-party skills come in two halves: **Apple/Swift** skills for what you are
+building, and **harness engineering** skills (how you run Claude Code itself — dispatch,
+review, ship). Every skill is an opinionated default backed by a shipped-it war story and held
+to a consistency gate. Alongside them sit best-of-breed **external** skill plugins, **aggregated
+by reference** — not written here, linked and credited to their authors, never copied.
 
 ## Quickstart
 
@@ -22,10 +22,14 @@ Inside a Claude Code session, run:
 ```
 /plugin marketplace add wei18/apple-dev-skills
 /plugin install apple-dev-skills@apple-dev-skills          # 26 Apple/Swift skills
-/plugin install collaboration-skills@apple-dev-skills      # 12 agent-collaboration skills
+/plugin install collaboration-skills@apple-dev-skills      # 12 harness-engineering skills
 ```
 
-If the install summary says `Run /reload-plugins to activate.`, run it — older clients always need it.
+Each install opens a details pane — pick **User** scope. The form is `plugin@marketplace`;
+the marketplace happens to share its first plugin's name.
+
+If the install summary says `Run /reload-plugins to activate.`, Claude Code runs it for you;
+if it warns that your next message would re-read the conversation, run `/reload-plugins --force`.
 
 Install either or both. Externals install the same way, e.g. `/plugin install swiftui-expert@apple-dev-skills`.
 
@@ -39,9 +43,12 @@ Then just describe the task:
 To force one, use its slash command: `/apple-dev-skills:swift6-concurrency`. `/skills` lists
 what is installed and which plugin each skill came from.
 
-> Newly installed skills are first to lose their descriptions if Claude Code's skill-listing
-> context budget overflows. Run `/doctor` to check the listing's cost; tune
-> `skillListingBudgetFraction` / `skillOverrides` in settings if it's too tight.
+> Installing both plugins loads all 38 first-party descriptions — about 5,500 tokens, ~2.7×
+> the default 1% skill-listing budget (2,000 tokens on a 200k-context model) — before any
+> externals. The skill-listing budget is 1% of the context window; when it overflows, Claude
+> Code drops descriptions starting with the skills you invoke least — freshly installed ones
+> first. Run `/doctor` to check the listing's cost, then raise `skillListingBudgetFraction`
+> (e.g. `0.02`) if it's tight, or disable plugins you don't use via `/plugin`.
 
 ## Catalog
 
@@ -59,7 +66,7 @@ Full index in the tables below.
 | Skill | One-liner |
 |---|---|
 | `swift6-concurrency` | Swift 6 language mode + complete concurrency checking; `MainActor` by default, Sendable only where code crosses into `nonisolated`/actor context |
-| `apple-platform-targets` | Default iOS 26 / macOS 26, Xcode 26.x; drop to 18 / 15 only when an older user base requires it |
+| `apple-platform-targets` | Default iOS 26 / macOS 26, Xcode 26.x; drop to iOS 18 / macOS 15 (or 17 / 14) only when an older user base requires it |
 | `swiftpm-modularization` | Single Package, multi-target, thin App, DI composition root, one-to-one tests |
 | `swift-testing-baseline` | swift-testing + pointfreeco snapshot; protocol fakes; strict/tolerant snapshot gate |
 | `xcode-cloud-single-track-ci` | Single-track Xcode Cloud; PR / Main / Release / Periodic; pre-merge PR CI |
@@ -83,24 +90,26 @@ Full index in the tables below.
 | `ios-design-mockup` | Single-file HTML iOS design mockup from a spec — iPhone frames + tokens |
 | `interactive-simulator-ux-audit` | Drive a booted Simulator with `idb` (tap/describe/screenshot) to catch nav/modal/safe-area bugs snapshots can't |
 | `host-driven-xcuitest-e2e` | Launch-the-app XCUITest E2E via Tuist — dedicated scheme wiring + macOS window-frame click driving |
-| `cloudkit-schema-source-of-truth` | Committed `.ckdb` + `cktool` export/validate/deploy to Development; Production is a user-owned Console-only gate |
+| `cloudkit-schema-source-of-truth` | Committed `.ckdb` + `cktool` export/validate/import to Development; Production is a user-owned Console-only gate |
 
 ### collaboration-skills (12) — harness engineering: dispatch, review, ship
 
 | Skill | One-liner |
 |---|---|
 | `spec-phase-orchestration` | Pre-implementation doc pipeline; section-by-section approval |
-| `subagent-review-cycles` | Leader / Developer / Code-Reviewer triad; round-1 cosmetic inline; limit(N) |
+| `subagent-review-cycles` | Leader / Developer / Code-Reviewer triad; how many rounds, what counts as a rejection |
 | `leader-developer-handoff-contract` | 6 required elements when dispatching a sub-agent |
-| `agent-impl-notes-log` | Running impl-notes during a sub-agent task — decisions, deviations, open questions |
+| `agent-impl-notes-log`† | Running impl-notes during a sub-agent task — decisions, deviations, open questions |
 | `subagent-conflict-detection` | Check a new sub-agent's targets don't overlap an in-flight worktree |
-| `methodology-pattern-extractor` | Extract patterns recurring ≥3 times from meeting logs |
-| `session-to-meeting-log` | Consolidate a Claude Code session into a meeting log; summary, not verbatim |
+| `methodology-pattern-extractor`† | Extract patterns recurring ≥3 times from meeting logs |
+| `session-to-meeting-log`† | Consolidate a Claude Code session into a meeting log; summary, not verbatim |
 | `pr-diff-verification` | Before push/PR, verify `git show --stat --summary HEAD` matches the commit's claims |
-| `backlog-routing-by-topic` | Route stray ideas by topic to the matching spec file's §Backlog |
-| `claude-skill-plugin-packaging` | Distribute/install Claude Code skills — depth-1 rule, plugin + marketplace, aggregation |
+| `backlog-routing-by-topic`† | Route stray ideas by topic to the matching spec file's §Backlog |
+| `claude-skill-plugin-packaging` | Distribute/install Claude Code skills — depth-1 rule, plugin + marketplace, install pinned per project, aggregate by reference |
 | `skill-authoring-patterns` | Apple/Swift catalog layer over `superpowers:writing-skills` — router descriptions, bookend sections, two-tier references, evidence-based CR |
-| `github-contribution-workflow` | gh-CLI contribution loop — PRs, issues, GitHub file ops, secrets, contribution-flow repo settings; conventions + CLEAN-before-merge |
+| `github-contribution-workflow` | gh-CLI contribution loop — PRs, issues, GitHub file ops, secrets, contribution-flow repo settings; conventions |
+
+† Assumes the `spec-phase-orchestration` doc layout (`design.md` / `plan.md` / `meetings/`).
 
 ### Aggregated external (7) — by reference, credited
 
@@ -116,10 +125,10 @@ level of detail.
 
 | Plugin | Author | Covers |
 |---|---|---|
-| [`apple-skills`](https://github.com/Prisma-Labs-Dev/apple-skills) | Prisma Labs (vabole), MIT | Broad Apple frameworks — SwiftUI, SwiftData, App Intents, WidgetKit, StoreKit, HealthKit …, and a SwiftUI performance audit guide (code-first, view-update causes) that complements `ios-performance-engineering`'s Instruments/MetricKit measurement |
+| [`apple-skills`](https://github.com/Prisma-Labs-Dev/apple-skills) | Prisma Labs (vabole), MIT | Broad Apple frameworks — SwiftUI, SwiftData, App Intents, WidgetKit, StoreKit, HealthKit, `apple-aso`, `hig` …; a SwiftUI performance audit guide that complements `ios-performance-engineering`'s Instruments/MetricKit measurement; also ships `simulator-utils` and `xcuitest` (see below for how those line up against this catalog's Simulator/XCUITest skills). A handful of its skills sit in `disabled-skills/` — kept in the repo but not loaded by agents |
 | [`swiftui-expert`](https://github.com/AvdLee/SwiftUI-Agent-Skill) | Antoine van der Lee (MIT) | SwiftUI patterns, Swift Charts, Liquid Glass, Instruments toolchain |
 | [`swiftui-pro`](https://github.com/twostraws/SwiftUI-Agent-Skill) | Paul Hudson (MIT) | SwiftUI pitfalls, deprecated-API watchlist, iOS 26 / Liquid Glass |
-| [`caveman`](https://github.com/JuliusBrussee/caveman) | JuliusBrussee (MIT) | Ultra-compressed communication mode — cuts ~75% of tokens (general agent behavior) |
+| [`caveman`](https://github.com/JuliusBrussee/caveman) | JuliusBrussee (MIT) | Ultra-compressed communication mode — cuts ~65% of output tokens (author's measurement); ships `SessionStart`/`UserPromptSubmit` hooks (needs `node` on PATH, runs every prompt) (general agent behavior) |
 | [`ponytail`](https://github.com/DietrichGebert/ponytail) | DietrichGebert (MIT) | "Lazy senior dev" mode — forces the simplest, shortest solution (general agent behavior) |
 | [`i-have-adhd`](https://github.com/ayghri/i-have-adhd) | Ayoub G. (MIT) | Always-on ADHD-friendly output mode — numbered steps, state restated each turn (general agent behavior) |
 | [`xcode-build-skill`](https://github.com/pzep1/xcode-build-skill) | pz (MIT) | `xcodebuild`/`xcrun simctl` CLI cheatsheet — schemes → simulators → build → install → launch → screenshot |
@@ -127,19 +136,22 @@ level of detail.
 `caveman`'s license: skills MIT; repo also ships a BSL-1.1 engine. `caveman` has since grown
 into a 20-skill suite; 4 of them (`caveman-discover`, `caveman-manage`,
 `caveman-evidence-review`, `caveman-setup`) document the author's hosted Caveman Cloud commercial
-service (general agent behavior).
+service.
 
-`i-have-adhd` vs `caveman` (token compression) and `ponytail` (solution simplicity), this shapes
-structure.
+Unlike `caveman` (token compression) and `ponytail` (solution simplicity), `i-have-adhd` shapes
+the *structure* of every answer.
 
-`xcode-build-skill` is CLI-driven, distinct from `interactive-simulator-ux-audit` (idb-driven
-interactive UX audit) and `host-driven-xcuitest-e2e` (Tuist-scheme XCUITest E2E) — the three
-don't overlap.
+`xcode-build-skill` (`xcodebuild`/`simctl` loop) and `apple-skills:simulator-utils` (`simctl`
+one-offs) are CLI references; `interactive-simulator-ux-audit` drives `idb` for exploratory
+audits; `host-driven-xcuitest-e2e` wires Tuist schemes for CI — `apple-skills:xcuitest` is the
+API reference it assumes.
 
 `apple-skills` moved from the `vabole` personal account to the `Prisma-Labs-Dev` organization;
 this table lists the org's repo.
 
 ## Other ways to install
+
+(A is the Quickstart above.)
 
 ### B — pinned for a team
 
@@ -160,8 +172,10 @@ Pin the marketplace to a released tag directly in `.claude/settings.json` — no
 ```
 
 Commit it — collaborators get the marketplace automatically once they trust the project
-folder, no separate prompt. If Claude Code still reports a plugin as not installed, run the
-`/plugin install` command it shows once.
+folder, no separate prompt. The two first-party plugins are relative-path entries, so they're
+installed at that point; externals are GitHub-sourced, so `enabledPlugins` won't auto-install
+them for anyone else — each collaborator still runs the `claude plugin install …` line Claude
+Code prints, once.
 
 ### C — `npx skills` (flat, no plugin)
 

--- a/README.md
+++ b/README.md
@@ -46,8 +46,8 @@ what is installed and which plugin each skill came from.
 > Installing both plugins loads all 38 first-party descriptions — about 5,500 tokens, ~2.7×
 > the default 1% skill-listing budget (2,000 tokens on a 200k-context model) — before any
 > externals. The skill-listing budget is 1% of the context window; when it overflows, Claude
-> Code drops descriptions starting with the skills you invoke least — freshly installed ones
-> first. Run `/doctor` to check the listing's cost, then raise `skillListingBudgetFraction`
+> Code drops descriptions starting with the skills you invoke least; in practice that tends
+> to mean freshly installed ones, which have no invocation history yet. Run `/doctor` to check the listing's cost, then raise `skillListingBudgetFraction`
 > (e.g. `0.02`) if it's tight, or disable plugins you don't use via `/plugin`.
 
 ## Catalog

--- a/README.zh-Hans.md
+++ b/README.zh-Hans.md
@@ -43,8 +43,8 @@ marketplace 刚好跟它第一个 plugin 同名。
 
 > 两个 plugin 一起装，会加载全部 38 条第一方描述 —— 约 5,500 tokens，是默认 1% 技能清单
 > 预算（200k context 模型下是 2,000 tokens）的约 2.7 倍，还没算外部 plugin。技能清单预算是
-> context window 的 1%；超支时 Claude Code 会从最少被调用的技能开始砍描述 —— 新安装的技能
-> 通常排最前面。执行 `/doctor` 检查清单成本，太吃紧就调高 `skillListingBudgetFraction`
+> context window 的 1%；超支时 Claude Code 会从最少被调用的技能开始砍描述；实务上通常
+> 就是还没有调用记录的新安装技能。执行 `/doctor` 检查清单成本，太吃紧就调高 `skillListingBudgetFraction`
 > （例如 `0.02`），或通过 `/plugin` 禁用不想用的 plugin。
 
 ## 目录
@@ -200,4 +200,4 @@ scripts/install-flat.sh --dry-run   # preview the `npx skills add` commands
 此处仅以引用方式呈现。催生本 repo 双 plugin 结构的设计 spec 与计划原本放在 `docs/superpowers/`
 —— 已退役、改由 git 历史保存；用 `git log -- docs/` 可以找回。MIT —— 见 [LICENSE](LICENSE)。
 
-<!-- src-sha: 717b9af19a42afc699c85476dae674477abc3726 -->
+<!-- src-sha: 7699870110c96d109c7bcda48151e19787a07aa3 -->

--- a/README.zh-Hans.md
+++ b/README.zh-Hans.md
@@ -4,11 +4,12 @@
 >
 > 语言：[English](README.md) · [繁體中文](README.zh-Hant.md) · [简体中文](README.zh-Hans.md) · [日本語](README.ja.md)
 
-apple-dev-skills 是一个 **marketplace**，服务对象是正在把一个点子做到 App Store 上架的
-独立开发者与小型团队。第一方技能分成两组：**Apple/Swift** 技能对应你正在打造的东西，
-**harness engineering** 技能对应你怎么驾驭 Claude Code 本身 —— 规划、审查、交付。每一支
-技能都是带立场的默认值，背后有实际上架的实战故事，并受一道一致性把关。旁边另以引用方式
-汇总同类最佳的**外部**技能 plugin —— 并非在此撰写，仅链接并标注原作者，绝不复制。
+apple-dev-skills 是一个 **marketplace**，服务对象是要在 **iOS 26 / macOS 26 底线**上打造全新
+（greenfield）App —— 从点子做到 App Store 上架 —— 的独立开发者与小型团队。第一方技能分成
+两组：**Apple/Swift** 技能对应你正在打造的东西，**harness engineering** 技能（你怎么驾驭
+Claude Code 本身 —— 调度、审查、交付）。每一支技能都是带立场的默认值，背后有实际上架的
+实战故事，并受一道一致性把关。旁边另以引用方式汇总同类最佳的**外部**技能 plugin —— 并非
+在此撰写，仅链接并标注原作者，绝不复制。
 
 ## 快速开始
 
@@ -19,10 +20,14 @@ apple-dev-skills 是一个 **marketplace**，服务对象是正在把一个点�
 ```
 /plugin marketplace add wei18/apple-dev-skills
 /plugin install apple-dev-skills@apple-dev-skills          # 26 Apple/Swift skills
-/plugin install collaboration-skills@apple-dev-skills      # 12 agent-collaboration skills
+/plugin install collaboration-skills@apple-dev-skills      # 12 harness-engineering skills
 ```
 
-若安装摘要显示 `Run /reload-plugins to activate.`，就执行它 —— 较旧版的 client 一定需要这步。
+每次安装都会打开一个详情面板 —— 选 **User** scope。格式是 `plugin@marketplace`；这个
+marketplace 刚好跟它第一个 plugin 同名。
+
+若安装摘要显示 `Run /reload-plugins to activate.`，Claude Code 会自动帮你执行；如果它警告
+你下一条消息会重读整个对话，就手动跑 `/reload-plugins --force`。
 
 装一个或两个都可以。外部 plugin 的安装方式相同，例如 `/plugin install swiftui-expert@apple-dev-skills`。
 
@@ -36,9 +41,11 @@ apple-dev-skills 是一个 **marketplace**，服务对象是正在把一个点�
 要指定某一个，用它的 slash command：`/apple-dev-skills:swift6-concurrency`。`/skills` 会列出
 已安装的全部技能，以及每一个来自哪个 plugin。
 
-> 新安装的技能最容易在 Claude Code 的技能清单 context 预算超支时第一个失去描述。执行
-> `/doctor` 检查清单的成本；若太吃紧，可在 settings 调整 `skillListingBudgetFraction` /
-> `skillOverrides`。
+> 两个 plugin 一起装，会加载全部 38 条第一方描述 —— 约 5,500 tokens，是默认 1% 技能清单
+> 预算（200k context 模型下是 2,000 tokens）的约 2.7 倍，还没算外部 plugin。技能清单预算是
+> context window 的 1%；超支时 Claude Code 会从最少被调用的技能开始砍描述 —— 新安装的技能
+> 通常排最前面。执行 `/doctor` 检查清单成本，太吃紧就调高 `skillListingBudgetFraction`
+> （例如 `0.02`），或通过 `/plugin` 禁用不想用的 plugin。
 
 ## 目录
 
@@ -56,7 +63,7 @@ apple-dev-skills 是一个 **marketplace**，服务对象是正在把一个点�
 | Skill | 一句话说明 |
 |---|---|
 | `swift6-concurrency` | Swift 6 语言模式 + 完整 concurrency 检查；默认 actor isolation 为 `MainActor`，只有跨入 `nonisolated` / actor 的代码才需要 Sendable |
-| `apple-platform-targets` | 默认 iOS 26 / macOS 26、Xcode 26.x；只有既有用户仍在旧版时才降到 18 / 15 |
+| `apple-platform-targets` | 默认 iOS 26 / macOS 26、Xcode 26.x；只有既有用户仍在旧版时才降到 iOS 18 / macOS 15（或 17 / 14） |
 | `swiftpm-modularization` | 单一 Package、多 target、薄 App、DI composition root、测试一对一 |
 | `swift-testing-baseline` | swift-testing + pointfreeco snapshot；protocol fake；严格/宽松 snapshot 把关 |
 | `xcode-cloud-single-track-ci` | 单轨 Xcode Cloud；PR / Main / Release / Periodic；merge 前的 PR CI |
@@ -80,24 +87,26 @@ apple-dev-skills 是一个 **marketplace**，服务对象是正在把一个点�
 | `ios-design-mockup` | 从 spec 生成单文件 HTML iOS 设计 mockup —— iPhone 外框 + tokens |
 | `interactive-simulator-ux-audit` | 用 `idb`（tap/describe/screenshot）驱动已启动的 Simulator，抓 snapshot 抓不到的导航／modal／safe-area bug |
 | `host-driven-xcuitest-e2e` | 通过 Tuist 启动 App 跑 XCUITest E2E —— 专用 scheme 接线 + macOS 窗口坐标点击驱动 |
-| `cloudkit-schema-source-of-truth` | 纳入版控的 `.ckdb` + `cktool` 导出／验证／部署到 Development；Production 是用户自持、仅限 Console 的关卡 |
+| `cloudkit-schema-source-of-truth` | 纳入版控的 `.ckdb` + `cktool` 导出／验证／导入到 Development；Production 是用户自持、仅限 Console 的关卡 |
 
 ### collaboration-skills（12）—— harness engineering：调度、审查、交付
 
 | Skill | 一句话说明 |
 |---|---|
 | `spec-phase-orchestration` | 实现前的文档流水线；逐节核准 |
-| `subagent-review-cycles` | Leader / Developer / Code-Reviewer 三角；第一轮外观问题直接 inline；limit(N) |
+| `subagent-review-cycles` | Leader / Developer / Code-Reviewer 三角；跑几轮、什么算驳回 |
 | `leader-developer-handoff-contract` | 调度 sub-agent 时必备的 6 个元素 |
-| `agent-impl-notes-log` | Sub-agent 任务进行中的即时 impl-notes —— 决策、偏离、未决问题 |
+| `agent-impl-notes-log`† | Sub-agent 任务进行中的即时 impl-notes —— 决策、偏离、未决问题 |
 | `subagent-conflict-detection` | 检查新 sub-agent 的目标不与进行中的 worktree 重叠 |
-| `methodology-pattern-extractor` | 从会议记录中提取重复出现 ≥3 次的模式 |
-| `session-to-meeting-log` | 把一场 Claude Code session 整合成会议记录；是摘要，不是逐字稿 |
+| `methodology-pattern-extractor`† | 从会议记录中提取重复出现 ≥3 次的模式 |
+| `session-to-meeting-log`† | 把一场 Claude Code session 整合成会议记录；是摘要，不是逐字稿 |
 | `pr-diff-verification` | Push／开 PR 前，确认 `git show --stat --summary HEAD` 与 commit 宣称的内容相符 |
-| `backlog-routing-by-topic` | 依主题把零散点子路由到对应 spec 文件的 §Backlog |
-| `claude-skill-plugin-packaging` | 发布／安装 Claude Code 技能 —— depth-1 规则、plugin + marketplace、汇总 |
+| `backlog-routing-by-topic`† | 依主题把零散点子路由到对应 spec 文件的 §Backlog |
+| `claude-skill-plugin-packaging` | 发布／安装 Claude Code 技能 —— depth-1 规则、plugin + marketplace、按项目钉版安装、以引用方式汇总 |
 | `skill-authoring-patterns` | 叠在 `superpowers:writing-skills` 之上的 Apple/Swift 目录层 —— router 描述、bookend 段落、两层式 references、证据导向 CR |
-| `github-contribution-workflow` | gh-CLI 贡献循环 —— PR、issue、GitHub 文件操作、secrets、贡献流程的 repo 设置；惯例 + merge 前 CLEAN |
+| `github-contribution-workflow` | gh-CLI 贡献循环 —— PR、issue、GitHub 文件操作、secrets、贡献流程的 repo 设置；惯例 |
+
+† 需要 `spec-phase-orchestration` 的文档版型（`design.md` / `plan.md` / `meetings/`）。
 
 ### 汇总的外部 plugin（7）—— 以引用方式收录，完整标注
 
@@ -111,28 +120,32 @@ swift-testing + snapshot、只用 OSLog、已知的运行时 bug 要避开）。
 
 | Plugin | 作者 | 涵盖范围 |
 |---|---|---|
-| [`apple-skills`](https://github.com/Prisma-Labs-Dev/apple-skills) | Prisma Labs (vabole), MIT | 广泛的 Apple 框架 —— SwiftUI、SwiftData、App Intents、WidgetKit、StoreKit、HealthKit……以及一份 SwiftUI 性能审计指南（代码优先、view-update 成因），与 `ios-performance-engineering` 的 Instruments / MetricKit 测量互补 |
+| [`apple-skills`](https://github.com/Prisma-Labs-Dev/apple-skills) | Prisma Labs (vabole), MIT | 广泛的 Apple 框架 —— SwiftUI、SwiftData、App Intents、WidgetKit、StoreKit、HealthKit、`apple-aso`、`hig`……以及一份 SwiftUI 性能审计指南，与 `ios-performance-engineering` 的 Instruments / MetricKit 测量互补；另外还有 `simulator-utils` 与 `xcuitest`（与本目录 Simulator／XCUITest 技能的分工见下方说明）。有一小部分技能放在 `disabled-skills/` —— 留在 repo 里但不会被 agent 加载 |
 | [`swiftui-expert`](https://github.com/AvdLee/SwiftUI-Agent-Skill) | Antoine van der Lee (MIT) | SwiftUI 模式、Swift Charts、Liquid Glass、Instruments 工具链 |
 | [`swiftui-pro`](https://github.com/twostraws/SwiftUI-Agent-Skill) | Paul Hudson (MIT) | SwiftUI 陷阱、deprecated API 观察清单、iOS 26 / Liquid Glass |
-| [`caveman`](https://github.com/JuliusBrussee/caveman) | JuliusBrussee (MIT) | 极度压缩的沟通模式 —— 省下约 75% token（通用 agent 行为） |
+| [`caveman`](https://github.com/JuliusBrussee/caveman) | JuliusBrussee (MIT) | 极度压缩的沟通模式 —— 省下约 65% 输出 token（作者自测）；会安装 `SessionStart`／`UserPromptSubmit` hook（需要 PATH 上有 `node`，每条 prompt 都会执行）（通用 agent 行为） |
 | [`ponytail`](https://github.com/DietrichGebert/ponytail) | DietrichGebert (MIT) | “懒惰资深工程师”模式 —— 逼出最简单、最短的解法（通用 agent 行为） |
 | [`i-have-adhd`](https://github.com/ayghri/i-have-adhd) | Ayoub G. (MIT) | 常驻的 ADHD 友好输出模式 —— 编号步骤、每一轮重述状态（通用 agent 行为） |
 | [`xcode-build-skill`](https://github.com/pzep1/xcode-build-skill) | pz (MIT) | `xcodebuild`/`xcrun simctl` CLI 小抄 —— scheme → 模拟器 → build → install → launch → 截图 |
 
 `caveman` 的授权：技能本身 MIT；repo 另外还有一个 BSL-1.1 授权的 engine。`caveman` 之后已
 长成 20 个技能的套件；其中 4 个（`caveman-discover`、`caveman-manage`、
-`caveman-evidence-review`、`caveman-setup`）在讲作者自家托管的 Caveman Cloud 商业服务
-（通用 agent 行为）。
+`caveman-evidence-review`、`caveman-setup`）在讲作者自家托管的 Caveman Cloud 商业服务。
 
-`i-have-adhd` 相对于 `caveman`（token 压缩）与 `ponytail`（解法简化），这个塑形的是结构。
+`i-have-adhd` 与 `caveman`（token 压缩）、`ponytail`（解法简化）不同，它塑形的是每次回答的
+**结构**。
 
-`xcode-build-skill` 是 CLI 驱动的，与 `interactive-simulator-ux-audit`（idb 驱动的交互式 UX
-审计）、`host-driven-xcuitest-e2e`（Tuist scheme 接线的 XCUITest E2E）不同 —— 三者不重叠。
+`xcode-build-skill`（`xcodebuild`／`simctl` 循环）与 `apple-skills:simulator-utils`（`simctl`
+单次操作）是 CLI 参考手册；`interactive-simulator-ux-audit` 用 `idb` 做探索式审计；
+`host-driven-xcuitest-e2e` 接 Tuist scheme 跑 CI —— `apple-skills:xcuitest` 是它假设你已具备
+的 API 参考。
 
 `apple-skills` 已从 `vabole` 的个人账号迁移到 `Prisma-Labs-Dev` 组织；此表列出的是组织版
 repo。
 
 ## 其他安装方式
+
+（A 就是上面的快速开始。）
 
 ### B —— 团队固定版本
 
@@ -152,8 +165,10 @@ repo。
 }
 ```
 
-commit 它 —— 协作者信任该项目文件夹之后就会自动拿到这个 marketplace，不会有额外提示。若
-Claude Code 仍报告某个 plugin 未安装，照它显示的 `/plugin install` 命令跑一次即可。
+commit 它 —— 协作者信任该项目文件夹之后就会自动拿到这个 marketplace，不会有额外提示。两个
+第一方 plugin 是相对路径条目，到这一步就已装好；外部 plugin 是 GitHub 来源，`enabledPlugins`
+不会帮别人自动安装 —— 每位协作者仍要自己跑一次 Claude Code 打印出的 `claude plugin install …`
+命令。
 
 ### C —— `npx skills`（平铺，不走 plugin）
 
@@ -185,4 +200,4 @@ scripts/install-flat.sh --dry-run   # preview the `npx skills add` commands
 此处仅以引用方式呈现。催生本 repo 双 plugin 结构的设计 spec 与计划原本放在 `docs/superpowers/`
 —— 已退役、改由 git 历史保存；用 `git log -- docs/` 可以找回。MIT —— 见 [LICENSE](LICENSE)。
 
-<!-- src-sha: 92addee1cd524bf074406c50bf882691f565f7a8 -->
+<!-- src-sha: 717b9af19a42afc699c85476dae674477abc3726 -->

--- a/README.zh-Hant.md
+++ b/README.zh-Hant.md
@@ -43,8 +43,8 @@ marketplace 剛好跟它第一個 plugin 同名。
 
 > 兩個 plugin 一起裝，會載入全部 38 條第一方描述 —— 約 5,500 tokens，是預設 1% 技能清單
 > 預算（200k context 模型下是 2,000 tokens）的約 2.7 倍，還沒算外部 plugin。技能清單預算是
-> context window 的 1%；爆量時 Claude Code 會從最少被呼叫的技能開始砍描述 —— 新安裝的技能
-> 通常排最前面。執行 `/doctor` 檢查清單成本，太吃緊就調高 `skillListingBudgetFraction`
+> context window 的 1%；爆量時 Claude Code 會從最少被呼叫的技能開始砍描述；實務上通常
+> 就是還沒有呼叫紀錄的新安裝技能。執行 `/doctor` 檢查清單成本，太吃緊就調高 `skillListingBudgetFraction`
 > （例如 `0.02`），或透過 `/plugin` 停用不想用的 plugin。
 
 ## 目錄
@@ -200,4 +200,4 @@ scripts/install-flat.sh --dry-run   # preview the `npx skills add` commands
 此處僅以引用方式呈現。催生本 repo 雙 plugin 結構的設計 spec 與計畫原本放在 `docs/superpowers/`
 —— 已退役、改由 git 歷史保存；用 `git log -- docs/` 可以找回。MIT —— 見 [LICENSE](LICENSE)。
 
-<!-- src-sha: 717b9af19a42afc699c85476dae674477abc3726 -->
+<!-- src-sha: 7699870110c96d109c7bcda48151e19787a07aa3 -->

--- a/README.zh-Hant.md
+++ b/README.zh-Hant.md
@@ -4,11 +4,12 @@
 >
 > 語言：[English](README.md) · [繁體中文](README.zh-Hant.md) · [简体中文](README.zh-Hans.md) · [日本語](README.ja.md)
 
-apple-dev-skills 是一個 **marketplace**，服務對象是正在把一個點子做到 App Store 上架的
-獨立開發者與小型團隊。第一方技能分成兩組：**Apple/Swift** 技能對應你正在打造的東西，
-**harness engineering** 技能對應你怎麼駕馭 Claude Code 本身 —— 規劃、審查、出貨。每一支
-技能都是帶立場的預設值，背後有實際上架的戰場故事，並受一道一致性把關。旁邊另以引用方式
-彙整同類最佳的**外部**技能 plugin —— 並非在此撰寫，僅連結並標註原作者，絕不複製。
+apple-dev-skills 是一個 **marketplace**，服務對象是要在 **iOS 26 / macOS 26 底線**上打造全新
+（greenfield）App —— 從點子做到 App Store 上架 —— 的獨立開發者與小型團隊。第一方技能分成
+兩組：**Apple/Swift** 技能對應你正在打造的東西，**harness engineering** 技能（你怎麼駕馭
+Claude Code 本身 —— 派工、審查、出貨）。每一支技能都是帶立場的預設值，背後有實際上架的
+戰場故事，並受一道一致性把關。旁邊另以引用方式彙整同類最佳的**外部**技能 plugin —— 並非
+在此撰寫，僅連結並標註原作者，絕不複製。
 
 ## 快速開始
 
@@ -19,10 +20,14 @@ apple-dev-skills 是一個 **marketplace**，服務對象是正在把一個點�
 ```
 /plugin marketplace add wei18/apple-dev-skills
 /plugin install apple-dev-skills@apple-dev-skills          # 26 Apple/Swift skills
-/plugin install collaboration-skills@apple-dev-skills      # 12 agent-collaboration skills
+/plugin install collaboration-skills@apple-dev-skills      # 12 harness-engineering skills
 ```
 
-若安裝摘要顯示 `Run /reload-plugins to activate.`，就執行它 —— 較舊版的 client 一定需要這步。
+每次安裝都會開一個詳情面板 —— 選 **User** scope。格式是 `plugin@marketplace`；這個
+marketplace 剛好跟它第一個 plugin 同名。
+
+若安裝摘要顯示 `Run /reload-plugins to activate.`，Claude Code 會自動幫你執行；如果它警告
+你下一則訊息會重讀整個對話，就手動跑 `/reload-plugins --force`。
 
 裝一個或兩個都可以。外部 plugin 的安裝方式相同，例如 `/plugin install swiftui-expert@apple-dev-skills`。
 
@@ -36,9 +41,11 @@ apple-dev-skills 是一個 **marketplace**，服務對象是正在把一個點�
 要指定某一支，用它的 slash command：`/apple-dev-skills:swift6-concurrency`。`/skills` 會列出
 已安裝的全部技能，以及每一支來自哪個 plugin。
 
-> 新安裝的技能最容易在 Claude Code 的技能清單 context 預算爆量時第一個失去描述。執行
-> `/doctor` 檢查清單的成本；若太吃緊，可在 settings 調整 `skillListingBudgetFraction` /
-> `skillOverrides`。
+> 兩個 plugin 一起裝，會載入全部 38 條第一方描述 —— 約 5,500 tokens，是預設 1% 技能清單
+> 預算（200k context 模型下是 2,000 tokens）的約 2.7 倍，還沒算外部 plugin。技能清單預算是
+> context window 的 1%；爆量時 Claude Code 會從最少被呼叫的技能開始砍描述 —— 新安裝的技能
+> 通常排最前面。執行 `/doctor` 檢查清單成本，太吃緊就調高 `skillListingBudgetFraction`
+> （例如 `0.02`），或透過 `/plugin` 停用不想用的 plugin。
 
 ## 目錄
 
@@ -56,7 +63,7 @@ apple-dev-skills 是一個 **marketplace**，服務對象是正在把一個點�
 | Skill | 一句話說明 |
 |---|---|
 | `swift6-concurrency` | Swift 6 語言模式 + 完整 concurrency 檢查；預設 actor isolation 為 `MainActor`，只有跨進 `nonisolated` / actor 的程式碼才需要 Sendable |
-| `apple-platform-targets` | 預設 iOS 26 / macOS 26、Xcode 26.x；只有既有使用者仍在舊版時才降到 18 / 15 |
+| `apple-platform-targets` | 預設 iOS 26 / macOS 26、Xcode 26.x；只有既有使用者仍在舊版時才降到 iOS 18 / macOS 15（或 17 / 14） |
 | `swiftpm-modularization` | 單一 Package、多 target、薄 App、DI composition root、測試一對一 |
 | `swift-testing-baseline` | swift-testing + pointfreeco snapshot；protocol fake；嚴格/寬鬆 snapshot 把關 |
 | `xcode-cloud-single-track-ci` | 單軌 Xcode Cloud；PR / Main / Release / Periodic；merge 前的 PR CI |
@@ -80,24 +87,26 @@ apple-dev-skills 是一個 **marketplace**，服務對象是正在把一個點�
 | `ios-design-mockup` | 從 spec 產出單檔 HTML iOS 設計 mockup —— iPhone 外框 + tokens |
 | `interactive-simulator-ux-audit` | 用 `idb`（tap/describe/screenshot）驅動已開機的 Simulator，抓 snapshot 抓不到的導航／modal／safe-area bug |
 | `host-driven-xcuitest-e2e` | 透過 Tuist 啟動 App 跑 XCUITest E2E —— 專用 scheme 接線 + macOS 視窗座標點擊驅動 |
-| `cloudkit-schema-source-of-truth` | 納入版控的 `.ckdb` + `cktool` 匯出／驗證／部署到 Development；Production 是使用者自持、僅限 Console 的關卡 |
+| `cloudkit-schema-source-of-truth` | 納入版控的 `.ckdb` + `cktool` 匯出／驗證／匯入到 Development；Production 是使用者自持、僅限 Console 的關卡 |
 
 ### collaboration-skills（12）—— harness engineering：派工、審查、出貨
 
 | Skill | 一句話說明 |
 |---|---|
 | `spec-phase-orchestration` | 實作前的文件流水線；逐節核可 |
-| `subagent-review-cycles` | Leader / Developer / Code-Reviewer 三角；第一輪外觀問題直接 inline；limit(N) |
+| `subagent-review-cycles` | Leader / Developer / Code-Reviewer 三角；跑幾輪、什麼算駁回 |
 | `leader-developer-handoff-contract` | 派工 sub-agent 時必備的 6 個元素 |
-| `agent-impl-notes-log` | Sub-agent 任務進行中的即時 impl-notes —— 決策、偏離、未決問題 |
+| `agent-impl-notes-log`† | Sub-agent 任務進行中的即時 impl-notes —— 決策、偏離、未決問題 |
 | `subagent-conflict-detection` | 檢查新 sub-agent 的目標不與進行中的 worktree 重疊 |
-| `methodology-pattern-extractor` | 從會議記錄中萃取重複出現 ≥3 次的模式 |
-| `session-to-meeting-log` | 把一場 Claude Code session 整併成會議記錄；是摘要，不是逐字稿 |
+| `methodology-pattern-extractor`† | 從會議記錄中萃取重複出現 ≥3 次的模式 |
+| `session-to-meeting-log`† | 把一場 Claude Code session 整併成會議記錄；是摘要，不是逐字稿 |
 | `pr-diff-verification` | Push／開 PR 前，確認 `git show --stat --summary HEAD` 與 commit 宣稱的內容相符 |
-| `backlog-routing-by-topic` | 依主題把零散點子路由到對應 spec 檔的 §Backlog |
-| `claude-skill-plugin-packaging` | 發佈／安裝 Claude Code 技能 —— depth-1 規則、plugin + marketplace、彙整 |
+| `backlog-routing-by-topic`† | 依主題把零散點子路由到對應 spec 檔的 §Backlog |
+| `claude-skill-plugin-packaging` | 發佈／安裝 Claude Code 技能 —— depth-1 規則、plugin + marketplace、依專案釘版安裝、以引用方式彙整 |
 | `skill-authoring-patterns` | 疊在 `superpowers:writing-skills` 之上的 Apple/Swift 目錄層 —— router 描述、bookend 段落、兩層式 references、證據導向 CR |
-| `github-contribution-workflow` | gh-CLI 貢獻循環 —— PR、issue、GitHub 檔案操作、secrets、貢獻流程的 repo 設定；慣例 + merge 前 CLEAN |
+| `github-contribution-workflow` | gh-CLI 貢獻循環 —— PR、issue、GitHub 檔案操作、secrets、貢獻流程的 repo 設定；慣例 |
+
+† 需要 `spec-phase-orchestration` 的文件版型（`design.md` / `plan.md` / `meetings/`）。
 
 ### 彙整之外部 plugin（7）—— 以引用方式收錄，完整標註
 
@@ -111,28 +120,32 @@ swift-testing + snapshot、只用 OSLog、已知的執行期 bug 要避開）。
 
 | Plugin | 作者 | 涵蓋範圍 |
 |---|---|---|
-| [`apple-skills`](https://github.com/Prisma-Labs-Dev/apple-skills) | Prisma Labs (vabole), MIT | 廣泛的 Apple 框架 —— SwiftUI、SwiftData、App Intents、WidgetKit、StoreKit、HealthKit……以及一份 SwiftUI 效能稽核指南（程式碼優先、view-update 成因），與 `ios-performance-engineering` 的 Instruments / MetricKit 量測互補 |
+| [`apple-skills`](https://github.com/Prisma-Labs-Dev/apple-skills) | Prisma Labs (vabole), MIT | 廣泛的 Apple 框架 —— SwiftUI、SwiftData、App Intents、WidgetKit、StoreKit、HealthKit、`apple-aso`、`hig`……以及一份 SwiftUI 效能稽核指南，與 `ios-performance-engineering` 的 Instruments / MetricKit 量測互補；另外還有 `simulator-utils` 與 `xcuitest`（與本目錄 Simulator／XCUITest 技能的分工見下方說明）。有一小部分技能放在 `disabled-skills/` —— 留在 repo 裡但不會被 agent 載入 |
 | [`swiftui-expert`](https://github.com/AvdLee/SwiftUI-Agent-Skill) | Antoine van der Lee (MIT) | SwiftUI 模式、Swift Charts、Liquid Glass、Instruments 工具鏈 |
 | [`swiftui-pro`](https://github.com/twostraws/SwiftUI-Agent-Skill) | Paul Hudson (MIT) | SwiftUI 陷阱、deprecated API 觀察清單、iOS 26 / Liquid Glass |
-| [`caveman`](https://github.com/JuliusBrussee/caveman) | JuliusBrussee (MIT) | 極度壓縮的溝通模式 —— 省下約 75% token（通用 agent 行為） |
+| [`caveman`](https://github.com/JuliusBrussee/caveman) | JuliusBrussee (MIT) | 極度壓縮的溝通模式 —— 省下約 65% 輸出 token（作者自測）；會裝上 `SessionStart`／`UserPromptSubmit` hook（需要 PATH 上有 `node`，每則 prompt 都會執行）（通用 agent 行為） |
 | [`ponytail`](https://github.com/DietrichGebert/ponytail) | DietrichGebert (MIT) | 「懶惰資深工程師」模式 —— 逼出最簡單、最短的解法（通用 agent 行為） |
 | [`i-have-adhd`](https://github.com/ayghri/i-have-adhd) | Ayoub G. (MIT) | 常駐的 ADHD 友善輸出模式 —— 編號步驟、每一輪重述狀態（通用 agent 行為） |
 | [`xcode-build-skill`](https://github.com/pzep1/xcode-build-skill) | pz (MIT) | `xcodebuild`/`xcrun simctl` CLI 小抄 —— scheme → 模擬器 → build → install → launch → 截圖 |
 
 `caveman` 的授權：技能本身 MIT；repo 另外還有一個 BSL-1.1 授權的 engine。`caveman` 之後已
 長成 20 個技能的套件；其中 4 個（`caveman-discover`、`caveman-manage`、
-`caveman-evidence-review`、`caveman-setup`）在講作者自家托管的 Caveman Cloud 商業服務
-（通用 agent 行為）。
+`caveman-evidence-review`、`caveman-setup`）在講作者自家托管的 Caveman Cloud 商業服務。
 
-`i-have-adhd` 相對於 `caveman`（token 壓縮）與 `ponytail`（解法簡化），這個塑形的是結構。
+`i-have-adhd` 與 `caveman`（token 壓縮）、`ponytail`（解法簡化）不同，它塑形的是每次回答的
+**結構**。
 
-`xcode-build-skill` 是 CLI 驅動的，與 `interactive-simulator-ux-audit`（idb 驅動的互動式 UX
-稽核）、`host-driven-xcuitest-e2e`（Tuist scheme 接線的 XCUITest E2E）不同 —— 三者不重疊。
+`xcode-build-skill`（`xcodebuild`／`simctl` 迴圈）與 `apple-skills:simulator-utils`（`simctl`
+單次操作）是 CLI 參考手冊；`interactive-simulator-ux-audit` 用 `idb` 做探索式稽核；
+`host-driven-xcuitest-e2e` 接 Tuist scheme 跑 CI —— `apple-skills:xcuitest` 是它假設你已具備
+的 API 參考。
 
 `apple-skills` 已從 `vabole` 的個人帳號移轉到 `Prisma-Labs-Dev` 組織；此表列出的是組織版
 repo。
 
 ## 其他安裝方式
+
+（A 就是上面的快速開始。）
 
 ### B —— 團隊固定版本
 
@@ -152,8 +165,10 @@ repo。
 }
 ```
 
-commit 它 —— 協作者信任該專案資料夾之後就會自動拿到這個 marketplace，不會有額外提示。若
-Claude Code 仍回報某個 plugin 未安裝，照它顯示的 `/plugin install` 指令跑一次即可。
+commit 它 —— 協作者信任該專案資料夾之後就會自動拿到這個 marketplace，不會有額外提示。兩支
+第一方 plugin 是相對路徑條目，到這步就已裝好；外部 plugin 是 GitHub 來源，`enabledPlugins`
+不會幫別人自動安裝 —— 每位協作者仍要自己跑一次 Claude Code 印出的 `claude plugin install …`
+指令。
 
 ### C —— `npx skills`（平鋪，不走 plugin）
 
@@ -185,4 +200,4 @@ scripts/install-flat.sh --dry-run   # preview the `npx skills add` commands
 此處僅以引用方式呈現。催生本 repo 雙 plugin 結構的設計 spec 與計畫原本放在 `docs/superpowers/`
 —— 已退役、改由 git 歷史保存；用 `git log -- docs/` 可以找回。MIT —— 見 [LICENSE](LICENSE)。
 
-<!-- src-sha: 92addee1cd524bf074406c50bf882691f565f7a8 -->
+<!-- src-sha: 717b9af19a42afc699c85476dae674477abc3726 -->


### PR DESCRIPTION
## Summary

2026-09-12 Fable review, PR-4 of 4 (README / marketplace.json scope only). Base: origin/main @ 06336d0 (rebased twice after PR #79 collaboration-skills and PR #80 apple-dev-skills landed; neither overlaps this PR's file scope).

Fixes for README.md + its three hand-mirrored translations + .claude-plugin/marketplace.json:

- **caveman "~75% of tokens" -> "~65% of output tokens (author's measurement)"** — upstream's plugin.json, repo description and README benchmark table all currently say 65% of *output* tokens (verified via `gh api repos/JuliusBrussee/caveman{,/readme}`). Also discloses its SessionStart/UserPromptSubmit hooks (needs node on PATH, runs on every prompt — verified via upstream .claude-plugin/plugin.json).
- **Drop skillOverrides advice for plugin skills** — official skills.md states plugin skills aren't affected by skillOverrides; replaced with the real remedy (skillListingBudgetFraction, /doctor, disable via /plugin) plus the actual budget math (38 first-party descriptions ~= 5,500 tokens, ~2.7x the default 1% budget).
- **Fix the dangling i-have-adhd sentence** ("... this shapes structure." had no subject/verb) into a complete sentence; the ja mirror had already self-corrected it independently, so English/zh mirrors now match it.
- **Reposition apple-skills vs. xcode-build-skill/interactive-simulator-ux-audit/host-driven-xcuitest-e2e** now that upstream apple-skills ships simulator-utils and xcuitest (confirmed via the repo's git tree API), plus discloses its disabled-skills/ mechanism (5 skills shipped but not loaded — confirmed via upstream README's "Disabled Skills" section).
- Misc MINOR fixes carried over from the review: stray "(general agent behavior)" leaking into prose, outdated /reload-plugins wording (verified against discover-plugins.md), missing install-scope/marketplace-name-collision note, Path B enabledPlugins never auto-installing GitHub-sourced externals for collaborators (verified against settings-reference.md), "drop to 18 / 15" -> "iOS 18 / macOS 15", CloudKit "deploy" -> "import" (matches the skill's own current description), jargon cleanup in the collaboration-skills table, ja external-table header translation, missing "(A is the Quickstart above.)".
- Footnotes the 4 collaboration skills that assume the spec-phase-orchestration doc layout; states up front that this catalog targets new, iOS 26 / macOS 26-floor apps (both pre-approved product-direction items).

All changes hand-mirrored into README.zh-Hant.md / README.zh-Hans.md / README.ja.md per CONTRIBUTING.md's "hand-mirror by default" rule; each mirror's src-sha comment was re-stamped to match the hash of the updated README.md.

## Test plan

- [x] `mise trust && mise run check` -> check-consistency.py OK (2 plugins 26/12, 3 mirrors consistent); check-skills.py -> BLOCKER 0 / MAJOR 0 / MINOR 1 (pre-existing, unrelated to this PR)
- [x] `grep -n 'skillOverrides\|75%' README*.md .claude-plugin/marketplace.json` -> zero hits
- [x] Each mirror's src-sha comment matches the hash of the current README.md
- [x] `rg -n 'TODO|FIXME|XXX'` on changed files -> no hits
- [x] Diff against origin/main touches only the 5 in-scope files
- [x] Rebased onto origin/main @ 06336d0 (PR #79 + #80, no file overlap, zero conflicts both times)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
