### PR TITLE
chore(release): 2.0.0 — catalog-wide audit, iOS 26 baseline, format gate, one skill retired

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -3,14 +3,14 @@
   "owner": { "name": "Wei18" },
   "metadata": {
     "description": "A curated catalog of skills for AI coding agents — first-party Apple/Swift and agent-collaboration skills, plus aggregated best-of-breed external plugins (credited to their authors)",
-    "version": "1.7.1"
+    "version": "2.0.0"
   },
   "plugins": [
     {
       "name": "apple-dev-skills",
       "source": "./apple-dev-skills",
       "description": "26 first-party Apple/Swift skills. Invoke explicitly with /apple-dev-skills:<skill>.",
-      "version": "1.3.0",
+      "version": "2.0.0",
       "author": { "name": "Wei18" },
       "keywords": ["swift", "ios", "macos", "apple-platform", "claude-code", "agent-skills"],
       "category": "workflow"
@@ -19,7 +19,7 @@
       "name": "collaboration-skills",
       "source": "./collaboration-skills",
       "description": "12 first-party AI-agent collaboration & process skills. Invoke explicitly with /collaboration-skills:<skill>.",
-      "version": "1.4.0",
+      "version": "2.0.0",
       "author": { "name": "Wei18" },
       "keywords": ["claude-code", "agent-skills", "ai-agents", "workflow", "collaboration"],
       "category": "workflow"

--- a/README.ja.md
+++ b/README.ja.md
@@ -169,7 +169,7 @@ OSLogのみ、避けるべき既知の実行時バグ）。トピックが重な
 {
   "extraKnownMarketplaces": {
     "apple-dev-skills": {
-      "source": { "source": "github", "repo": "wei18/apple-dev-skills", "ref": "v1.7.1" }
+      "source": { "source": "github", "repo": "wei18/apple-dev-skills", "ref": "v2.0.0" }
     }
   },
   "enabledPlugins": {
@@ -221,4 +221,4 @@ scripts/install-flat.sh --dry-run   # preview the `npx skills add` commands
 `docs/superpowers/`にありました——現在は廃止され、git履歴として保存されています。
 `git log -- docs/`で見つけることができます。MIT——[LICENSE](LICENSE)を参照してください。
 
-<!-- src-sha: 7699870110c96d109c7bcda48151e19787a07aa3 -->
+<!-- src-sha: 7924a7df00ae1716dc63a5f4079753769dc081f2 -->

--- a/README.md
+++ b/README.md
@@ -161,7 +161,7 @@ Pin the marketplace to a released tag directly in `.claude/settings.json` — no
 {
   "extraKnownMarketplaces": {
     "apple-dev-skills": {
-      "source": { "source": "github", "repo": "wei18/apple-dev-skills", "ref": "v1.7.1" }
+      "source": { "source": "github", "repo": "wei18/apple-dev-skills", "ref": "v2.0.0" }
     }
   },
   "enabledPlugins": {

--- a/README.zh-Hans.md
+++ b/README.zh-Hans.md
@@ -155,7 +155,7 @@ repo。
 {
   "extraKnownMarketplaces": {
     "apple-dev-skills": {
-      "source": { "source": "github", "repo": "wei18/apple-dev-skills", "ref": "v1.7.1" }
+      "source": { "source": "github", "repo": "wei18/apple-dev-skills", "ref": "v2.0.0" }
     }
   },
   "enabledPlugins": {
@@ -200,4 +200,4 @@ scripts/install-flat.sh --dry-run   # preview the `npx skills add` commands
 此处仅以引用方式呈现。催生本 repo 双 plugin 结构的设计 spec 与计划原本放在 `docs/superpowers/`
 —— 已退役、改由 git 历史保存；用 `git log -- docs/` 可以找回。MIT —— 见 [LICENSE](LICENSE)。
 
-<!-- src-sha: 7699870110c96d109c7bcda48151e19787a07aa3 -->
+<!-- src-sha: 7924a7df00ae1716dc63a5f4079753769dc081f2 -->

--- a/README.zh-Hant.md
+++ b/README.zh-Hant.md
@@ -155,7 +155,7 @@ repo。
 {
   "extraKnownMarketplaces": {
     "apple-dev-skills": {
-      "source": { "source": "github", "repo": "wei18/apple-dev-skills", "ref": "v1.7.1" }
+      "source": { "source": "github", "repo": "wei18/apple-dev-skills", "ref": "v2.0.0" }
     }
   },
   "enabledPlugins": {
@@ -200,4 +200,4 @@ scripts/install-flat.sh --dry-run   # preview the `npx skills add` commands
 此處僅以引用方式呈現。催生本 repo 雙 plugin 結構的設計 spec 與計畫原本放在 `docs/superpowers/`
 —— 已退役、改由 git 歷史保存；用 `git log -- docs/` 可以找回。MIT —— 見 [LICENSE](LICENSE)。
 
-<!-- src-sha: 7699870110c96d109c7bcda48151e19787a07aa3 -->
+<!-- src-sha: 7924a7df00ae1716dc63a5f4079753769dc081f2 -->

--- a/apple-dev-skills/.claude-plugin/plugin.json
+++ b/apple-dev-skills/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "apple-dev-skills",
-  "version": "1.3.0",
+  "version": "2.0.0",
   "description": "26 first-party Apple/Swift skills for AI-agent development — Swift 6 / SwiftPM / testing / CI / L10n / telemetry defaults, security & secrets, monetization, StoreKit 2 IAP, App Review, ASC API automation, local archive/export/upload, SwiftUI footguns & navigation, plus accessibility, dependency injection, performance engineering, interactive simulator UX audits, host-driven XCUITest E2E, and CloudKit schema source of truth. Distilled from a real shipping project and public Apple/standards docs.",
   "author": { "name": "Wei18" },
   "homepage": "https://github.com/wei18/apple-dev-skills",

--- a/collaboration-skills/.claude-plugin/plugin.json
+++ b/collaboration-skills/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "collaboration-skills",
-  "version": "1.4.0",
+  "version": "2.0.0",
   "description": "12 first-party AI-agent collaboration & process skills — spec-phase orchestration, Leader/Developer handoff contract, subagent review cycles & conflict detection, impl-notes & meeting logs, methodology extraction, backlog routing, PR-diff verification, Claude Code skill-plugin packaging, skill-authoring patterns, and GitHub contribution workflow. Harness engineering for AI coding agents — tool-agnostic, not Apple-specific.",
   "author": { "name": "Wei18" },
   "homepage": "https://github.com/wei18/apple-dev-skills",


### PR DESCRIPTION
Version bump only: marketplace 1.7.1 → 2.0.0, apple-dev-skills 1.3.0 → 2.0.0, collaboration-skills 1.4.0 → 2.0.0, plus the `ref: v2.0.0` install pin in the four READMEs (mirrors re-stamped). Produced by `mise run bump`, which also ran the consistency gate.

Release notes will be on the GitHub Release after this merges and `v2.0.0` is tagged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)